### PR TITLE
feat: add --workers option for parallel execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `--workers N` option for parallel package testing in `labeille run`.
+- `--workers N` option for parallel PyPI resolution in `labeille resolve`.
+- Cancellation support for `--stop-after-crash` in parallel mode.
 - `clone_depth` registry field for packages needing git tags (e.g. setuptools-scm).
 - `import_name` registry field for packages whose import name differs from PyPI name.
 - `summary.py` module for formatting run results.
@@ -19,8 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Documentation
 - Comprehensive enrichment guide with manual workflow, troubleshooting, and Claude Code prompts (doc/enrichment.md).
 - Updated README with enrichment overview and link to guide.
+- Parallel execution guidance, resource considerations, and ASAN vs non-ASAN trade-offs.
 
 ### Enhanced
+- Progress reporting adapted for parallel execution with per-completion status lines.
 - Rich end-of-run summary with per-package table, timing stats, and crash details.
 - Quiet mode shows only crash information; default mode hides passing packages.
 - Post-install import validation catches broken installs before running tests.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ labeille run --target-python /path/to/jit-python --skip-extensions
 
 # Stop after finding the first crash
 labeille run --target-python /path/to/jit-python --stop-after-crash 1
+
+# Run tests in parallel (4 workers)
+labeille run --target-python /path/to/jit-python --workers 4
 ```
 
 ## How It Works
@@ -84,6 +87,10 @@ Runs test suites and detects crashes:
 5. For crashes: extracts a signature (signal + stderr context) and saves the
    full stderr output.
 6. Writes results as JSONL for analysis, with full metadata for reproducibility.
+
+Runs can execute packages in parallel with `--workers N` for faster batch
+testing. Each worker handles one package end-to-end with results collected
+thread-safely.
 
 Runs are **resumable**: use `--skip-completed` with the same `--run-id` to
 continue after an interruption.

--- a/doc/enrichment.md
+++ b/doc/enrichment.md
@@ -578,6 +578,16 @@ grep "enriched: false" registry/index.yaml
       --timeout 600 -v
   ```
 
+- **Use parallel execution for batch runs.** `--workers N` tests multiple
+  packages in parallel, overlapping clone/install/test across packages:
+  ```bash
+  labeille run --target-python /path/to/python --workers 4
+  ```
+  Each parallel package test spawns its own subprocesses with a full venv.
+  With N workers, expect roughly N times the memory usage of a single run.
+  For ASAN builds, `--workers 2-3` is the practical limit. For non-ASAN
+  builds, `--workers 4-8` works well on most machines.
+
 - **Check for orphaned processes after killing labeille.** If you interrupt a
   labeille run, pytest subprocesses may survive and consume significant memory.
   Check with `ps aux | grep pytest` and clean up as needed.


### PR DESCRIPTION
## Summary
- Add `--workers N` option to `labeille run` for parallel package testing using `ThreadPoolExecutor`. Workers=1 preserves existing sequential behavior; workers>=2 runs packages in parallel with thread-safe result recording and crash counting.
- Add `--workers N` option to `labeille resolve` for parallel PyPI API requests with 0.25s rate limiting between submissions.
- Cancellation support for `--stop-after-crash` in parallel mode via `threading.Event` — workers check before each phase (clone, venv, install, test) and return early when the crash limit is reached.

## Test plan
- [x] `ruff format` — clean
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues in 9 source files
- [x] 201 unit tests pass (193 existing + 8 new)
- [x] New tests: parallel result collection, stop-after-crash cancellation, workers=1 sequential path, parallel JSONL writing, cancel_event behavior, parallel resolve

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)