### PR TITLE
Enhanced run summary, clone depth, import check, and registry fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `clone_depth` registry field for packages needing git tags (e.g. setuptools-scm).
+- `import_name` registry field for packages whose import name differs from PyPI name.
+- `summary.py` module for formatting run results.
+- Enrichment best practices documented in CONTRIBUTING.md.
 - `--refresh-venvs` flag to delete and recreate existing venvs, ensuring updated install commands take effect.
 - Initial project scaffolding.
 - CLI skeleton with `resolve` and `run` subcommands.
 - Registry schema and data structures.
 
 ### Enhanced
+- Rich end-of-run summary with per-package table, timing stats, and crash details.
+- Quiet mode shows only crash information; default mode hides passing packages.
+- Post-install import validation catches broken installs before running tests.
 - Add `--work-dir`, `--repos-dir`, and `--venvs-dir` options to `run` for persistent
   clone/venv directories that survive across runs.
 - Reuse existing repo clones (pull instead of re-clone) and venvs (skip create+install).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ skip: false
 skip_reason: null
 notes: ""
 enriched: false            # set to true after manual review
+clone_depth: null           # null = shallow (depth=1); set higher for setuptools-scm
+import_name: null           # null = derived from package name; override when different
 ```
 
 ### Index file (`registry/index.yaml`)

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -43,6 +43,8 @@ class PackageEntry:
     skip_reason: str | None = None
     notes: str = ""
     enriched: bool = False
+    clone_depth: int | None = None
+    import_name: str | None = None
 
 
 @dataclass

--- a/src/labeille/summary.py
+++ b/src/labeille/summary.py
@@ -1,0 +1,287 @@
+"""Run summary formatting for labeille.
+
+Provides functions to format test run results into human-readable summaries
+with per-package tables, timing statistics, and crash details.
+"""
+
+from __future__ import annotations
+
+import signal as signal_module
+from pathlib import Path
+
+from labeille.runner import PackageResult, RunnerConfig, RunSummary
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_STATUS_ORDER: dict[str, int] = {
+    "crash": 0,
+    "timeout": 1,
+    "fail": 2,
+    "install_error": 3,
+    "clone_error": 4,
+    "error": 5,
+    "pass": 6,
+}
+
+_STATUS_DISPLAY: dict[str, str] = {
+    "crash": "\u2717 CRASH",
+    "timeout": "\u23f1 TIMEOUT",
+    "fail": "\u2717 FAIL",
+    "install_error": "\u26a0 ERROR",
+    "clone_error": "\u26a0 ERROR",
+    "error": "\u26a0 ERROR",
+    "pass": "\u2713 PASS",
+}
+
+_SEPARATOR = "\u2500" * 84
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds to a human-readable string.
+
+    Returns strings like ``"3s"``, ``"2m  5s"``, or ``"1h 12m 34s"``.
+    """
+    total = int(seconds)
+    if total >= 3600:
+        h = total // 3600
+        m = (total % 3600) // 60
+        s = total % 60
+        return f"{h}h {m:2d}m {s:2d}s"
+    if total >= 60:
+        m = total // 60
+        s = total % 60
+        return f"{m}m {s:2d}s"
+    return f"{total}s"
+
+
+def _signal_name(sig: int | None) -> str:
+    """Convert a signal number to its name (e.g. 11 -> ``"SIGSEGV"``)."""
+    if sig is None:
+        return ""
+    try:
+        return signal_module.Signals(sig).name
+    except (ValueError, AttributeError):
+        return f"SIG{sig}"
+
+
+def _detail(result: PackageResult) -> str:
+    """Build a brief detail string for a single result."""
+    if result.status == "crash":
+        return (result.crash_signature or "")[:60]
+    if result.status == "timeout":
+        return f"(timeout: {int(result.duration_seconds)}s)"
+    if result.status == "fail":
+        return f"exit code {result.exit_code}"
+    if result.status in ("install_error", "clone_error", "error"):
+        return (result.error_message or "")[:60]
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+
+
+def _format_run_header(
+    run_id: str,
+    python_version: str,
+    jit_enabled: bool,
+    total_duration: float,
+) -> str:
+    """Format the run header section."""
+    return "\n".join(
+        [
+            f"Run ID: {run_id}",
+            f"Target Python: {python_version}",
+            f"JIT enabled: {'yes' if jit_enabled else 'no'}",
+            f"Duration: {format_duration(total_duration)}",
+        ]
+    )
+
+
+def _format_package_table(
+    results: list[PackageResult],
+    *,
+    show_passing: bool = True,
+) -> str:
+    """Format the per-package results table.
+
+    When *show_passing* is ``False``, rows with status ``"pass"`` are omitted.
+    """
+    if not results:
+        return ""
+
+    rows = results if show_passing else [r for r in results if r.status != "pass"]
+    if not rows:
+        return ""
+
+    rows = sorted(rows, key=lambda r: (_STATUS_ORDER.get(r.status, 99), r.package))
+
+    header = f"  {'Package':<17s}{'Status':<13s}{'Duration':>10s}  {'Signal':<8s} {'Detail'}"
+    lines: list[str] = [
+        f"\u2500\u2500\u2500 Results {'\u2500' * 75}",
+        header,
+    ]
+
+    for r in rows:
+        pkg_name = r.package[:16]
+        status = _STATUS_DISPLAY.get(r.status, r.status)
+        dur = format_duration(r.duration_seconds)
+        sig = _signal_name(r.signal)
+        detail = _detail(r)
+        if len(detail) > 50:
+            detail = detail[:49] + "\u2026"
+        lines.append(f"  {pkg_name:<17s}{status:<13s}{dur:>10s}  {sig:<8s} {detail}")
+
+    lines.append(_SEPARATOR)
+    return "\n".join(lines)
+
+
+def _format_aggregate(
+    results: list[PackageResult],
+    summary: RunSummary,
+    total_duration: float,
+) -> str:
+    """Format the aggregate summary with timing stats."""
+    durations = [r.duration_seconds for r in results]
+    avg_dur = sum(durations) / len(durations) if durations else 0.0
+
+    fastest = min(results, key=lambda r: r.duration_seconds) if results else None
+    slowest = max(results, key=lambda r: r.duration_seconds) if results else None
+
+    def pct(n: int) -> str:
+        if summary.tested == 0:
+            return "0.0%"
+        return f"{n / summary.tested * 100:.1f}%"
+
+    left = [
+        f"Packages tested: {summary.tested} / {summary.total}",
+        f"  Passed:        {summary.passed:3d} ({pct(summary.passed)})",
+        f"  Failed:        {summary.failed:3d} ({pct(summary.failed)})",
+        f"  Crashed:       {summary.crashed:3d} ({pct(summary.crashed)})",
+        f"  Timed out:     {summary.timed_out:3d}",
+        f"  Install errors:{summary.install_errors:3d}",
+        f"  Clone errors:  {summary.clone_errors:3d}",
+        f"  Other errors:  {summary.errors:3d}",
+        f"Skipped:         {summary.skipped:3d}",
+    ]
+
+    right: list[str] = [
+        f"Total time: {format_duration(total_duration)}",
+        f"Avg per package: {format_duration(avg_dur)}",
+    ]
+    if fastest:
+        right.append(f"Fastest: {fastest.package} ({format_duration(fastest.duration_seconds)})")
+    if slowest:
+        right.append(f"Slowest: {slowest.package} ({format_duration(slowest.duration_seconds)})")
+
+    pad = max(len(line) for line in left) + 4
+    lines: list[str] = []
+    for i in range(max(len(left), len(right))):
+        l_text = left[i] if i < len(left) else ""
+        r_text = right[i] if i < len(right) else ""
+        lines.append(f"{l_text:<{pad}s}{r_text}")
+
+    return "\n".join(lines)
+
+
+def _format_crash_detail(
+    results: list[PackageResult],
+    run_dir: Path | None = None,
+) -> str:
+    """Format the detailed crash section."""
+    crashes = [r for r in results if r.status == "crash"]
+    if not crashes:
+        return ""
+
+    lines: list[str] = [f"\u2500\u2500\u2500 Crashes {'\u2500' * 75}"]
+    for r in crashes:
+        sig = _signal_name(r.signal)
+        signature = r.crash_signature or "unknown"
+        lines.append(f"  {r.package}: {sig}: {signature}")
+        if run_dir:
+            lines.append(f"    Stderr: {run_dir / 'crashes' / f'{r.package}.stderr'}")
+        lines.append(f"    Test command: {r.test_command}")
+        lines.append("")
+
+    if lines and lines[-1] == "":
+        lines.pop()
+    lines.append(_SEPARATOR)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def format_summary(
+    results: list[PackageResult],
+    summary: RunSummary,
+    config: RunnerConfig,
+    python_version: str,
+    jit_enabled: bool,
+    total_duration: float,
+    run_dir: Path | None = None,
+    mode: str = "default",
+) -> str:
+    """Format a complete run summary.
+
+    Args:
+        results: List of per-package results.
+        summary: Aggregate summary statistics.
+        config: Runner configuration (used for run_id).
+        python_version: Target Python version string.
+        jit_enabled: Whether the JIT was enabled.
+        total_duration: Total wall-clock duration in seconds.
+        run_dir: Path to the run directory (for crash stderr paths).
+        mode: Output mode -- ``"verbose"``, ``"default"``, or ``"quiet"``.
+
+    Returns:
+        The formatted summary string.
+    """
+    if mode == "quiet":
+        if summary.crashed == 0:
+            return ""
+        parts: list[str] = []
+        crash_detail = _format_crash_detail(results, run_dir)
+        if crash_detail:
+            parts.append(crash_detail)
+        crash_word = "crash" if summary.crashed == 1 else "crashes"
+        parts.append(
+            f"{summary.crashed} {crash_word} found "
+            f"in {summary.tested} packages tested ({format_duration(total_duration)})"
+        )
+        return "\n".join(parts)
+
+    parts = []
+
+    # Run header
+    parts.append("")
+    parts.append(_format_run_header(config.run_id, python_version, jit_enabled, total_duration))
+    parts.append("")
+
+    # Package table
+    show_passing = mode == "verbose"
+    table = _format_package_table(results, show_passing=show_passing)
+    if table:
+        parts.append(table)
+        parts.append("")
+
+    # Aggregate summary
+    parts.append(_format_aggregate(results, summary, total_duration))
+
+    # Crash detail
+    crash_detail = _format_crash_detail(results, run_dir)
+    if crash_detail:
+        parts.append("")
+        parts.append(crash_detail)
+
+    return "\n".join(parts)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -98,6 +98,44 @@ class TestPackageIO(unittest.TestCase):
         loaded = load_package("mystery", self.registry)
         self.assertIsNone(loaded.repo)
 
+    def test_clone_depth_roundtrip(self) -> None:
+        entry = PackageEntry(package="scm-pkg", clone_depth=50)
+        save_package(entry, self.registry)
+        loaded = load_package("scm-pkg", self.registry)
+        self.assertEqual(loaded.clone_depth, 50)
+
+    def test_clone_depth_none_default(self) -> None:
+        entry = PackageEntry(package="default-pkg")
+        save_package(entry, self.registry)
+        loaded = load_package("default-pkg", self.registry)
+        self.assertIsNone(loaded.clone_depth)
+
+    def test_import_name_roundtrip(self) -> None:
+        entry = PackageEntry(package="python-dateutil", import_name="dateutil")
+        save_package(entry, self.registry)
+        loaded = load_package("python-dateutil", self.registry)
+        self.assertEqual(loaded.import_name, "dateutil")
+
+    def test_import_name_none_default(self) -> None:
+        entry = PackageEntry(package="simple")
+        save_package(entry, self.registry)
+        loaded = load_package("simple", self.registry)
+        self.assertIsNone(loaded.import_name)
+
+    def test_new_fields_tolerated_when_missing(self) -> None:
+        """Old YAML files without new fields load with defaults."""
+        import yaml
+
+        # Write a YAML file without clone_depth and import_name
+        p = self.registry / "packages" / "oldpkg.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        data = {"package": "oldpkg", "repo": "https://github.com/x/y", "enriched": True}
+        p.write_text(yaml.dump(data), encoding="utf-8")
+        loaded = load_package("oldpkg", self.registry)
+        self.assertEqual(loaded.package, "oldpkg")
+        self.assertIsNone(loaded.clone_depth)
+        self.assertIsNone(loaded.import_name)
+
 
 class TestIndexIO(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,371 @@
+"""Tests for labeille.summary."""
+
+import signal
+import unittest
+from pathlib import Path
+
+from labeille.runner import PackageResult, RunnerConfig, RunSummary
+from labeille.summary import (
+    _detail,
+    _format_aggregate,
+    _format_crash_detail,
+    _format_package_table,
+    _format_run_header,
+    _signal_name,
+    format_duration,
+    format_summary,
+)
+
+
+def _make_config() -> RunnerConfig:
+    return RunnerConfig(
+        target_python=Path("/usr/bin/python3"),
+        registry_dir=Path("registry"),
+        results_dir=Path("results"),
+        run_id="test-run-2026",
+    )
+
+
+def _make_results() -> list[PackageResult]:
+    return [
+        PackageResult(
+            package="crash-pkg",
+            status="crash",
+            signal=signal.SIGSEGV,
+            crash_signature="Fatal Python error: Segmentation fault",
+            duration_seconds=83.0,
+            test_command="python -m pytest tests/",
+        ),
+        PackageResult(
+            package="pass-pkg",
+            status="pass",
+            exit_code=0,
+            duration_seconds=8.0,
+        ),
+        PackageResult(
+            package="fail-pkg",
+            status="fail",
+            exit_code=1,
+            duration_seconds=12.0,
+        ),
+        PackageResult(
+            package="timeout-pkg",
+            status="timeout",
+            timeout_hit=True,
+            duration_seconds=900.0,
+        ),
+        PackageResult(
+            package="error-pkg",
+            status="install_error",
+            error_message="Install failed: build error in some-package",
+            duration_seconds=3.0,
+        ),
+    ]
+
+
+def _make_summary(results: list[PackageResult] | None = None) -> RunSummary:
+    if results is None:
+        results = _make_results()
+    s = RunSummary(total=6, tested=len(results), skipped=1)
+    for r in results:
+        if r.status == "pass":
+            s.passed += 1
+        elif r.status == "fail":
+            s.failed += 1
+        elif r.status == "crash":
+            s.crashed += 1
+        elif r.status == "timeout":
+            s.timed_out += 1
+        elif r.status == "install_error":
+            s.install_errors += 1
+        elif r.status == "clone_error":
+            s.clone_errors += 1
+        else:
+            s.errors += 1
+    return s
+
+
+class TestFormatDuration(unittest.TestCase):
+    def test_seconds_only(self) -> None:
+        self.assertEqual(format_duration(5.0), "5s")
+
+    def test_zero(self) -> None:
+        self.assertEqual(format_duration(0.0), "0s")
+
+    def test_minutes_and_seconds(self) -> None:
+        self.assertEqual(format_duration(125.0), "2m  5s")
+
+    def test_exact_minute(self) -> None:
+        self.assertEqual(format_duration(60.0), "1m  0s")
+
+    def test_hours_minutes_seconds(self) -> None:
+        self.assertEqual(format_duration(3661.0), "1h  1m  1s")
+
+    def test_large_hours(self) -> None:
+        self.assertEqual(format_duration(7384.0), "2h  3m  4s")
+
+    def test_just_under_a_minute(self) -> None:
+        self.assertEqual(format_duration(59.9), "59s")
+
+    def test_just_over_a_minute(self) -> None:
+        self.assertEqual(format_duration(61.0), "1m  1s")
+
+
+class TestSignalName(unittest.TestCase):
+    def test_none(self) -> None:
+        self.assertEqual(_signal_name(None), "")
+
+    def test_sigsegv(self) -> None:
+        self.assertEqual(_signal_name(signal.SIGSEGV), "SIGSEGV")
+
+    def test_sigabrt(self) -> None:
+        self.assertEqual(_signal_name(signal.SIGABRT), "SIGABRT")
+
+
+class TestDetail(unittest.TestCase):
+    def test_crash(self) -> None:
+        r = PackageResult(package="p", status="crash", crash_signature="Fatal error in something")
+        self.assertEqual(_detail(r), "Fatal error in something")
+
+    def test_crash_truncates_at_60(self) -> None:
+        r = PackageResult(package="p", status="crash", crash_signature="A" * 80)
+        self.assertEqual(len(_detail(r)), 60)
+
+    def test_timeout(self) -> None:
+        r = PackageResult(package="p", status="timeout", duration_seconds=900.0)
+        self.assertEqual(_detail(r), "(timeout: 900s)")
+
+    def test_fail(self) -> None:
+        r = PackageResult(package="p", status="fail", exit_code=2)
+        self.assertEqual(_detail(r), "exit code 2")
+
+    def test_error(self) -> None:
+        r = PackageResult(package="p", status="install_error", error_message="build failed")
+        self.assertEqual(_detail(r), "build failed")
+
+    def test_pass(self) -> None:
+        r = PackageResult(package="p", status="pass")
+        self.assertEqual(_detail(r), "")
+
+
+class TestFormatRunHeader(unittest.TestCase):
+    def test_header_content(self) -> None:
+        header = _format_run_header("my-run", "3.15.0a5", True, 3661.0)
+        self.assertIn("my-run", header)
+        self.assertIn("3.15.0a5", header)
+        self.assertIn("yes", header)
+        self.assertIn("1h  1m  1s", header)
+
+    def test_jit_disabled(self) -> None:
+        header = _format_run_header("run1", "3.15.0", False, 60.0)
+        self.assertIn("no", header)
+
+
+class TestFormatPackageTable(unittest.TestCase):
+    def test_empty_results(self) -> None:
+        self.assertEqual(_format_package_table([]), "")
+
+    def test_show_passing_true(self) -> None:
+        results = _make_results()
+        table = _format_package_table(results, show_passing=True)
+        self.assertIn("pass-pkg", table)
+        self.assertIn("crash-pkg", table)
+        self.assertIn("Results", table)
+
+    def test_show_passing_false(self) -> None:
+        results = _make_results()
+        table = _format_package_table(results, show_passing=False)
+        self.assertNotIn("pass-pkg", table)
+        self.assertIn("crash-pkg", table)
+        self.assertIn("fail-pkg", table)
+
+    def test_all_passing_hidden(self) -> None:
+        results = [PackageResult(package="ok", status="pass", duration_seconds=1.0)]
+        table = _format_package_table(results, show_passing=False)
+        self.assertEqual(table, "")
+
+    def test_sorted_by_status_order(self) -> None:
+        results = _make_results()
+        table = _format_package_table(results, show_passing=True)
+        lines = table.splitlines()
+        data_lines = [ln for ln in lines if ln.startswith("  ") and "Package" not in ln]
+        # First data line should be crash, last should be pass
+        self.assertIn("CRASH", data_lines[0])
+        self.assertIn("PASS", data_lines[-1])
+
+    def test_truncates_long_detail(self) -> None:
+        results = [
+            PackageResult(
+                package="long",
+                status="install_error",
+                error_message="A" * 100,
+                duration_seconds=1.0,
+            ),
+        ]
+        table = _format_package_table(results, show_passing=True)
+        # The detail column should be truncated with ellipsis
+        self.assertIn("\u2026", table)
+
+
+class TestFormatAggregate(unittest.TestCase):
+    def test_has_counts(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        text = _format_aggregate(results, summary, 1200.0)
+        self.assertIn("Packages tested: 5 / 6", text)
+        self.assertIn("Passed:", text)
+        self.assertIn("Failed:", text)
+        self.assertIn("Crashed:", text)
+
+    def test_has_percentages(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        text = _format_aggregate(results, summary, 100.0)
+        self.assertIn("20.0%", text)  # 1 pass out of 5
+
+    def test_has_timing_stats(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        text = _format_aggregate(results, summary, 1200.0)
+        self.assertIn("Total time:", text)
+        self.assertIn("Avg per package:", text)
+        self.assertIn("Fastest:", text)
+        self.assertIn("Slowest:", text)
+
+    def test_fastest_slowest(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        text = _format_aggregate(results, summary, 100.0)
+        self.assertIn("error-pkg", text)  # fastest at 3s
+        self.assertIn("timeout-pkg", text)  # slowest at 900s
+
+    def test_empty_results(self) -> None:
+        summary = RunSummary(total=5, tested=0)
+        text = _format_aggregate([], summary, 0.0)
+        self.assertIn("Packages tested: 0 / 5", text)
+
+    def test_zero_tested_percentage(self) -> None:
+        summary = RunSummary(total=5, tested=0)
+        text = _format_aggregate([], summary, 0.0)
+        self.assertIn("0.0%", text)
+
+
+class TestFormatCrashDetail(unittest.TestCase):
+    def test_no_crashes(self) -> None:
+        results = [PackageResult(package="ok", status="pass")]
+        self.assertEqual(_format_crash_detail(results), "")
+
+    def test_with_crashes(self) -> None:
+        results = _make_results()
+        text = _format_crash_detail(results)
+        self.assertIn("crash-pkg", text)
+        self.assertIn("SIGSEGV", text)
+        self.assertIn("Crashes", text)
+
+    def test_crash_has_test_command(self) -> None:
+        results = _make_results()
+        text = _format_crash_detail(results)
+        self.assertIn("Test command:", text)
+        self.assertIn("python -m pytest tests/", text)
+
+    def test_crash_with_run_dir(self) -> None:
+        results = _make_results()
+        run_dir = Path("/tmp/results/my-run")
+        text = _format_crash_detail(results, run_dir=run_dir)
+        self.assertIn("Stderr:", text)
+        self.assertIn("crash-pkg.stderr", text)
+
+
+class TestFormatSummary(unittest.TestCase):
+    def test_verbose_mode(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        config = _make_config()
+        text = format_summary(results, summary, config, "3.15.0a5", True, 1200.0, mode="verbose")
+        # Should have header, table with all packages, aggregate, crash detail
+        self.assertIn("Run ID:", text)
+        self.assertIn("pass-pkg", text)
+        self.assertIn("crash-pkg", text)
+        self.assertIn("Packages tested:", text)
+        self.assertIn("Crashes", text)
+
+    def test_default_mode(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        config = _make_config()
+        text = format_summary(results, summary, config, "3.15.0a5", True, 1200.0, mode="default")
+        # Should have header, table without passing, aggregate, crash detail
+        self.assertIn("Run ID:", text)
+        self.assertNotIn("pass-pkg", text)
+        self.assertIn("crash-pkg", text)
+        self.assertIn("Packages tested:", text)
+
+    def test_quiet_mode_with_crashes(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        config = _make_config()
+        text = format_summary(results, summary, config, "3.15.0a5", True, 1200.0, mode="quiet")
+        # Should have crash detail and one-line count
+        self.assertIn("crash-pkg", text)
+        self.assertIn("1 crash found", text)
+        # Should NOT have full header or aggregate
+        self.assertNotIn("Run ID:", text)
+        self.assertNotIn("Packages tested:", text)
+
+    def test_quiet_mode_no_crashes(self) -> None:
+        results = [PackageResult(package="ok", status="pass", duration_seconds=5.0)]
+        summary = _make_summary(results)
+        config = _make_config()
+        text = format_summary(results, summary, config, "3.15.0a5", True, 10.0, mode="quiet")
+        self.assertEqual(text, "")
+
+    def test_quiet_mode_plural_crashes(self) -> None:
+        results = [
+            PackageResult(
+                package="c1",
+                status="crash",
+                signal=signal.SIGSEGV,
+                crash_signature="sig1",
+                duration_seconds=1.0,
+                test_command="pytest",
+            ),
+            PackageResult(
+                package="c2",
+                status="crash",
+                signal=signal.SIGABRT,
+                crash_signature="sig2",
+                duration_seconds=2.0,
+                test_command="pytest",
+            ),
+        ]
+        summary = _make_summary(results)
+        config = _make_config()
+        text = format_summary(results, summary, config, "3.15.0", True, 10.0, mode="quiet")
+        self.assertIn("2 crashes found", text)
+
+    def test_no_results(self) -> None:
+        summary = RunSummary(total=5, tested=0)
+        config = _make_config()
+        text = format_summary([], summary, config, "3.15.0", True, 0.0, mode="default")
+        self.assertIn("Packages tested: 0 / 5", text)
+
+    def test_run_dir_in_crash_detail(self) -> None:
+        results = _make_results()
+        summary = _make_summary(results)
+        config = _make_config()
+        run_dir = Path("/tmp/results/my-run")
+        text = format_summary(
+            results,
+            summary,
+            config,
+            "3.15.0",
+            True,
+            100.0,
+            run_dir=run_dir,
+            mode="verbose",
+        )
+        self.assertIn("crash-pkg.stderr", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `summary.py` module with rich end-of-run formatting (per-package table, timing stats, crash details) in verbose/default/quiet modes
- Add `clone_depth` and `import_name` fields to registry schema for packages needing git tags or non-standard import names
- Add post-install import validation to catch broken installs before running tests
- 55 new tests (193 total), enrichment best practices in CONTRIBUTING.md

## Test plan
- [x] ruff format — 7 files unchanged
- [x] ruff check — all checks passed
- [x] mypy — no issues in 9 source files
- [x] unittest — 193 tests passed

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)