### PR TITLE
Add persistent work directories with clone/venv reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Initial project scaffolding.
 - CLI skeleton with `resolve` and `run` subcommands.
 - Registry schema and data structures.
+
+### Enhanced
+- Add `--work-dir`, `--repos-dir`, and `--venvs-dir` options to `run` for persistent
+  clone/venv directories that survive across runs.
+- Reuse existing repo clones (pull instead of re-clone) and venvs (skip create+install).
+- Log repo and venv paths in default output for each package.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -138,6 +138,24 @@ def resolve(
     show_default=True,
 )
 @click.option("--keep-work-dirs", is_flag=True, help="Don't clean up working directories.")
+@click.option(
+    "--repos-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Persistent directory for repo clones. Reuses existing clones.",
+)
+@click.option(
+    "--venvs-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Persistent directory for venvs. Reuses existing venvs.",
+)
+@click.option(
+    "--work-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Base directory for repos and venvs (sets --repos-dir and --venvs-dir).",
+)
 @click.pass_context
 def run_cmd(
     ctx: click.Context,
@@ -157,6 +175,9 @@ def run_cmd(
     quiet: bool,
     log_file: Path,
     keep_work_dirs: bool,
+    repos_dir: Path | None,
+    venvs_dir: Path | None,
+    work_dir: Path | None,
 ) -> None:
     """Run test suites against a JIT-enabled Python build and detect crashes."""
     from datetime import datetime, timezone
@@ -189,6 +210,13 @@ def run_cmd(
     if run_id is None:
         run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
 
+    # --work-dir sets both --repos-dir and --venvs-dir as defaults.
+    if work_dir is not None:
+        if repos_dir is None:
+            repos_dir = work_dir / "repos"
+        if venvs_dir is None:
+            venvs_dir = work_dir / "venvs"
+
     config = RunnerConfig(
         target_python=target_python,
         registry_dir=registry_dir,
@@ -205,6 +233,8 @@ def run_cmd(
         verbose=verbose,
         quiet=quiet,
         keep_work_dirs=keep_work_dirs,
+        repos_dir=repos_dir,
+        venvs_dir=venvs_dir,
         cli_args=list(ctx.params.keys()),
     )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -255,6 +255,37 @@ class TestRunIntegration(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("Packages tested: 0", result.output)
 
+    def test_run_work_dir_option(self) -> None:
+        """--work-dir sets both --repos-dir and --venvs-dir."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+        work_dir = self.base / "workdir"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-workdir",
+                "--work-dir",
+                str(work_dir),
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `--work-dir`, `--repos-dir`, and `--venvs-dir` CLI options to the `run` command
- Reuse existing repo clones (git pull) and venvs (skip create+install) when persistent directories are configured
- Log repo and venv paths in default output for each package

## Test plan
- [x] ruff format — no changes
- [x] ruff check — all passed
- [x] mypy strict — no errors
- [x] 136 tests passing (9 new: 4 for `_resolve_dirs`, 3 for repo/venv reuse, 1 for pull failure fallback, 1 integration test for `--work-dir`)

Closes #1

Generated with [Claude Code](https://claude.com/claude-code)