### PR TITLE
Enhance verbose mode with subprocess output and detailed logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   clone/venv directories that survive across runs.
 - Reuse existing repo clones (pull instead of re-clone) and venvs (skip create+install).
 - Log repo and venv paths in default output for each package.
+- Verbose mode (`-v`) now shows test subprocess stdout/stderr, resolved commands,
+  install output, installed dependency list, git operations, and per-phase timing.


### PR DESCRIPTION
## Summary
- Add `log.debug()` calls throughout the runner so `-v` shows test stdout/stderr, install output, resolved commands, git operations, dependency lists, and per-phase timing
- Add package progress counter to default output (e.g. "Testing pkg (2/5)")
- Add timing to PASS/FAIL result lines in default mode

## Test plan
- [x] ruff format — no changes
- [x] ruff check — all passed
- [x] mypy strict — no errors
- [x] 136 tests passing

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)