### PR TITLE
feat: add skip_versions, --force-run, and improved repo URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `skip_versions` registry field for per-Python-version skip reasons (e.g. `3.15: "PyO3 not supported"`).
+- `--force-run` flag to override `skip` and `skip_versions` for debugging.
 - `--workers N` option for parallel package testing in `labeille run`.
 - `--workers N` option for parallel PyPI resolution in `labeille resolve`.
 - Cancellation support for `--stop-after-crash` in parallel mode.
@@ -25,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Parallel execution guidance, resource considerations, and ASAN vs non-ASAN trade-offs.
 
 ### Enhanced
+- Improved repo URL resolution with secondary keys (bug tracker, issues, changelog) and legacy field fallbacks (home_page, download_url).
+- Run summary shows version-skipped count separately when skip_versions is active.
 - Progress reporting adapted for parallel execution with per-completion status lines.
 - Rich end-of-run summary with per-package table, timing stats, and crash details.
 - Quiet mode shows only crash information; default mode hides passing packages.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
+skip_versions:             # per-version skip reasons (empty = no version skips)
+  "3.15": "PyO3 not supported on 3.15"
 notes: ""
 enriched: false            # set to true after manual review
 clone_depth: null           # null = shallow (depth=1); set higher for setuptools-scm

--- a/doc/enrichment.md
+++ b/doc/enrichment.md
@@ -75,6 +75,7 @@ schema with explanations.
 | `python_versions` | list | Python versions this package supports (informational). |
 | `skip` | bool | Skip this package entirely during `labeille run`. |
 | `skip_reason` | string or null | Why the package is skipped — build failures, missing 3.15 support, etc. |
+| `skip_versions` | dict | Per-Python-version skip reasons. Keys are `"major.minor"` strings (e.g. `"3.15"`), values are human-readable reasons. When the target Python matches a key, the package is skipped — unless `--force-run` is used. Use this instead of `skip: true` when a package only fails on specific Python versions. |
 | `notes` | string | Free-form notes about quirks, known issues, or enrichment decisions. |
 | `enriched` | bool | Whether this file has been reviewed and filled in. Set to `true` once you've determined the install and test commands, even if some tests fail. |
 
@@ -99,6 +100,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
+skip_versions: {}
 notes: Click CLI framework by Pallets. Uses flit_core build backend.
 enriched: true
 clone_depth: null
@@ -122,6 +124,7 @@ uses_xdist: false
 timeout: 180
 skip: false
 skip_reason: null
+skip_versions: {}
 notes: SCM-based version management. Needs git tags for version detection
   (git fetch --tags). Tests in testing/ directory.
 enriched: true
@@ -416,7 +419,16 @@ Some packages can't be built on 3.15 at all:
 | Changed C API | Some Cython packages | Check case-by-case |
 | Unreleased dependency pins | Packages pinning pre-release versions | Skip with reason |
 
-**Fix:** Set `skip: true` with a clear `skip_reason`.
+**Fix:** For version-specific failures, use `skip_versions` instead of `skip: true`:
+
+```yaml
+skip_versions:
+  "3.15": "PyO3 not supported on 3.15"
+```
+
+This keeps the package testable on other Python versions. Use `skip: true` only
+for packages that can never be tested (e.g. abandoned projects, broken repos).
+Use `--force-run` to override both `skip` and `skip_versions` for debugging.
 
 ### Timeout issues
 

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -137,6 +137,11 @@ def resolve(
 @click.option("--packages", "packages_csv", type=str, default=None)
 @click.option("--skip-extensions", is_flag=True)
 @click.option("--skip-completed", is_flag=True, help="Resume: skip already-tested packages.")
+@click.option(
+    "--force-run",
+    is_flag=True,
+    help="Override skip and skip_versions flags; run all selected packages.",
+)
 @click.option("--stop-after-crash", type=int, default=None)
 @click.option("--timeout", type=int, default=600, show_default=True)
 @click.option("--env", "env_pairs", type=str, multiple=True, help="KEY=VALUE env var.")
@@ -191,6 +196,7 @@ def run_cmd(
     packages_csv: str | None,
     skip_extensions: bool,
     skip_completed: bool,
+    force_run: bool,
     stop_after_crash: int | None,
     timeout: int,
     env_pairs: tuple[str, ...],
@@ -209,7 +215,12 @@ def run_cmd(
     """Run test suites against a JIT-enabled Python build and detect crashes."""
     from datetime import datetime, timezone
 
-    from labeille.runner import RunnerConfig, run_all, validate_target_python
+    from labeille.runner import (
+        RunnerConfig,
+        extract_python_minor_version,
+        run_all,
+        validate_target_python,
+    )
     from labeille.summary import format_summary
 
     setup_logging(verbose=verbose, quiet=quiet, log_file=log_file)
@@ -258,6 +269,8 @@ def run_cmd(
         packages_filter=packages_filter,
         skip_extensions=skip_extensions,
         skip_completed=skip_completed,
+        force_run=force_run,
+        target_python_version=extract_python_minor_version(python_version),
         stop_after_crash=stop_after_crash,
         env_overrides=env_overrides,
         dry_run=dry_run,

--- a/src/labeille/summary.py
+++ b/src/labeille/summary.py
@@ -172,6 +172,8 @@ def _format_aggregate(
         f"  Other errors:  {summary.errors:3d}",
         f"Skipped:         {summary.skipped:3d}",
     ]
+    if summary.version_skipped > 0:
+        left.append(f"  Version-skipped:{summary.version_skipped:3d}")
 
     right: list[str] = [
         f"Total time: {format_duration(total_duration)}",


### PR DESCRIPTION
## Summary
- Add `skip_versions` registry field for per-Python-version skip reasons (e.g. `"3.15": "PyO3 not supported"`), with YAML float-key coercion so bare `3.15` keys work correctly
- Add `--force-run` CLI flag to override both `skip` and `skip_versions` for debugging
- Improve `extract_repo_url()` with secondary project_urls keys (bug tracker, issues, changelog), `_normalize_github_url()` for deriving repo roots from non-repo URLs, and legacy field fallbacks (`home_page`, `download_url`)
- Add `extract_python_minor_version()` to parse target Python version for skip_versions matching
- Update run summary to show version-skipped count separately

## Test plan
- [x] Registry round-trip tests for skip_versions (including float-key coercion)
- [x] filter_packages tests: version match, non-match, force_run override, empty target version
- [x] extract_python_minor_version tests: full version, release, build info, short, empty, malformed
- [x] _normalize_github_url tests: issues, blob, tree, wiki, .git, archive, non-GitHub, orgs
- [x] extract_repo_url tests: secondary keys, legacy fields, non-forge ignored
- [x] ruff format, ruff check, mypy strict pass
- [x] 229 tests pass (28 new)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)