### PR TITLE
feat: add analyze CLI subgroup with five subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `labeille analyze` CLI subgroup with five subcommands: `registry`, `run`, `compare`, `history`, `package`.
+- `formatting.py` shared formatting module (tables, histograms, sparklines, duration, status icons).
+- `analyze.py` data loading and analysis module (run data, registry stats, comparison, flaky detection).
 - `labeille registry` CLI subgroup for batch registry management (add-field, remove-field, rename-field, set-field, validate, add-index-field, remove-index-field).
 - Line-level YAML manipulation (`yaml_lines.py`) preserving exact formatting.
 - Batch operations module (`registry_ops.py`) with filtering, atomic writes, and dry-run previews.
@@ -31,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Parallel execution guidance, resource considerations, and ASAN vs non-ASAN trade-offs.
 
 ### Enhanced
+- Refactored `summary.py` to use shared formatters from `formatting.py`.
 - Improved repo URL resolution with secondary keys (bug tracker, issues, changelog) and legacy field fallbacks (home_page, download_url).
 - Run summary shows version-skipped count separately when skip_versions is active.
 - Progress reporting adapted for parallel execution with per-completion status lines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 - Click CLI framework — Click 8.3+ (no `mix_stderr` in CliRunner)
 
 ## Architecture
-- `cli.py` — Click CLI entry point with `resolve`, `run`, and `registry` subcommands
+- `cli.py` — Click CLI entry point with `resolve`, `run`, `registry`, and `analyze` subcommands
 - `resolve.py` — PyPI metadata fetching, repo URL extraction, registry building
 - `runner.py` — Clone repos, create venvs, run test suites, detect crashes
 - `crash.py` — Crash detection from exit codes and stderr patterns
@@ -40,13 +40,17 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 - `registry.py` — YAML registry I/O (index + per-package configs)
 - `registry_cli.py` — Batch registry management CLI (add/remove/rename/set fields, validate)
 - `registry_ops.py` — Batch operations with filtering, atomic writes, dry-run previews
+- `analyze.py` — Data loading and analysis (run data, registry stats, comparison, flaky detection)
+- `analyze_cli.py` — Analysis CLI (registry, run, compare, history, package subcommands)
+- `formatting.py` — Shared text formatting (tables, histograms, sparklines, durations)
+- `summary.py` — Run summary formatting (uses formatting.py)
 - `yaml_lines.py` — Line-level YAML manipulation preserving formatting
 - `logging.py` — Structured logging setup
 
 ## Testing notes
 - Integration tests mock `fetch_pypi_metadata` to avoid network calls
 - Runner tests mock `subprocess.run` and `clone_repo` extensively
-- 323 tests total across 9 test files
+- 429 tests total across 12 test files
 
 ## Enriching packages
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,33 @@ For the complete guide — including field reference, step-by-step walkthrough,
 common problems, and ready-to-use Claude Code prompts — see
 **[doc/enrichment.md](doc/enrichment.md)**.
 
+## Analyzing Results
+
+Analyze registry composition and run results:
+
+```bash
+# Registry overview (counts by type, framework, skip reasons)
+labeille analyze registry
+
+# Registry as a table, filtered
+labeille analyze registry --format table --where extension_type:pure
+
+# Single run summary (aggregate stats, crash detail, reproduce commands)
+labeille analyze run
+
+# Specific run, quiet mode (crashes only)
+labeille analyze run 2026-02-23T08-01-05 -q
+
+# Compare two runs (status changes, timing deltas)
+labeille analyze compare 2026-02-20T10-00-00 2026-02-22T10-00-00
+
+# Run history with trends and flaky package detection
+labeille analyze history --last 5
+
+# Deep dive on a specific package
+labeille analyze package requests
+```
+
 ## Registry Management
 
 Batch operations for managing the package registry:
@@ -190,12 +217,16 @@ Result statuses: `pass`, `fail`, `crash`, `timeout`, `install_error`,
 ```
 labeille/
 ├── src/labeille/        # Main package
-│   ├── cli.py           # Click CLI with resolve, run, and registry subcommands
+│   ├── cli.py           # Click CLI with resolve, run, registry, and analyze subcommands
 │   ├── resolve.py       # Resolve PyPI packages to source repositories
 │   ├── runner.py        # Run test suites and capture results
 │   ├── registry.py      # Registry reading/writing/schema
 │   ├── registry_cli.py  # Batch registry management CLI
 │   ├── registry_ops.py  # Batch operations (add/remove/rename/set/validate)
+│   ├── analyze.py       # Data loading and analysis functions
+│   ├── analyze_cli.py   # Analysis CLI (registry, run, compare, history, package)
+│   ├── formatting.py    # Shared text formatting (tables, histograms, sparklines)
+│   ├── summary.py       # Run summary formatting
 │   ├── yaml_lines.py    # Line-level YAML manipulation
 │   ├── classifier.py    # Pure Python / C extension detection
 │   ├── crash.py         # Crash detection and signature extraction

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -1,0 +1,833 @@
+"""Analysis and data loading for labeille run results.
+
+Provides :class:`RunData` for lazily loading individual run data,
+:class:`ResultsStore` for discovering and accessing runs, and pure
+analysis functions that operate on loaded data.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from labeille.registry import PackageEntry
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunMeta:
+    """Metadata for a single run, loaded from run_meta.json."""
+
+    run_id: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    target_python: str = ""
+    python_version: str = ""
+    jit_enabled: bool = False
+    hostname: str = ""
+    platform: str = ""
+    packages_tested: int = 0
+    packages_skipped: int = 0
+    crashes_found: int = 0
+    total_duration_seconds: float = 0.0
+    cli_args: list[str] = field(default_factory=list)
+    env_overrides: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunMeta:
+        """Create a RunMeta from a JSON-loaded dict, tolerating missing keys."""
+        return cls(
+            run_id=data.get("run_id", ""),
+            started_at=data.get("started_at", ""),
+            finished_at=data.get("finished_at", ""),
+            target_python=data.get("target_python", ""),
+            python_version=data.get("python_version", ""),
+            jit_enabled=data.get("jit_enabled", False),
+            hostname=data.get("hostname", ""),
+            platform=data.get("platform", ""),
+            packages_tested=data.get("packages_tested", 0),
+            packages_skipped=data.get("packages_skipped", 0),
+            crashes_found=data.get("crashes_found", 0),
+            total_duration_seconds=data.get("total_duration_seconds", 0.0),
+            cli_args=data.get("cli_args", []),
+            env_overrides=data.get("env_overrides", {}),
+        )
+
+
+@dataclass
+class PackageResult:
+    """Result of testing a single package, loaded from results.jsonl."""
+
+    package: str = ""
+    repo: str | None = None
+    package_version: str | None = None
+    git_revision: str | None = None
+    status: str = "error"
+    exit_code: int = -1
+    signal: int | None = None
+    crash_signature: str | None = None
+    duration_seconds: float = 0.0
+    install_duration_seconds: float = 0.0
+    test_command: str = ""
+    timeout_hit: bool = False
+    stderr_tail: str = ""
+    installed_dependencies: dict[str, str] = field(default_factory=dict)
+    error_message: str | None = None
+    timestamp: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PackageResult:
+        """Create a PackageResult from a JSON-loaded dict."""
+        return cls(
+            package=data.get("package", ""),
+            repo=data.get("repo"),
+            package_version=data.get("package_version"),
+            git_revision=data.get("git_revision"),
+            status=data.get("status", "error"),
+            exit_code=data.get("exit_code", -1),
+            signal=data.get("signal"),
+            crash_signature=data.get("crash_signature"),
+            duration_seconds=data.get("duration_seconds", 0.0),
+            install_duration_seconds=data.get("install_duration_seconds", 0.0),
+            test_command=data.get("test_command", ""),
+            timeout_hit=data.get("timeout_hit", False),
+            stderr_tail=data.get("stderr_tail", ""),
+            installed_dependencies=data.get("installed_dependencies", {}),
+            error_message=data.get("error_message"),
+            timestamp=data.get("timestamp", ""),
+        )
+
+
+class RunData:
+    """Lazily loaded data for a single run."""
+
+    def __init__(self, run_id: str, run_dir: Path) -> None:
+        self.run_id = run_id
+        self.run_dir = run_dir
+        self._meta: RunMeta | None = None
+        self._results: list[PackageResult] | None = None
+
+    def __repr__(self) -> str:
+        return f"RunData(run_id={self.run_id!r})"
+
+    @property
+    def meta(self) -> RunMeta:
+        """Load run_meta.json on first access."""
+        if self._meta is None:
+            self._meta = self._load_meta()
+        return self._meta
+
+    @property
+    def results(self) -> list[PackageResult]:
+        """Load results.jsonl on first access."""
+        if self._results is None:
+            self._results = self._load_results()
+        return self._results
+
+    def result_for(self, package: str) -> PackageResult | None:
+        """Find result for a specific package, or None."""
+        for r in self.results:
+            if r.package == package:
+                return r
+        return None
+
+    def results_by_status(self) -> dict[str, list[PackageResult]]:
+        """Group results by status."""
+        grouped: dict[str, list[PackageResult]] = {}
+        for r in self.results:
+            grouped.setdefault(r.status, []).append(r)
+        return grouped
+
+    def _load_meta(self) -> RunMeta:
+        meta_file = self.run_dir / "run_meta.json"
+        if not meta_file.exists():
+            return RunMeta(run_id=self.run_id)
+        data = json.loads(meta_file.read_text(encoding="utf-8"))
+        return RunMeta.from_dict(data)
+
+    def _load_results(self) -> list[PackageResult]:
+        results_file = self.run_dir / "results.jsonl"
+        if not results_file.exists():
+            return []
+        results: list[PackageResult] = []
+        for line in results_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    data = json.loads(line)
+                    results.append(PackageResult.from_dict(data))
+                except json.JSONDecodeError:
+                    continue
+        return results
+
+
+def _extract_minor_version(version_string: str) -> str:
+    """Extract major.minor from a full Python version string."""
+    parts = version_string.strip().split(".")
+    if len(parts) >= 2:
+        minor = ""
+        for ch in parts[1]:
+            if ch.isdigit():
+                minor += ch
+            else:
+                break
+        if parts[0].isdigit() and minor:
+            return f"{parts[0]}.{minor}"
+    return version_string
+
+
+class ResultsStore:
+    """Discovers and provides access to run results."""
+
+    def __init__(self, results_dir: Path) -> None:
+        self.results_dir = results_dir
+
+    def list_runs(self, *, python_version: str | None = None) -> list[RunData]:
+        """List all runs sorted newest first.
+
+        If *python_version* is given, filter to runs with that Python minor
+        version (e.g. ``'3.15'``).
+        """
+        if not self.results_dir.is_dir():
+            return []
+        runs: list[RunData] = []
+        for d in sorted(self.results_dir.iterdir(), reverse=True):
+            if d.is_dir() and (d / "run_meta.json").exists():
+                runs.append(RunData(run_id=d.name, run_dir=d))
+
+        if python_version is not None:
+            filtered: list[RunData] = []
+            for run in runs:
+                pv = _extract_minor_version(run.meta.python_version)
+                if pv == python_version:
+                    filtered.append(run)
+            runs = filtered
+
+        return runs
+
+    def latest(self) -> RunData | None:
+        """Return the most recent run, or None."""
+        runs = self.list_runs()
+        return runs[0] if runs else None
+
+    def get(self, run_id: str) -> RunData | None:
+        """Get a specific run. Accepts ``'latest'`` as alias."""
+        if run_id == "latest":
+            return self.latest()
+        run_dir = self.results_dir / run_id
+        if run_dir.is_dir() and (run_dir / "run_meta.json").exists():
+            return RunData(run_id=run_id, run_dir=run_dir)
+        return None
+
+    def runs_for_package(self, package: str) -> list[tuple[RunData, PackageResult]]:
+        """Find all runs that tested a specific package.
+
+        Returns ``(run, result)`` pairs, newest first.
+        """
+        pairs: list[tuple[RunData, PackageResult]] = []
+        for run in self.list_runs():
+            result = run.result_for(package)
+            if result is not None:
+                pairs.append((run, result))
+        return pairs
+
+
+# ---------------------------------------------------------------------------
+# Registry analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RegistryStats:
+    """Aggregate statistics about the registry."""
+
+    total: int = 0
+    active: int = 0
+    skipped: int = 0
+    by_extension_type: dict[str, tuple[int, int]] = field(default_factory=dict)
+    by_skip_category: dict[str, int] = field(default_factory=dict)
+    by_test_framework: dict[str, int] = field(default_factory=dict)
+    notable: dict[str, int] = field(default_factory=dict)
+    quality_warnings: list[tuple[str, str]] = field(default_factory=list)
+
+
+def categorize_skip_reason(reason: str) -> str:
+    """Categorize a skip reason into a human-readable bucket."""
+    lower = reason.lower()
+    if any(kw in lower for kw in ("pyo3", "rust", "maturin")):
+        return "PyO3/Rust (no 3.15)"
+    if any(kw in lower for kw in ("monorepo", "mono repo", "workspace")):
+        return "Monorepo"
+    if any(kw in lower for kw in ("no repo", "no source", "no url", "no repository")):
+        return "No repo URL"
+    if any(kw in lower for kw in ("c build", "c++", "meson", "cmake", "fortran", "header")):
+        return "C/C++ build complexity"
+    if any(kw in lower for kw in ("no test", "no tests")):
+        return "No test suite"
+    if any(kw in lower for kw in ("credential", "api key", "cloud", "auth")):
+        return "Cloud/API credentials"
+    if any(kw in lower for kw in ("jit crash", "crash during install", "segfault")):
+        return "JIT crash during install"
+    if any(kw in lower for kw in ("heavy", "large dep", "numpy", "pandas")):
+        return "Heavy dependencies"
+    return "Other"
+
+
+def detect_quality_warnings(pkg: PackageEntry) -> list[str]:
+    """Detect potential enrichment quality issues for a single package."""
+    warnings: list[str] = []
+    if not pkg.skip and pkg.enriched:
+        if not pkg.install_command:
+            warnings.append("active but empty install_command")
+        if not pkg.test_command:
+            warnings.append("active but empty test_command")
+    if not pkg.skip and pkg.skip_reason:
+        warnings.append("active but skip_reason is non-null")
+    if pkg.skip and pkg.skip_versions:
+        warnings.append("skip is true but skip_versions has entries (redundant)")
+    return warnings
+
+
+def analyze_registry(
+    packages: list[PackageEntry],
+    *,
+    target_python_version: str | None = None,
+) -> RegistryStats:
+    """Analyze registry composition.
+
+    If *target_python_version* is given, ``skip_versions`` entries for that
+    version are counted as skipped.
+    """
+    stats = RegistryStats(total=len(packages))
+
+    for pkg in packages:
+        is_skipped = pkg.skip
+        if (
+            not is_skipped
+            and target_python_version
+            and pkg.skip_versions
+            and target_python_version in pkg.skip_versions
+        ):
+            is_skipped = True
+
+        if is_skipped:
+            stats.skipped += 1
+        else:
+            stats.active += 1
+
+        # Extension type breakdown.
+        ext = pkg.extension_type or "unknown"
+        active_count, skipped_count = stats.by_extension_type.get(ext, (0, 0))
+        if is_skipped:
+            stats.by_extension_type[ext] = (active_count, skipped_count + 1)
+        else:
+            stats.by_extension_type[ext] = (active_count + 1, skipped_count)
+
+        # Skip reason categorization.
+        if is_skipped:
+            reason = pkg.skip_reason or ""
+            if target_python_version and pkg.skip_versions:
+                ver_reason = pkg.skip_versions.get(target_python_version)
+                if ver_reason:
+                    reason = ver_reason
+            if reason:
+                cat = categorize_skip_reason(reason)
+            else:
+                cat = "Other"
+            stats.by_skip_category[cat] = stats.by_skip_category.get(cat, 0) + 1
+
+        # Test framework (active only).
+        if not is_skipped:
+            fw = pkg.test_framework or "unknown"
+            stats.by_test_framework[fw] = stats.by_test_framework.get(fw, 0) + 1
+
+        # Notable attributes (active only).
+        if not is_skipped:
+            if pkg.timeout is not None:
+                stats.notable["Custom timeout"] = stats.notable.get("Custom timeout", 0) + 1
+            if pkg.clone_depth is not None:
+                stats.notable["clone_depth set"] = stats.notable.get("clone_depth set", 0) + 1
+            if pkg.uses_xdist:
+                stats.notable["uses_xdist"] = stats.notable.get("uses_xdist", 0) + 1
+            if pkg.import_name is not None:
+                stats.notable["import_name set"] = stats.notable.get("import_name set", 0) + 1
+
+        # Quality warnings.
+        for warning in detect_quality_warnings(pkg):
+            stats.quality_warnings.append((pkg.package, warning))
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Run analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StatusChange:
+    """A status change for a single package between two runs."""
+
+    package: str
+    old_status: str
+    new_status: str
+    old_detail: str = ""
+    new_detail: str = ""
+
+
+@dataclass
+class RunAnalysis:
+    """Analysis of a single run."""
+
+    run: RunData
+    status_counts: dict[str, int] = field(default_factory=dict)
+    total_duration: float = 0.0
+    install_duration: float = 0.0
+    test_duration: float = 0.0
+    avg_duration: float = 0.0
+    fastest: PackageResult | None = None
+    slowest: PackageResult | None = None
+    duration_buckets: list[tuple[str, int]] = field(default_factory=list)
+    crashes: list[PackageResult] = field(default_factory=list)
+    status_changes: list[StatusChange] | None = None
+
+
+def _result_detail(r: PackageResult) -> str:
+    """Build a brief detail string for a result."""
+    if r.status == "crash":
+        return (r.crash_signature or "")[:60]
+    if r.status == "timeout":
+        return f"(timeout: {int(r.duration_seconds)}s)"
+    if r.status == "fail":
+        return f"exit code {r.exit_code}"
+    if r.status in ("install_error", "clone_error", "error"):
+        return (r.error_message or "")[:60]
+    return ""
+
+
+def compute_duration_buckets(
+    results: list[PackageResult],
+) -> list[tuple[str, int]]:
+    """Bucket durations into ranges for histogram display."""
+    buckets = [
+        ("0-10s", 0),
+        ("10-30s", 0),
+        ("30s-1m", 0),
+        ("1-5m", 0),
+        ("5-15m", 0),
+        ("15m+", 0),
+    ]
+    thresholds = [10, 30, 60, 300, 900]
+    for r in results:
+        d = r.duration_seconds
+        placed = False
+        for i, t in enumerate(thresholds):
+            if d < t:
+                label, count = buckets[i]
+                buckets[i] = (label, count + 1)
+                placed = True
+                break
+        if not placed:
+            label, count = buckets[-1]
+            buckets[-1] = (label, count + 1)
+    return buckets
+
+
+def analyze_run(
+    run: RunData,
+    *,
+    previous_run: RunData | None = None,
+) -> RunAnalysis:
+    """Full analysis of a single run."""
+    results = run.results
+    analysis = RunAnalysis(run=run)
+
+    # Status counts.
+    for r in results:
+        analysis.status_counts[r.status] = analysis.status_counts.get(r.status, 0) + 1
+
+    # Timing.
+    if results:
+        analysis.total_duration = sum(r.duration_seconds for r in results)
+        analysis.install_duration = sum(r.install_duration_seconds for r in results)
+        analysis.test_duration = analysis.total_duration - analysis.install_duration
+        analysis.avg_duration = analysis.total_duration / len(results)
+        analysis.fastest = min(results, key=lambda r: r.duration_seconds)
+        analysis.slowest = max(results, key=lambda r: r.duration_seconds)
+
+    # Duration histogram.
+    analysis.duration_buckets = compute_duration_buckets(results)
+
+    # Crashes.
+    analysis.crashes = [r for r in results if r.status == "crash"]
+
+    # Status changes vs previous run.
+    if previous_run is not None:
+        analysis.status_changes = _compute_status_changes(previous_run, run)
+
+    return analysis
+
+
+def _compute_status_changes(old_run: RunData, new_run: RunData) -> list[StatusChange]:
+    """Compute status changes between two runs."""
+    old_map: dict[str, PackageResult] = {r.package: r for r in old_run.results}
+    changes: list[StatusChange] = []
+
+    for r in new_run.results:
+        old_r = old_map.get(r.package)
+        if old_r is None:
+            continue
+        if old_r.status != r.status:
+            changes.append(
+                StatusChange(
+                    package=r.package,
+                    old_status=old_r.status,
+                    new_status=r.status,
+                    old_detail=_result_detail(old_r),
+                    new_detail=_result_detail(r),
+                )
+            )
+
+    return changes
+
+
+def build_reproduce_command(
+    result: PackageResult,
+    registry_entry: PackageEntry,
+    python_path: str,
+) -> str:
+    """Build a shell script to reproduce a crash from scratch."""
+    lines: list[str] = []
+    repo = result.repo or registry_entry.repo or ""
+    pkg_name = result.package
+
+    clone_cmd = f"git clone --depth=1 {repo} /tmp/{pkg_name}-repro"
+    if registry_entry.clone_depth is not None and registry_entry.clone_depth > 1:
+        clone_cmd = f"git clone --depth={registry_entry.clone_depth} {repo} /tmp/{pkg_name}-repro"
+
+    lines.append(clone_cmd)
+    lines.append(f"cd /tmp/{pkg_name}-repro")
+    lines.append(f"{python_path} -m venv .venv")
+
+    install_cmd = registry_entry.install_command or "pip install -e ."
+    install_cmd = install_cmd.replace("pip install", ".venv/bin/pip install")
+    lines.append(install_cmd)
+
+    test_cmd = result.test_command or registry_entry.test_command or "python -m pytest"
+    test_cmd = test_cmd.replace("python ", ".venv/bin/python ")
+    lines.append(f"PYTHON_JIT=1 PYTHONFAULTHANDLER=1 {test_cmd}")
+
+    return "\n".join(lines)
+
+
+def categorize_install_errors(
+    results: list[PackageResult],
+) -> dict[str, list[str]]:
+    """Group install errors by error pattern."""
+    categories: dict[str, list[str]] = {}
+    for r in results:
+        if r.status != "install_error":
+            continue
+        msg = (r.error_message or "").lower()
+        if any(kw in msg for kw in ("header", "include", ".h")):
+            cat = "Missing headers"
+        elif any(kw in msg for kw in ("resolution", "conflict", "incompatible")):
+            cat = "Pip resolution"
+        elif any(kw in msg for kw in ("build", "compile", "setup.py", "wheel")):
+            cat = "Build error"
+        elif any(kw in msg for kw in ("import", "modulenotfound")):
+            cat = "Import failure"
+        else:
+            cat = "Other"
+        categories.setdefault(cat, []).append(r.package)
+    return categories
+
+
+# ---------------------------------------------------------------------------
+# Comparison analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TimingChange:
+    """A significant timing change for a single package between two runs."""
+
+    package: str
+    old_seconds: float
+    new_seconds: float
+    change_pct: float
+
+
+@dataclass
+class ComparisonResult:
+    """Comparison between two runs."""
+
+    run_a: RunData
+    run_b: RunData
+    packages_in_common: int = 0
+    packages_only_in_a: list[str] = field(default_factory=list)
+    packages_only_in_b: list[str] = field(default_factory=list)
+    status_changes: list[StatusChange] = field(default_factory=list)
+    signature_changes: list[tuple[str, str | None, str | None]] = field(default_factory=list)
+    timing_changes: list[TimingChange] = field(default_factory=list)
+    unchanged_counts: dict[str, int] = field(default_factory=dict)
+
+
+def compare_runs(
+    run_a: RunData,
+    run_b: RunData,
+    *,
+    timing_threshold_pct: float = 20.0,
+    timing_threshold_abs: float = 30.0,
+) -> ComparisonResult:
+    """Compare two runs.
+
+    Timing changes are only reported if they exceed BOTH the percentage
+    threshold AND the absolute threshold.
+    """
+    result = ComparisonResult(run_a=run_a, run_b=run_b)
+
+    map_a: dict[str, PackageResult] = {r.package: r for r in run_a.results}
+    map_b: dict[str, PackageResult] = {r.package: r for r in run_b.results}
+
+    names_a = set(map_a.keys())
+    names_b = set(map_b.keys())
+    common = names_a & names_b
+
+    result.packages_in_common = len(common)
+    result.packages_only_in_a = sorted(names_a - names_b)
+    result.packages_only_in_b = sorted(names_b - names_a)
+
+    for pkg in sorted(common):
+        ra = map_a[pkg]
+        rb = map_b[pkg]
+
+        if ra.status != rb.status:
+            result.status_changes.append(
+                StatusChange(
+                    package=pkg,
+                    old_status=ra.status,
+                    new_status=rb.status,
+                    old_detail=_result_detail(ra),
+                    new_detail=_result_detail(rb),
+                )
+            )
+        else:
+            result.unchanged_counts[ra.status] = result.unchanged_counts.get(ra.status, 0) + 1
+
+        # Crash signature comparison.
+        if ra.status == "crash" or rb.status == "crash":
+            if ra.crash_signature != rb.crash_signature:
+                result.signature_changes.append((pkg, ra.crash_signature, rb.crash_signature))
+
+        # Timing changes.
+        if ra.duration_seconds > 0 and rb.duration_seconds > 0:
+            abs_change = abs(rb.duration_seconds - ra.duration_seconds)
+            if ra.duration_seconds > 0:
+                pct_change = (
+                    (rb.duration_seconds - ra.duration_seconds) / ra.duration_seconds * 100
+                )
+            else:
+                pct_change = 0.0
+
+            if abs(pct_change) >= timing_threshold_pct and abs_change >= timing_threshold_abs:
+                result.timing_changes.append(
+                    TimingChange(
+                        package=pkg,
+                        old_seconds=ra.duration_seconds,
+                        new_seconds=rb.duration_seconds,
+                        change_pct=pct_change,
+                    )
+                )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# History analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HistoryAnalysis:
+    """Analysis across multiple runs."""
+
+    runs: list[RunData] = field(default_factory=list)
+    crash_trend: list[int] = field(default_factory=list)
+    pass_rate_trend: list[float] = field(default_factory=list)
+    total_unique_crashes: int = 0
+    currently_reproducing: int = 0
+    likely_fixed: int = 0
+    flaky_packages: list[tuple[str, list[str]]] = field(default_factory=list)
+
+
+def analyze_history(
+    runs: list[RunData],
+    *,
+    flaky_min_oscillations: int = 2,
+) -> HistoryAnalysis:
+    """Analyze trends across multiple runs."""
+    analysis = HistoryAnalysis(runs=runs)
+
+    if not runs:
+        return analysis
+
+    # Crash and pass rate trends (oldest to newest for sparklines).
+    all_crash_sigs: set[str] = set()
+    latest_crash_sigs: set[str] = set()
+
+    for run in reversed(runs):  # oldest first
+        results = run.results
+        crash_count = sum(1 for r in results if r.status == "crash")
+        analysis.crash_trend.append(crash_count)
+
+        total = len(results)
+        passed = sum(1 for r in results if r.status == "pass")
+        rate = (passed / total * 100) if total > 0 else 0.0
+        analysis.pass_rate_trend.append(rate)
+
+        for r in results:
+            if r.status == "crash" and r.crash_signature:
+                all_crash_sigs.add(r.crash_signature)
+
+    # Latest run stats.
+    if runs:
+        latest = runs[0]
+        for r in latest.results:
+            if r.status == "crash" and r.crash_signature:
+                latest_crash_sigs.add(r.crash_signature)
+
+    analysis.total_unique_crashes = len(all_crash_sigs)
+    analysis.currently_reproducing = len(latest_crash_sigs)
+    analysis.likely_fixed = len(all_crash_sigs - latest_crash_sigs)
+
+    # Flaky packages.
+    analysis.flaky_packages = detect_flaky_packages(runs, min_oscillations=flaky_min_oscillations)
+
+    return analysis
+
+
+def detect_flaky_packages(
+    runs: list[RunData],
+    *,
+    min_oscillations: int = 2,
+) -> list[tuple[str, list[str]]]:
+    """Find packages with inconsistent results across runs.
+
+    Only considers runs with the same Python minor version.
+    Ignores crash status (crashes are not flaky tests).
+    """
+    if not runs:
+        return []
+
+    # Group runs by Python minor version.
+    by_version: dict[str, list[RunData]] = {}
+    for run in runs:
+        pv = _extract_minor_version(run.meta.python_version)
+        by_version.setdefault(pv, []).append(run)
+
+    flaky: list[tuple[str, list[str]]] = []
+
+    for version_runs in by_version.values():
+        if len(version_runs) < 2:
+            continue
+
+        # Collect all packages across these runs.
+        all_packages: set[str] = set()
+        for run in version_runs:
+            for r in run.results:
+                all_packages.add(r.package)
+
+        for pkg in sorted(all_packages):
+            statuses: list[str] = []
+            for run in reversed(version_runs):  # oldest first
+                pkg_result = run.result_for(pkg)
+                if pkg_result is not None:
+                    statuses.append(pkg_result.status)
+
+            if len(statuses) < 2:
+                continue
+
+            # Count oscillations (ignoring crashes).
+            filtered = [s for s in statuses if s != "crash"]
+            if len(filtered) < 2:
+                continue
+
+            oscillations = 0
+            for i in range(1, len(filtered)):
+                if filtered[i] != filtered[i - 1]:
+                    oscillations += 1
+
+            if oscillations >= min_oscillations:
+                flaky.append((pkg, statuses))
+
+    return flaky
+
+
+# ---------------------------------------------------------------------------
+# Package history
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PackageHistory:
+    """Complete history for a single package across all runs."""
+
+    package: str = ""
+    registry_entry: PackageEntry | None = None
+    run_results: list[tuple[RunData, PackageResult]] = field(default_factory=list)
+    crash_signatures: dict[str, int] = field(default_factory=dict)
+    latest_crash_date: str | None = None
+    likely_fixed: bool = False
+    dependency_changes: list[tuple[str, dict[str, str], dict[str, str]]] = field(
+        default_factory=list
+    )
+
+
+def analyze_package(
+    package: str,
+    store: ResultsStore,
+    registry_entry: PackageEntry | None = None,
+) -> PackageHistory:
+    """Build complete history for a single package across all runs."""
+    history = PackageHistory(
+        package=package,
+        registry_entry=registry_entry,
+    )
+
+    pairs = store.runs_for_package(package)
+    history.run_results = pairs
+
+    if not pairs:
+        return history
+
+    # Crash signatures.
+    for run, result in pairs:
+        if result.status == "crash" and result.crash_signature:
+            sig = result.crash_signature
+            history.crash_signatures[sig] = history.crash_signatures.get(sig, 0) + 1
+            if history.latest_crash_date is None:
+                history.latest_crash_date = run.run_id
+
+    # Likely fixed: had crashes in the past but not in the latest run.
+    latest_result = pairs[0][1] if pairs else None
+    if latest_result and latest_result.status != "crash" and history.crash_signatures:
+        history.likely_fixed = True
+
+    # Dependency changes at status transition boundaries.
+    for i in range(len(pairs) - 1):
+        run_new, result_new = pairs[i]
+        run_old, result_old = pairs[i + 1]
+        if result_new.status != result_old.status:
+            old_deps = result_old.installed_dependencies
+            new_deps = result_new.installed_dependencies
+            if old_deps and new_deps and old_deps != new_deps:
+                history.dependency_changes.append((run_new.run_id, old_deps, new_deps))
+
+    return history

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -1,0 +1,954 @@
+"""CLI commands for the ``labeille analyze`` subgroup.
+
+Provides five subcommands for analyzing registry composition and run results:
+``registry``, ``run``, ``compare``, ``history``, and ``package``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from labeille.analyze import (
+    ComparisonResult,
+    HistoryAnalysis,
+    PackageHistory,
+    PackageResult,
+    RegistryStats,
+    ResultsStore,
+    RunAnalysis,
+    RunData,
+    analyze_history,
+    analyze_package,
+    analyze_registry,
+    analyze_run,
+    build_reproduce_command,
+    categorize_install_errors,
+    compare_runs,
+)
+from labeille.formatting import (
+    format_duration,
+    format_histogram,
+    format_percentage,
+    format_section_header,
+    format_sparkline,
+    format_status_icon,
+    format_table,
+    truncate,
+)
+from labeille.registry import PackageEntry, load_package, package_exists
+
+
+@click.group()
+def analyze() -> None:
+    """Analyze registry composition and run results."""
+
+
+_results_dir_option = click.option(
+    "--results-dir",
+    type=click.Path(path_type=Path),
+    default=Path("results"),
+    show_default=True,
+)
+_registry_dir_option = click.option(
+    "--registry-dir",
+    type=click.Path(path_type=Path),
+    default=Path("registry"),
+    show_default=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# analyze registry
+# ---------------------------------------------------------------------------
+
+
+@analyze.command("registry")
+@_registry_dir_option
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["counts", "table"]),
+    default="counts",
+    show_default=True,
+)
+@click.option("--where", "where_exprs", type=str, multiple=True)
+@click.option("--python-version", type=str, default=None)
+def registry_cmd(
+    registry_dir: Path,
+    fmt: str,
+    where_exprs: tuple[str, ...],
+    python_version: str | None,
+) -> None:
+    """Analyze registry composition."""
+    packages = _load_all_packages(registry_dir, where_exprs)
+
+    if fmt == "table":
+        _print_registry_table(packages, python_version)
+    else:
+        stats = analyze_registry(packages, target_python_version=python_version)
+        _print_registry_counts(stats)
+
+
+def _load_all_packages(
+    registry_dir: Path, where_exprs: tuple[str, ...] = ()
+) -> list[PackageEntry]:
+    """Load all package entries from the registry, optionally filtered."""
+    from labeille.registry_ops import FieldFilter, matches, parse_where
+
+    packages_dir = registry_dir / "packages"
+    if not packages_dir.is_dir():
+        return []
+
+    filters: list[FieldFilter] = [parse_where(e) for e in where_exprs]
+    packages: list[PackageEntry] = []
+
+    import yaml
+
+    for f in sorted(packages_dir.glob("*.yaml")):
+        if filters:
+            raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict) or not matches(raw, filters):
+                continue
+        pkg = load_package(f.stem, registry_dir)
+        packages.append(pkg)
+
+    return packages
+
+
+def _print_registry_counts(stats: RegistryStats) -> None:
+    """Print the counts format for registry analysis."""
+    click.echo(
+        f"Registry: {stats.total} packages ({stats.active} active, {stats.skipped} skipped)"
+    )
+    click.echo()
+
+    # By extension type.
+    click.echo("By extension type:")
+    for ext_type in sorted(stats.by_extension_type.keys()):
+        active, skipped = stats.by_extension_type[ext_type]
+        total = active + skipped
+        click.echo(f"  {ext_type:<15s} {total:3d}  ({active:3d} active, {skipped:3d} skipped)")
+    click.echo()
+
+    # By skip reason.
+    if stats.by_skip_category:
+        click.echo(f"By skip reason ({stats.skipped} skipped):")
+        for cat, count in sorted(stats.by_skip_category.items(), key=lambda x: -x[1]):
+            click.echo(f"  {cat:<30s} {count:3d}")
+        click.echo()
+
+    # By test framework.
+    if stats.by_test_framework:
+        click.echo(f"By test framework ({stats.active} active):")
+        for fw, count in sorted(stats.by_test_framework.items(), key=lambda x: -x[1]):
+            click.echo(f"  {fw:<15s} {count:3d}")
+        click.echo()
+
+    # Notable.
+    if stats.notable:
+        click.echo("Notable:")
+        for label, count in sorted(stats.notable.items()):
+            click.echo(f"  {label + ':':<20s} {count:3d} packages")
+        click.echo()
+
+    # Quality warnings.
+    if stats.quality_warnings:
+        click.echo(f"Quality warnings ({len(stats.quality_warnings)}):")
+        for pkg_name, warning in stats.quality_warnings[:20]:
+            click.echo(f"  {pkg_name}: {warning}")
+
+
+def _print_registry_table(packages: list[PackageEntry], python_version: str | None) -> None:
+    """Print the table format for registry analysis."""
+    headers = ["Package", "Type", "Status", "Framework", "Timeout", "Notes"]
+    rows: list[list[str]] = []
+
+    for pkg in sorted(packages, key=lambda p: p.package):
+        is_skipped = pkg.skip
+        if (
+            not is_skipped
+            and python_version
+            and pkg.skip_versions
+            and python_version in pkg.skip_versions
+        ):
+            is_skipped = True
+
+        status = "skip" if is_skipped else "active"
+        timeout_str = str(pkg.timeout) if pkg.timeout is not None else ""
+        notes = truncate(pkg.notes or "", 30)
+
+        rows.append(
+            [
+                pkg.package,
+                pkg.extension_type,
+                status,
+                pkg.test_framework,
+                timeout_str,
+                notes,
+            ]
+        )
+
+    click.echo(
+        format_table(
+            headers,
+            rows,
+            alignments=["l", "l", "l", "l", "r", "l"],
+            max_col_width={0: 25, 5: 30},
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# analyze run
+# ---------------------------------------------------------------------------
+
+_STATUS_ORDER: dict[str, int] = {
+    "crash": 0,
+    "timeout": 1,
+    "fail": 2,
+    "install_error": 3,
+    "clone_error": 4,
+    "error": 5,
+    "pass": 6,
+}
+
+
+@analyze.command("run")
+@_results_dir_option
+@_registry_dir_option
+@click.argument("run_id", default="latest")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["summary", "table", "full"]),
+    default="summary",
+    show_default=True,
+)
+@click.option("-q", "--quiet", is_flag=True)
+@click.option("-v", "--verbose", is_flag=True)
+@click.option("--no-histogram", is_flag=True)
+@click.option("--no-reproduce", is_flag=True)
+def run_cmd(
+    results_dir: Path,
+    registry_dir: Path,
+    run_id: str,
+    fmt: str,
+    quiet: bool,
+    verbose: bool,
+    no_histogram: bool,
+    no_reproduce: bool,
+) -> None:
+    """Analyze a single run."""
+    store = ResultsStore(results_dir)
+
+    run = store.get(run_id)
+    if run is None:
+        raise click.ClickException(f"Run not found: {run_id}")
+
+    # Find previous run with same Python minor version.
+    from labeille.analyze import _extract_minor_version
+
+    all_runs = store.list_runs()
+    current_pv = _extract_minor_version(run.meta.python_version)
+    previous: RunData | None = None
+    found_current = False
+    for r in all_runs:
+        if r.run_id == run.run_id:
+            found_current = True
+            continue
+        if found_current and _extract_minor_version(r.meta.python_version) == current_pv:
+            previous = r
+            break
+
+    analysis = analyze_run(run, previous_run=previous)
+
+    if quiet:
+        _print_run_quiet(analysis, run)
+        return
+
+    if fmt == "table":
+        _print_run_table(analysis, verbose=True)
+        return
+
+    if fmt == "full":
+        _print_run_table(analysis, verbose=True)
+        _print_run_stderr(analysis)
+        return
+
+    # summary format
+    _print_run_summary(
+        analysis,
+        run,
+        registry_dir,
+        verbose=verbose,
+        no_histogram=no_histogram,
+        no_reproduce=no_reproduce,
+    )
+
+
+def _print_run_quiet(analysis: RunAnalysis, run: RunData) -> None:
+    """Print quiet mode: only crashes + one-liner."""
+    crashes = analysis.crashes
+    if not crashes:
+        return
+
+    click.echo(format_section_header("Crashes"))
+    for r in crashes:
+        sig_name = _signal_name(r.signal)
+        signature = r.crash_signature or "unknown"
+        click.echo(f"  {r.package}: {sig_name}: {signature}")
+        if run.run_dir:
+            click.echo(f"    Stderr: {run.run_dir / 'crashes' / f'{r.package}.stderr'}")
+        click.echo(f"    Test command: {r.test_command}")
+        click.echo()
+    click.echo(format_section_header(""))
+
+    total_dur = analysis.total_duration
+    tested = len(run.results)
+    crash_word = "crash" if len(crashes) == 1 else "crashes"
+    click.echo(
+        f"{len(crashes)} {crash_word} found in {tested} packages tested "
+        f"({format_duration(total_dur)})"
+    )
+
+
+def _print_run_summary(
+    analysis: RunAnalysis,
+    run: RunData,
+    registry_dir: Path,
+    *,
+    verbose: bool = False,
+    no_histogram: bool = False,
+    no_reproduce: bool = False,
+) -> None:
+    """Print the summary format for run analysis."""
+    meta = run.meta
+
+    # 1. Run header.
+    click.echo()
+    click.echo(f"Run ID: {run.run_id}")
+    click.echo(f"Python: {meta.python_version}")
+    click.echo(f"JIT enabled: {'yes' if meta.jit_enabled else 'no'}")
+    click.echo(f"Duration: {format_duration(analysis.total_duration)}")
+    click.echo()
+
+    # 2. Per-package table.
+    results = run.results
+    if verbose:
+        show_results = results
+    else:
+        show_results = [r for r in results if r.status != "pass"]
+
+    if show_results:
+        show_results = sorted(
+            show_results,
+            key=lambda r: (_STATUS_ORDER.get(r.status, 99), r.package),
+        )
+
+        # Build change tags.
+        change_tags: dict[str, str] = {}
+        if analysis.status_changes is not None:
+            for sc in analysis.status_changes:
+                if sc.new_status == "pass" and sc.old_status in ("crash", "fail"):
+                    change_tags[sc.package] = "[FIXED]"
+                elif sc.old_status == "pass" and sc.new_status in ("crash", "fail"):
+                    change_tags[sc.package] = "[REGRESSED]"
+
+        headers = ["Package", "Status", "Duration", "Signal", "Detail"]
+        rows: list[list[str]] = []
+        for r in show_results:
+            status_str = format_status_icon(r.status)
+            tag = change_tags.get(r.package, "")
+            if tag:
+                status_str += f" {tag}"
+            sig = _signal_name(r.signal)
+            detail = _result_detail_str(r)
+            rows.append(
+                [
+                    r.package,
+                    status_str,
+                    format_duration(r.duration_seconds),
+                    sig,
+                    truncate(detail, 60),
+                ]
+            )
+
+        click.echo(
+            format_table(
+                headers,
+                rows,
+                alignments=["l", "l", "r", "l", "l"],
+                max_col_width={0: 20, 4: 60},
+            )
+        )
+        click.echo()
+
+    # 3. Aggregate summary.
+    tested = len(results)
+    total_pkgs = meta.packages_tested + meta.packages_skipped
+    if total_pkgs == 0:
+        total_pkgs = tested
+
+    counts = analysis.status_counts
+
+    def _p(n: int) -> str:
+        return format_percentage(n, tested)
+
+    passed = counts.get("pass", 0)
+    failed = counts.get("fail", 0)
+    crashed = counts.get("crash", 0)
+
+    left = [
+        f"Packages tested: {tested} / {total_pkgs}",
+        f"  Passed:        {passed:3d} ({_p(passed)})",
+        f"  Failed:        {failed:3d} ({_p(failed)})",
+        f"  Crashed:       {crashed:3d} ({_p(crashed)})",
+        f"  Timed out:     {counts.get('timeout', 0):3d}",
+        f"  Install errors:{counts.get('install_error', 0):3d}",
+        f"  Clone errors:  {counts.get('clone_error', 0):3d}",
+        f"  Other errors:  {counts.get('error', 0):3d}",
+    ]
+
+    right = [
+        f"Total time: {format_duration(analysis.total_duration)}",
+        f"Avg per package: {format_duration(analysis.avg_duration)}",
+    ]
+    if analysis.fastest:
+        right.append(
+            f"Fastest: {analysis.fastest.package} "
+            f"({format_duration(analysis.fastest.duration_seconds)})"
+        )
+    if analysis.slowest:
+        right.append(
+            f"Slowest: {analysis.slowest.package} "
+            f"({format_duration(analysis.slowest.duration_seconds)})"
+        )
+
+    pad = max(len(line) for line in left) + 4
+    for i in range(max(len(left), len(right))):
+        l_text = left[i] if i < len(left) else ""
+        r_text = right[i] if i < len(right) else ""
+        click.echo(f"{l_text:<{pad}s}{r_text}")
+    click.echo()
+
+    # 4. Duration histogram.
+    if not no_histogram and analysis.duration_buckets:
+        click.echo(f"Duration distribution ({tested} packages):")
+        click.echo(format_histogram(analysis.duration_buckets, total=tested))
+        click.echo()
+
+    # 5. Install error analysis.
+    install_errors = [r for r in results if r.status == "install_error"]
+    if install_errors:
+        cats = categorize_install_errors(results)
+        click.echo("Install errors by type:")
+        for cat, pkgs in sorted(cats.items(), key=lambda x: -len(x[1])):
+            pkg_list = ", ".join(pkgs[:5])
+            if len(pkgs) > 5:
+                pkg_list += ", ..."
+            click.echo(f"  {cat + ':':<20s} {len(pkgs):2d}  ({pkg_list})")
+        click.echo()
+
+    # 6. Crash detail.
+    if analysis.crashes:
+        click.echo(format_section_header("Crashes"))
+        for r in analysis.crashes:
+            sig = _signal_name(r.signal)
+            signature = r.crash_signature or "unknown"
+            click.echo(f"  {r.package}: {sig}: {signature}")
+            if run.run_dir:
+                click.echo(f"    Stderr: {run.run_dir / 'crashes' / f'{r.package}.stderr'}")
+            click.echo(f"    Test command: {r.test_command}")
+            click.echo()
+        click.echo(format_section_header(""))
+
+    # 7. Reproduce blocks.
+    if not no_reproduce and analysis.crashes:
+        click.echo(format_section_header("Reproduce"))
+        for r in analysis.crashes:
+            entry: PackageEntry | None = None
+            if package_exists(r.package, registry_dir):
+                entry = load_package(r.package, registry_dir)
+
+            if entry is not None:
+                sig = _signal_name(r.signal)
+                click.echo(f"# {r.package} ({sig}):")
+                cmd = build_reproduce_command(r, entry, str(meta.target_python))
+                click.echo(cmd)
+                click.echo()
+        click.echo(format_section_header(""))
+
+
+def _print_run_table(analysis: RunAnalysis, *, verbose: bool = False) -> None:
+    """Print the table format for run analysis."""
+    results = analysis.run.results
+    headers = [
+        "Package",
+        "Status",
+        "Duration",
+        "Install",
+        "Signal",
+        "Exit Code",
+        "Timed Out",
+        "Detail",
+    ]
+    rows: list[list[str]] = []
+    for r in sorted(results, key=lambda r: (_STATUS_ORDER.get(r.status, 99), r.package)):
+        rows.append(
+            [
+                r.package,
+                format_status_icon(r.status),
+                format_duration(r.duration_seconds),
+                format_duration(r.install_duration_seconds),
+                _signal_name(r.signal),
+                str(r.exit_code),
+                "yes" if r.timeout_hit else "",
+                truncate(_result_detail_str(r), 50),
+            ]
+        )
+
+    click.echo(
+        format_table(
+            headers,
+            rows,
+            alignments=["l", "l", "r", "r", "l", "r", "l", "l"],
+            max_col_width={0: 20, 7: 50},
+        )
+    )
+
+
+def _print_run_stderr(analysis: RunAnalysis) -> None:
+    """Print stderr for non-passing packages (full format)."""
+    for r in analysis.run.results:
+        if r.status == "pass":
+            continue
+        if r.stderr_tail:
+            click.echo(f"\n  --- {r.package} stderr (last lines) ---")
+            for line in r.stderr_tail.splitlines()[-10:]:
+                click.echo(f"    {line}")
+
+
+# ---------------------------------------------------------------------------
+# analyze compare
+# ---------------------------------------------------------------------------
+
+
+@analyze.command("compare")
+@_results_dir_option
+@click.argument("run_a")
+@click.argument("run_b")
+@click.option("--only-changes", is_flag=True)
+@click.option("--no-timing", is_flag=True)
+def compare_cmd(
+    results_dir: Path,
+    run_a: str,
+    run_b: str,
+    only_changes: bool,
+    no_timing: bool,
+) -> None:
+    """Compare two runs."""
+    store = ResultsStore(results_dir)
+
+    ra = store.get(run_a)
+    rb = store.get(run_b)
+    if ra is None:
+        raise click.ClickException(f"Run not found: {run_a}")
+    if rb is None:
+        raise click.ClickException(f"Run not found: {run_b}")
+
+    comparison = compare_runs(ra, rb)
+    _print_comparison(comparison, only_changes=only_changes, no_timing=no_timing)
+
+
+def _print_comparison(
+    comp: ComparisonResult,
+    *,
+    only_changes: bool = False,
+    no_timing: bool = False,
+) -> None:
+    """Print comparison results."""
+    click.echo(f"Comparing: {comp.run_a.run_id} \u2192 {comp.run_b.run_id}")
+
+    pv_a = comp.run_a.meta.python_version
+    pv_b = comp.run_b.meta.python_version
+    if pv_a or pv_b:
+        pv_a_short = truncate(pv_a, 40)
+        pv_b_short = truncate(pv_b, 40)
+        click.echo(f"  Python: {pv_a_short} \u2192 {pv_b_short}")
+
+    click.echo(f"  Packages in common: {comp.packages_in_common}")
+    if comp.packages_only_in_a:
+        click.echo(
+            f"  Only in first run:  {len(comp.packages_only_in_a)}  "
+            f"({', '.join(comp.packages_only_in_a[:5])})"
+        )
+    if comp.packages_only_in_b:
+        click.echo(
+            f"  Only in second run: {len(comp.packages_only_in_b)}  "
+            f"({', '.join(comp.packages_only_in_b[:5])})"
+        )
+    click.echo()
+
+    # Status changes.
+    if comp.status_changes:
+        click.echo(f"Status changes ({len(comp.status_changes)}):")
+        for sc in comp.status_changes:
+            old_icon = format_status_icon(sc.old_status).split()[0]
+            new_icon = format_status_icon(sc.new_status).split()[0]
+            detail = sc.new_detail
+            if detail:
+                click.echo(
+                    f"  {old_icon}\u2192{new_icon}  {sc.package:<20s} "
+                    f"{sc.old_status.upper()} \u2192 {sc.new_status.upper()}  "
+                    f"  {truncate(detail, 40)}"
+                )
+            else:
+                click.echo(
+                    f"  {old_icon}\u2192{new_icon}  {sc.package:<20s} "
+                    f"{sc.old_status.upper()} \u2192 {sc.new_status.upper()}"
+                )
+        click.echo()
+    else:
+        click.echo("No status changes.")
+        click.echo()
+
+    # Crash signature changes.
+    if comp.signature_changes:
+        click.echo(f"Crash signature changes ({len(comp.signature_changes)}):")
+        for pkg, old_sig, new_sig in comp.signature_changes:
+            if old_sig is None and new_sig is not None:
+                click.echo(f"  {pkg}: NEW crash \u2014 {truncate(new_sig, 60)}")
+            elif old_sig is not None and new_sig is None:
+                click.echo(f"  {pkg}: crash RESOLVED (was: {truncate(old_sig, 60)})")
+            elif old_sig != new_sig:
+                click.echo(
+                    f"  {pkg}: {truncate(old_sig or '', 30)} \u2192 {truncate(new_sig or '', 30)}"
+                )
+        click.echo()
+
+    # Unchanged.
+    if not only_changes and comp.unchanged_counts:
+        parts = [
+            f"{count} {status}"
+            for status, count in sorted(comp.unchanged_counts.items(), key=lambda x: -x[1])
+        ]
+        total_unchanged = sum(comp.unchanged_counts.values())
+        click.echo(f"Unchanged: {total_unchanged} ({', '.join(parts)})")
+        click.echo()
+
+    # Timing changes.
+    if not no_timing and not only_changes and comp.timing_changes:
+        click.echo(f"Timing changes (>{20}% and >{30}s):")
+        headers = ["Package", "Before", "After", "Change"]
+        rows: list[list[str]] = []
+        for tc in sorted(comp.timing_changes, key=lambda x: -abs(x.change_pct)):
+            sign = "+" if tc.change_pct > 0 else ""
+            rows.append(
+                [
+                    tc.package,
+                    format_duration(tc.old_seconds),
+                    format_duration(tc.new_seconds),
+                    f"{sign}{tc.change_pct:.0f}%",
+                ]
+            )
+        click.echo(format_table(headers, rows, alignments=["l", "r", "r", "r"]))
+
+
+# ---------------------------------------------------------------------------
+# analyze history
+# ---------------------------------------------------------------------------
+
+
+@analyze.command("history")
+@_results_dir_option
+@click.option("--last", "last_n", type=int, default=10, show_default=True)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["table", "timeline"]),
+    default="table",
+    show_default=True,
+)
+@click.option("--python-version", type=str, default=None)
+def history_cmd(
+    results_dir: Path,
+    last_n: int,
+    fmt: str,
+    python_version: str | None,
+) -> None:
+    """View run history and trends."""
+    store = ResultsStore(results_dir)
+
+    runs = store.list_runs(python_version=python_version)[:last_n]
+
+    if not runs:
+        click.echo("No runs found.")
+        return
+
+    history = analyze_history(runs)
+
+    if fmt == "timeline":
+        _print_history_timeline(history)
+    else:
+        _print_history_table(history)
+
+
+def _print_history_table(history: HistoryAnalysis) -> None:
+    """Print the table format for history analysis."""
+    click.echo(f"Run history (last {len(history.runs)}):")
+    click.echo()
+
+    headers = [
+        "Run ID",
+        "Python",
+        "Tested",
+        "Pass",
+        "Fail",
+        "Crash",
+        "Timeout",
+        "Error",
+        "Duration",
+    ]
+    rows: list[list[str]] = []
+
+    for run in history.runs:
+        results = run.results
+        by_status: dict[str, int] = {}
+        for r in results:
+            by_status[r.status] = by_status.get(r.status, 0) + 1
+
+        pv = truncate(run.meta.python_version.split("(")[0].strip(), 20)
+        total_dur = sum(r.duration_seconds for r in results)
+
+        rows.append(
+            [
+                run.run_id,
+                pv,
+                str(len(results)),
+                str(by_status.get("pass", 0)),
+                str(by_status.get("fail", 0)),
+                str(by_status.get("crash", 0)),
+                str(by_status.get("timeout", 0)),
+                str(
+                    by_status.get("error", 0)
+                    + by_status.get("install_error", 0)
+                    + by_status.get("clone_error", 0)
+                ),
+                format_duration(total_dur),
+            ]
+        )
+
+    click.echo(
+        format_table(
+            headers,
+            rows,
+            alignments=["l", "l", "r", "r", "r", "r", "r", "r", "r"],
+        )
+    )
+    click.echo()
+
+    # Crash summary.
+    click.echo("Crash summary:")
+    click.echo(f"  Total unique crash signatures: {history.total_unique_crashes}")
+    click.echo(f"  Currently reproducing (latest run): {history.currently_reproducing}")
+    click.echo(f"  Likely fixed (in earlier runs, not in latest): {history.likely_fixed}")
+    click.echo()
+
+    # Flaky packages.
+    if history.flaky_packages:
+        click.echo("Flaky packages (inconsistent across runs with same Python version):")
+        for pkg, statuses in history.flaky_packages:
+            icons = " ".join(format_status_icon(s).split()[0] for s in statuses)
+            oscillations = sum(
+                1
+                for i in range(1, len(statuses))
+                if statuses[i] != statuses[i - 1] and statuses[i] != "crash"
+            )
+            click.echo(f"  {pkg}: {icons}  ({oscillations} oscillations)")
+
+
+def _print_history_timeline(history: HistoryAnalysis) -> None:
+    """Print the timeline format for history analysis."""
+    if history.crash_trend:
+        spark = format_sparkline([float(x) for x in history.crash_trend], width=10)
+        crash_first = history.crash_trend[0]
+        crash_last = history.crash_trend[-1]
+        click.echo(
+            f"Crash trend (last {len(history.runs)} runs):   "
+            f"{spark}  {crash_first} \u2192 {crash_last}"
+        )
+
+    if history.pass_rate_trend:
+        spark = format_sparkline(history.pass_rate_trend, width=10)
+        rate_first = f"{history.pass_rate_trend[0]:.0f}%"
+        rate_last = f"{history.pass_rate_trend[-1]:.0f}%"
+        click.echo(f"Pass rate trend:               {spark}  {rate_first} \u2192 {rate_last}")
+
+    click.echo()
+
+    # Group by Python version.
+    from labeille.analyze import _extract_minor_version
+
+    by_version: dict[str, list[RunData]] = {}
+    for run in history.runs:
+        pv = _extract_minor_version(run.meta.python_version)
+        by_version.setdefault(pv, []).append(run)
+
+    if len(by_version) > 1:
+        click.echo("By Python version:")
+        for pv, vruns in sorted(by_version.items()):
+            first_crashes = sum(1 for r in vruns[-1].results if r.status == "crash")
+            last_crashes = sum(1 for r in vruns[0].results if r.status == "crash")
+            first_total = len(vruns[-1].results)
+            last_total = len(vruns[0].results)
+            first_pass = sum(1 for r in vruns[-1].results if r.status == "pass")
+            last_pass = sum(1 for r in vruns[0].results if r.status == "pass")
+            first_rate = f"{first_pass / first_total * 100:.0f}%" if first_total else "-"
+            last_rate = f"{last_pass / last_total * 100:.0f}%" if last_total else "-"
+            click.echo(
+                f"  {pv}  ({len(vruns)} runs): "
+                f"crashes {first_crashes}\u2192{last_crashes}, "
+                f"pass rate {first_rate}\u2192{last_rate}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# analyze package
+# ---------------------------------------------------------------------------
+
+
+@analyze.command("package")
+@_results_dir_option
+@_registry_dir_option
+@click.argument("package_name")
+@click.option("--last", "last_n", type=int, default=None)
+def package_cmd(
+    results_dir: Path,
+    registry_dir: Path,
+    package_name: str,
+    last_n: int | None,
+) -> None:
+    """Deep dive on a specific package's history."""
+    store = ResultsStore(results_dir)
+
+    entry: PackageEntry | None = None
+    if package_exists(package_name, registry_dir):
+        entry = load_package(package_name, registry_dir)
+
+    history = analyze_package(package_name, store, registry_entry=entry)
+
+    if last_n is not None:
+        history.run_results = history.run_results[:last_n]
+
+    _print_package_history(history)
+
+
+def _print_package_history(history: PackageHistory) -> None:
+    """Print package history."""
+    click.echo(f"Package: {history.package}")
+
+    entry = history.registry_entry
+    if entry is not None:
+        click.echo(f"  Repo: {entry.repo or 'N/A'}")
+        timeout_str = f"{entry.timeout}s" if entry.timeout is not None else "default"
+        click.echo(
+            f"  Type: {entry.extension_type} | "
+            f"Framework: {entry.test_framework} | "
+            f"Timeout: {timeout_str}"
+        )
+    click.echo()
+
+    # Run history.
+    if history.run_results:
+        click.echo(f"Run history ({len(history.run_results)} runs):")
+        for run, result in history.run_results:
+            from labeille.analyze import _extract_minor_version
+
+            pv = _extract_minor_version(run.meta.python_version)
+            rev = ""
+            if result.git_revision:
+                rev = f" ({result.git_revision[:7]})"
+            status = format_status_icon(result.status)
+            dur = format_duration(result.duration_seconds)
+            detail = ""
+            if result.status == "crash":
+                detail = f"  {result.crash_signature or ''}"
+            elif result.status == "pass":
+                install_dur = format_duration(result.install_duration_seconds)
+                detail = f"  (install: {install_dur})"
+
+            date = run.run_id[:10] if len(run.run_id) >= 10 else run.run_id
+            click.echo(f"  {date}  {pv}{rev}  {status}  {dur:>8s}{detail}")
+        click.echo()
+    else:
+        click.echo("No run history found.")
+        click.echo()
+
+    # Crash signatures.
+    if history.crash_signatures:
+        click.echo("Crash signatures seen:")
+        for sig, count in sorted(history.crash_signatures.items(), key=lambda x: -x[1]):
+            status_note = ""
+            if history.likely_fixed:
+                status_note = " \u2014 not in latest run (likely fixed)"
+            click.echo(f"  {sig}")
+            click.echo(f"    Occurrences: {count}")
+            if history.latest_crash_date:
+                click.echo(f"    Last seen: {history.latest_crash_date}")
+            if status_note:
+                click.echo(f"    Status: {status_note.strip()}")
+        click.echo()
+
+    # Duration trend.
+    if len(history.run_results) >= 2:
+        durations = [format_duration(r.duration_seconds) for _, r in reversed(history.run_results)]
+        click.echo(f"Duration trend: {' \u2192 '.join(durations)}")
+        click.echo()
+
+    # Dependency changes.
+    if history.dependency_changes:
+        click.echo("Dependency changes at status transitions:")
+        for run_id, old_deps, new_deps in history.dependency_changes[:3]:
+            click.echo(f"  Run {run_id}:")
+            all_keys = set(old_deps.keys()) | set(new_deps.keys())
+            for key in sorted(all_keys):
+                old_v = old_deps.get(key)
+                new_v = new_deps.get(key)
+                if old_v is None and new_v is not None:
+                    click.echo(f"    + {key} {new_v}")
+                elif old_v is not None and new_v is None:
+                    click.echo(f"    - {key} {old_v}")
+                elif old_v != new_v:
+                    click.echo(f"    ~ {key} {old_v} \u2192 {new_v}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _signal_name(sig: int | None) -> str:
+    """Convert a signal number to its name."""
+    if sig is None:
+        return ""
+    import signal as signal_module
+
+    try:
+        return signal_module.Signals(sig).name
+    except (ValueError, AttributeError):
+        return f"SIG{sig}"
+
+
+def _result_detail_str(r: PackageResult) -> str:
+    """Build a brief detail string for a result."""
+    if r.status == "crash":
+        return (r.crash_signature or "")[:60]
+    if r.status == "timeout":
+        return f"(timeout: {int(r.duration_seconds)}s)"
+    if r.status == "fail":
+        return f"exit code {r.exit_code}"
+    if r.status in ("install_error", "clone_error", "error"):
+        return (r.error_message or "")[:60]
+    return ""

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -26,10 +26,14 @@ def main() -> None:
     """labeille — Hunt for CPython JIT bugs by running real-world test suites."""
 
 
-# Register the registry management subgroup.
+# Register subgroups.
 from labeille.registry_cli import registry as registry_group  # noqa: E402
 
 main.add_command(registry_group)
+
+from labeille.analyze_cli import analyze as analyze_group  # noqa: E402
+
+main.add_command(analyze_group)
 
 
 @main.command()

--- a/src/labeille/formatting.py
+++ b/src/labeille/formatting.py
@@ -1,0 +1,246 @@
+"""Shared text formatting helpers for labeille.
+
+Provides functions for formatting durations, tables, histograms, sparklines,
+and other text output used across CLI commands and summaries.
+"""
+
+from __future__ import annotations
+
+
+def format_duration(seconds: float) -> str:
+    """Format seconds as human-readable duration.
+
+    Examples: ``'8s'``, ``'1m 23s'``, ``'1h 12m 34s'``. Always whole seconds
+    (truncated, not rounded).
+    """
+    total = int(seconds)
+    if total >= 3600:
+        h = total // 3600
+        m = (total % 3600) // 60
+        s = total % 60
+        return f"{h}h {m:2d}m {s:2d}s"
+    if total >= 60:
+        m = total // 60
+        s = total % 60
+        return f"{m}m {s:2d}s"
+    return f"{total}s"
+
+
+def format_status_icon(status: str) -> str:
+    """Return a visual status indicator for the given status string."""
+    icons: dict[str, str] = {
+        "crash": "\u2717 CRASH",
+        "timeout": "\u23f1 TIMEOUT",
+        "fail": "\u2717 FAIL",
+        "install_error": "\u26a0 ERROR",
+        "clone_error": "\u26a0 ERROR",
+        "error": "\u26a0 ERROR",
+        "pass": "\u2713 PASS",
+        "skip": "\u2298 SKIP",
+    }
+    return icons.get(status, status.upper())
+
+
+def format_table(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    alignments: list[str] | None = None,
+    max_col_width: dict[int, int] | None = None,
+    indent: int = 2,
+) -> str:
+    """Format a list of rows as an aligned text table.
+
+    Auto-calculates column widths from content. Truncates columns that
+    exceed *max_col_width* (with ``'...'`` suffix). Right-aligns columns
+    marked ``'r'`` in *alignments*.
+
+    Args:
+        headers: Column header strings.
+        rows: List of rows, each a list of cell strings.
+        alignments: Per-column alignment: ``'l'``, ``'r'``, or ``'c'``.
+        max_col_width: Column index to max width mapping.
+        indent: Number of leading spaces per line.
+
+    Returns:
+        The formatted table as a string.
+    """
+    if not headers:
+        return ""
+
+    ncols = len(headers)
+    if alignments is None:
+        alignments = ["l"] * ncols
+    while len(alignments) < ncols:
+        alignments.append("l")
+
+    max_widths = max_col_width or {}
+
+    # Truncate cells and compute column widths.
+    def _trunc(text: str, max_w: int) -> str:
+        if len(text) <= max_w:
+            return text
+        return text[: max_w - 3] + "..."
+
+    proc_headers = list(headers)
+    proc_rows: list[list[str]] = []
+    for row in rows:
+        padded = list(row) + [""] * (ncols - len(row))
+        proc_rows.append(padded[:ncols])
+
+    # Apply max_col_width truncation.
+    for ci, max_w in max_widths.items():
+        if ci < ncols:
+            proc_headers[ci] = _trunc(proc_headers[ci], max_w)
+            for row in proc_rows:
+                row[ci] = _trunc(row[ci], max_w)
+
+    # Compute widths.
+    widths = [len(h) for h in proc_headers]
+    for row in proc_rows:
+        for ci, cell in enumerate(row):
+            widths[ci] = max(widths[ci], len(cell))
+
+    prefix = " " * indent
+
+    def _format_cell(text: str, width: int, align: str) -> str:
+        if align == "r":
+            return text.rjust(width)
+        if align == "c":
+            return text.center(width)
+        return text.ljust(width)
+
+    lines: list[str] = []
+    header_line = "  ".join(
+        _format_cell(proc_headers[i], widths[i], alignments[i]) for i in range(ncols)
+    )
+    lines.append(prefix + header_line)
+
+    for row in proc_rows:
+        row_line = "  ".join(_format_cell(row[i], widths[i], alignments[i]) for i in range(ncols))
+        lines.append(prefix + row_line)
+
+    return "\n".join(lines)
+
+
+def format_histogram(
+    buckets: list[tuple[str, int]],
+    *,
+    max_bar_width: int = 40,
+    show_percentages: bool = True,
+    total: int | None = None,
+) -> str:
+    """Format a text histogram using block characters.
+
+    Each bucket is ``(label, count)``. Labels are left-aligned, bars are
+    proportional to the largest bucket.
+
+    Args:
+        buckets: List of (label, count) tuples.
+        max_bar_width: Maximum width of the bar in characters.
+        show_percentages: Whether to show percentage after count.
+        total: Total for percentage calculation. If None, computed from buckets.
+
+    Returns:
+        The formatted histogram as a string.
+    """
+    if not buckets:
+        return ""
+
+    if total is None:
+        total = sum(count for _, count in buckets)
+
+    max_count = max((count for _, count in buckets), default=0)
+    label_width = max((len(label) for label, _ in buckets), default=0)
+
+    lines: list[str] = []
+    for label, count in buckets:
+        if max_count > 0:
+            bar_len = int(count / max_count * max_bar_width)
+            bar = "\u2588" * bar_len if bar_len > 0 else "\u258f"
+        else:
+            bar = ""
+
+        count_str = f"{count:3d}"
+        if show_percentages and total > 0:
+            pct = count / total * 100
+            pct_str = f"({pct:4.0f}%)"
+        elif show_percentages:
+            pct_str = "(  -%)"
+        else:
+            pct_str = ""
+
+        line = f"  {label:>{label_width}s}   {bar:<{max_bar_width}s}  {count_str}  {pct_str}"
+        lines.append(line.rstrip())
+
+    return "\n".join(lines)
+
+
+_SPARK_CHARS = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588"
+
+
+def format_sparkline(values: list[float], width: int = 10) -> str:
+    """Format a series of values as a sparkline using block characters.
+
+    Scales values to the block character range. Returns a string of
+    *width* characters.
+
+    Args:
+        values: Numeric values to display.
+        width: Output width in characters.
+
+    Returns:
+        The sparkline string.
+    """
+    if not values:
+        return ""
+
+    # Resample to width if needed.
+    if len(values) > width:
+        step = len(values) / width
+        sampled = [values[int(i * step)] for i in range(width)]
+    elif len(values) < width:
+        sampled = list(values)
+        while len(sampled) < width:
+            sampled.append(values[-1])
+    else:
+        sampled = list(values)
+
+    lo = min(sampled)
+    hi = max(sampled)
+    span = hi - lo
+
+    result: list[str] = []
+    for v in sampled:
+        if span == 0:
+            idx = len(_SPARK_CHARS) // 2
+        else:
+            idx = int((v - lo) / span * (len(_SPARK_CHARS) - 1))
+        idx = max(0, min(idx, len(_SPARK_CHARS) - 1))
+        result.append(_SPARK_CHARS[idx])
+
+    return "".join(result)
+
+
+def format_section_header(title: str, width: int = 80) -> str:
+    """Format a section header: ``'\u2500\u2500\u2500 Title \u2500\u2500...'``."""
+    prefix = "\u2500\u2500\u2500 "
+    suffix_len = width - len(prefix) - len(title) - 1
+    suffix = " " + "\u2500" * max(0, suffix_len)
+    return prefix + title + suffix
+
+
+def truncate(text: str, max_len: int, suffix: str = "...") -> str:
+    """Truncate text to *max_len*, adding *suffix* if truncated."""
+    if len(text) <= max_len:
+        return text
+    if max_len <= len(suffix):
+        return suffix[:max_len]
+    return text[: max_len - len(suffix)] + suffix
+
+
+def format_percentage(count: int, total: int) -> str:
+    """Format as percentage: ``'44.2%'``. Returns ``'-'`` if *total* is 0."""
+    if total == 0:
+        return "-"
+    return f"{count / total * 100:.1f}%"

--- a/src/labeille/summary.py
+++ b/src/labeille/summary.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 import signal as signal_module
 from pathlib import Path
 
+from labeille.formatting import (
+    format_duration,
+    format_section_header,
+    format_status_icon,
+)
 from labeille.runner import PackageResult, RunnerConfig, RunSummary
 
 # ---------------------------------------------------------------------------
@@ -25,40 +30,12 @@ _STATUS_ORDER: dict[str, int] = {
     "pass": 6,
 }
 
-_STATUS_DISPLAY: dict[str, str] = {
-    "crash": "\u2717 CRASH",
-    "timeout": "\u23f1 TIMEOUT",
-    "fail": "\u2717 FAIL",
-    "install_error": "\u26a0 ERROR",
-    "clone_error": "\u26a0 ERROR",
-    "error": "\u26a0 ERROR",
-    "pass": "\u2713 PASS",
-}
-
 _SEPARATOR = "\u2500" * 84
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def format_duration(seconds: float) -> str:
-    """Format a duration in seconds to a human-readable string.
-
-    Returns strings like ``"3s"``, ``"2m  5s"``, or ``"1h 12m 34s"``.
-    """
-    total = int(seconds)
-    if total >= 3600:
-        h = total // 3600
-        m = (total % 3600) // 60
-        s = total % 60
-        return f"{h}h {m:2d}m {s:2d}s"
-    if total >= 60:
-        m = total // 60
-        s = total % 60
-        return f"{m}m {s:2d}s"
-    return f"{total}s"
 
 
 def _signal_name(sig: int | None) -> str:
@@ -126,13 +103,13 @@ def _format_package_table(
 
     header = f"  {'Package':<17s}{'Status':<13s}{'Duration':>10s}  {'Signal':<8s} {'Detail'}"
     lines: list[str] = [
-        f"\u2500\u2500\u2500 Results {'\u2500' * 75}",
+        format_section_header("Results", width=84),
         header,
     ]
 
     for r in rows:
         pkg_name = r.package[:16]
-        status = _STATUS_DISPLAY.get(r.status, r.status)
+        status = format_status_icon(r.status)
         dur = format_duration(r.duration_seconds)
         sig = _signal_name(r.signal)
         detail = _detail(r)
@@ -203,7 +180,7 @@ def _format_crash_detail(
     if not crashes:
         return ""
 
-    lines: list[str] = [f"\u2500\u2500\u2500 Crashes {'\u2500' * 75}"]
+    lines: list[str] = [format_section_header("Crashes", width=84)]
     for r in crashes:
         sig = _signal_name(r.signal)
         signature = r.crash_signature or "unknown"

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,870 @@
+"""Tests for labeille.analyze — data loading and analysis functions."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from labeille.analyze import (
+    PackageResult,
+    ResultsStore,
+    RunData,
+    analyze_history,
+    analyze_package,
+    analyze_registry,
+    analyze_run,
+    build_reproduce_command,
+    categorize_install_errors,
+    categorize_skip_reason,
+    compare_runs,
+    compute_duration_buckets,
+    detect_flaky_packages,
+    detect_quality_warnings,
+)
+from labeille.registry import PackageEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_run(
+    results_dir: Path,
+    run_id: str,
+    *,
+    python_version: str = "3.15.0a5+ (heads/main:abc1234)",
+    jit_enabled: bool = True,
+    results: list[dict[str, object]] | None = None,
+) -> Path:
+    """Create a mock run directory with run_meta.json and results.jsonl."""
+    run_dir = results_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "crashes").mkdir(exist_ok=True)
+
+    meta = {
+        "run_id": run_id,
+        "started_at": f"{run_id}T00:00:00Z",
+        "finished_at": f"{run_id}T01:00:00Z",
+        "target_python": "/usr/bin/python3",
+        "python_version": python_version,
+        "jit_enabled": jit_enabled,
+        "hostname": "test",
+        "platform": "Linux",
+        "packages_tested": len(results or []),
+        "packages_skipped": 0,
+        "crashes_found": 0,
+        "total_duration_seconds": 0.0,
+    }
+    (run_dir / "run_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    if results:
+        lines = [json.dumps(r) for r in results]
+        (run_dir / "results.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    return run_dir
+
+
+def _make_result(
+    package: str = "testpkg",
+    status: str = "pass",
+    duration: float = 10.0,
+    **kwargs: object,
+) -> dict[str, object]:
+    """Create a result dict for testing."""
+    data: dict[str, object] = {
+        "package": package,
+        "status": status,
+        "duration_seconds": duration,
+        "install_duration_seconds": kwargs.get("install_duration", 2.0),
+        "exit_code": kwargs.get("exit_code", 0 if status == "pass" else 1),
+        "signal": kwargs.get("signal"),
+        "crash_signature": kwargs.get("crash_signature"),
+        "test_command": kwargs.get("test_command", "python -m pytest"),
+        "timeout_hit": status == "timeout",
+        "stderr_tail": kwargs.get("stderr_tail", ""),
+        "installed_dependencies": kwargs.get("installed_dependencies", {}),
+        "error_message": kwargs.get("error_message"),
+        "repo": kwargs.get("repo", f"https://github.com/user/{package}"),
+        "git_revision": kwargs.get("git_revision"),
+        "timestamp": "2026-02-23T00:00:00Z",
+    }
+    return data
+
+
+def _make_pkg(
+    name: str = "testpkg",
+    skip: bool = False,
+    skip_reason: str | None = None,
+    enriched: bool = True,
+    extension_type: str = "pure",
+    test_framework: str = "pytest",
+    **kwargs: object,
+) -> PackageEntry:
+    """Create a PackageEntry for testing."""
+    return PackageEntry(
+        package=name,
+        repo=f"https://github.com/user/{name}",
+        extension_type=extension_type,
+        enriched=enriched,
+        skip=skip,
+        skip_reason=skip_reason,
+        test_framework=test_framework,
+        install_command=str(kwargs.get("install_command", "pip install -e '.[dev]'")),
+        test_command=str(kwargs.get("test_command", "python -m pytest")),
+        timeout=kwargs.get("timeout"),  # type: ignore[arg-type]
+        clone_depth=kwargs.get("clone_depth"),  # type: ignore[arg-type]
+        import_name=kwargs.get("import_name"),  # type: ignore[arg-type]
+        uses_xdist=bool(kwargs.get("uses_xdist", False)),
+        skip_versions=kwargs.get("skip_versions") or {},  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data loading tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunData(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_lazy_loading(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("alpha"), _make_result("beta")],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        # Properties should not be loaded yet.
+        self.assertIsNone(run._meta)
+        self.assertIsNone(run._results)
+        # Accessing meta loads it.
+        meta = run.meta
+        self.assertIsNotNone(run._meta)
+        self.assertEqual(meta.run_id, "run1")
+        # Accessing results loads them.
+        results = run.results
+        self.assertIsNotNone(run._results)
+        self.assertEqual(len(results), 2)
+
+    def test_result_for(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("alpha"), _make_result("beta")],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        r = run.result_for("alpha")
+        self.assertIsNotNone(r)
+        self.assertEqual(r.package, "alpha")  # type: ignore[union-attr]
+
+    def test_result_for_missing(self) -> None:
+        _write_run(self.results_dir, "run1", results=[_make_result("alpha")])
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        self.assertIsNone(run.result_for("nonexistent"))
+
+    def test_results_by_status(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="pass"),
+                _make_result("b", status="fail"),
+                _make_result("c", status="pass"),
+            ],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        by_status = run.results_by_status()
+        self.assertEqual(len(by_status["pass"]), 2)
+        self.assertEqual(len(by_status["fail"]), 1)
+
+
+class TestResultsStore(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_list_runs(self) -> None:
+        _write_run(self.results_dir, "2026-02-20", results=[_make_result()])
+        _write_run(self.results_dir, "2026-02-22", results=[_make_result()])
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        self.assertEqual(len(runs), 2)
+        # Newest first.
+        self.assertEqual(runs[0].run_id, "2026-02-22")
+
+    def test_latest(self) -> None:
+        _write_run(self.results_dir, "2026-02-20", results=[_make_result()])
+        _write_run(self.results_dir, "2026-02-22", results=[_make_result()])
+        store = ResultsStore(self.results_dir)
+        latest = store.latest()
+        self.assertIsNotNone(latest)
+        self.assertEqual(latest.run_id, "2026-02-22")  # type: ignore[union-attr]
+
+    def test_get_by_id(self) -> None:
+        _write_run(self.results_dir, "run1", results=[_make_result()])
+        store = ResultsStore(self.results_dir)
+        run = store.get("run1")
+        self.assertIsNotNone(run)
+        self.assertEqual(run.run_id, "run1")  # type: ignore[union-attr]
+
+    def test_get_latest_alias(self) -> None:
+        _write_run(self.results_dir, "run1", results=[_make_result()])
+        store = ResultsStore(self.results_dir)
+        run = store.get("latest")
+        self.assertIsNotNone(run)
+
+    def test_empty(self) -> None:
+        store = ResultsStore(self.results_dir)
+        self.assertEqual(store.list_runs(), [])
+        self.assertIsNone(store.latest())
+
+    def test_filter_python_version(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            python_version="3.15.0a5+",
+            results=[_make_result()],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            python_version="3.14.2",
+            results=[_make_result()],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs(python_version="3.15")
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0].run_id, "run1")
+
+    def test_runs_for_package(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("alpha"), _make_result("beta")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("alpha")],
+        )
+        store = ResultsStore(self.results_dir)
+        pairs = store.runs_for_package("alpha")
+        self.assertEqual(len(pairs), 2)
+
+
+# ---------------------------------------------------------------------------
+# Registry analysis tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeRegistry(unittest.TestCase):
+    def test_counts(self) -> None:
+        packages = [
+            _make_pkg("a", skip=False),
+            _make_pkg("b", skip=True, skip_reason="PyO3"),
+            _make_pkg("c", skip=False),
+        ]
+        stats = analyze_registry(packages)
+        self.assertEqual(stats.total, 3)
+        self.assertEqual(stats.active, 2)
+        self.assertEqual(stats.skipped, 1)
+
+    def test_extension_types(self) -> None:
+        packages = [
+            _make_pkg("a", extension_type="pure"),
+            _make_pkg("b", extension_type="extensions", skip=True, skip_reason="reason"),
+            _make_pkg("c", extension_type="pure"),
+        ]
+        stats = analyze_registry(packages)
+        self.assertEqual(stats.by_extension_type["pure"], (2, 0))
+        self.assertEqual(stats.by_extension_type["extensions"], (0, 1))
+
+    def test_with_skip_versions(self) -> None:
+        packages = [
+            _make_pkg("a", skip_versions={"3.15": "PyO3 not supported"}),
+            _make_pkg("b"),
+        ]
+        stats = analyze_registry(packages, target_python_version="3.15")
+        self.assertEqual(stats.active, 1)
+        self.assertEqual(stats.skipped, 1)
+
+    def test_without_target_version(self) -> None:
+        packages = [
+            _make_pkg("a", skip_versions={"3.15": "PyO3 not supported"}),
+        ]
+        stats = analyze_registry(packages)
+        # Without target_python_version, skip_versions doesn't count as skipped.
+        self.assertEqual(stats.active, 1)
+        self.assertEqual(stats.skipped, 0)
+
+
+class TestCategorizeSkipReason(unittest.TestCase):
+    def test_pyo3(self) -> None:
+        self.assertEqual(categorize_skip_reason("PyO3 not supported"), "PyO3/Rust (no 3.15)")
+
+    def test_monorepo(self) -> None:
+        self.assertEqual(categorize_skip_reason("Part of monorepo"), "Monorepo")
+
+    def test_no_repo(self) -> None:
+        self.assertEqual(categorize_skip_reason("No repo URL available"), "No repo URL")
+
+    def test_other(self) -> None:
+        self.assertEqual(categorize_skip_reason("something else entirely"), "Other")
+
+    def test_rust(self) -> None:
+        self.assertEqual(categorize_skip_reason("Built with Rust"), "PyO3/Rust (no 3.15)")
+
+    def test_cloud(self) -> None:
+        self.assertEqual(
+            categorize_skip_reason("Needs cloud credentials"),
+            "Cloud/API credentials",
+        )
+
+
+class TestDetectQualityWarnings(unittest.TestCase):
+    def test_empty_test_command(self) -> None:
+        pkg = _make_pkg("a", test_command="")
+        warnings = detect_quality_warnings(pkg)
+        self.assertTrue(any("test_command" in w for w in warnings))
+
+    def test_clean(self) -> None:
+        pkg = _make_pkg("a")
+        warnings = detect_quality_warnings(pkg)
+        self.assertEqual(warnings, [])
+
+    def test_skip_reason_on_active(self) -> None:
+        pkg = _make_pkg("a", skip_reason="some reason")
+        warnings = detect_quality_warnings(pkg)
+        self.assertTrue(any("skip_reason" in w for w in warnings))
+
+
+# ---------------------------------------------------------------------------
+# Run analysis tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeRun(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_status_counts(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="pass"),
+                _make_result("b", status="fail"),
+                _make_result("c", status="crash", signal=11, crash_signature="SIGSEGV"),
+            ],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        analysis = analyze_run(run)
+        self.assertEqual(analysis.status_counts.get("pass"), 1)
+        self.assertEqual(analysis.status_counts.get("fail"), 1)
+        self.assertEqual(analysis.status_counts.get("crash"), 1)
+
+    def test_timing(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", duration=5.0),
+                _make_result("b", duration=15.0),
+                _make_result("c", duration=10.0),
+            ],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        analysis = analyze_run(run)
+        self.assertAlmostEqual(analysis.total_duration, 30.0)
+        self.assertAlmostEqual(analysis.avg_duration, 10.0)
+        self.assertIsNotNone(analysis.fastest)
+        self.assertEqual(analysis.fastest.package, "a")  # type: ignore[union-attr]
+        self.assertIsNotNone(analysis.slowest)
+        self.assertEqual(analysis.slowest.package, "b")  # type: ignore[union-attr]
+
+    def test_duration_buckets(self) -> None:
+        results = [
+            PackageResult(package="a", duration_seconds=5.0),
+            PackageResult(package="b", duration_seconds=25.0),
+            PackageResult(package="c", duration_seconds=120.0),
+        ]
+        buckets = compute_duration_buckets(results)
+        self.assertEqual(buckets[0][0], "0-10s")
+        self.assertEqual(buckets[0][1], 1)  # 5s in 0-10s
+        self.assertEqual(buckets[1][0], "10-30s")
+        self.assertEqual(buckets[1][1], 1)  # 25s in 10-30s
+        self.assertEqual(buckets[3][0], "1-5m")
+        self.assertEqual(buckets[3][1], 1)  # 120s in 1-5m
+
+    def test_with_previous(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="crash", signal=11, crash_signature="SIGSEGV"),
+                _make_result("b", status="pass"),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result("a", status="pass"),
+                _make_result("b", status="fail"),
+            ],
+        )
+        old = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        new = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        analysis = analyze_run(new, previous_run=old)
+        self.assertIsNotNone(analysis.status_changes)
+        self.assertEqual(len(analysis.status_changes), 2)  # type: ignore[arg-type]
+
+    def test_no_previous(self) -> None:
+        _write_run(self.results_dir, "run1", results=[_make_result()])
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        analysis = analyze_run(run)
+        self.assertIsNone(analysis.status_changes)
+
+
+class TestBuildReproduceCommand(unittest.TestCase):
+    def test_basic(self) -> None:
+        result = PackageResult(
+            package="urllib3",
+            repo="https://github.com/urllib3/urllib3",
+            test_command="python -m pytest tests/",
+        )
+        entry = _make_pkg("urllib3")
+        cmd = build_reproduce_command(result, entry, "/path/to/python3.15")
+        self.assertIn("git clone", cmd)
+        self.assertIn("urllib3", cmd)
+        self.assertIn("venv", cmd)
+        self.assertIn("PYTHON_JIT=1", cmd)
+
+    def test_with_clone_depth(self) -> None:
+        result = PackageResult(package="pkg", repo="https://example.com/repo")
+        entry = _make_pkg("pkg", clone_depth=50)
+        cmd = build_reproduce_command(result, entry, "/path/to/python")
+        self.assertIn("--depth=50", cmd)
+
+
+class TestCategorizeInstallErrors(unittest.TestCase):
+    def test_basic(self) -> None:
+        results = [
+            PackageResult(
+                package="a",
+                status="install_error",
+                error_message="build error: failed to compile",
+            ),
+            PackageResult(
+                package="b",
+                status="install_error",
+                error_message="ModuleNotFoundError: no module named 'foo'",
+            ),
+            PackageResult(package="c", status="pass"),
+        ]
+        cats = categorize_install_errors(results)
+        self.assertIn("Build error", cats)
+        self.assertIn("a", cats["Build error"])
+        self.assertIn("Import failure", cats)
+        self.assertIn("b", cats["Import failure"])
+        # "c" is pass, should not appear.
+        for pkgs in cats.values():
+            self.assertNotIn("c", pkgs)
+
+
+# ---------------------------------------------------------------------------
+# Comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareRuns(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_status_changes(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="crash", signal=11, crash_signature="SIGSEGV"),
+                _make_result("b", status="pass"),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result("a", status="pass"),
+                _make_result("b", status="fail"),
+            ],
+        )
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb)
+        self.assertEqual(len(comp.status_changes), 2)
+
+    def test_packages_only_in_a(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a"), _make_result("b")],
+        )
+        _write_run(self.results_dir, "run2", results=[_make_result("a")])
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb)
+        self.assertIn("b", comp.packages_only_in_a)
+
+    def test_packages_only_in_b(self) -> None:
+        _write_run(self.results_dir, "run1", results=[_make_result("a")])
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a"), _make_result("c")],
+        )
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb)
+        self.assertIn("c", comp.packages_only_in_b)
+
+    def test_timing_changes(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", duration=100.0)],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", duration=200.0)],
+        )
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb, timing_threshold_pct=20.0, timing_threshold_abs=30.0)
+        self.assertEqual(len(comp.timing_changes), 1)
+        self.assertAlmostEqual(comp.timing_changes[0].change_pct, 100.0)
+
+    def test_timing_below_threshold(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", duration=10.0)],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", duration=15.0)],
+        )
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        # 50% change but only 5s absolute — below 30s threshold.
+        comp = compare_runs(ra, rb, timing_threshold_pct=20.0, timing_threshold_abs=30.0)
+        self.assertEqual(len(comp.timing_changes), 0)
+
+    def test_crash_signature_different(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="crash", crash_signature="SIGSEGV")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", status="crash", crash_signature="SIGABRT")],
+        )
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb)
+        self.assertEqual(len(comp.signature_changes), 1)
+
+    def test_identical(self) -> None:
+        results = [_make_result("a"), _make_result("b")]
+        _write_run(self.results_dir, "run1", results=results)
+        _write_run(self.results_dir, "run2", results=results)
+        ra = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        rb = RunData(run_id="run2", run_dir=self.results_dir / "run2")
+        comp = compare_runs(ra, rb)
+        self.assertEqual(len(comp.status_changes), 0)
+        self.assertEqual(comp.packages_in_common, 2)
+
+
+# ---------------------------------------------------------------------------
+# History analysis tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeHistory(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_crash_trend(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="crash", crash_signature="sig1"),
+                _make_result("b", status="crash", crash_signature="sig2"),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result("a", status="crash", crash_signature="sig1"),
+                _make_result("b", status="pass"),
+            ],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        history = analyze_history(runs)
+        # Trend is oldest to newest.
+        self.assertEqual(history.crash_trend, [2, 1])
+
+    def test_pass_rate(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="pass"), _make_result("b", status="fail")],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        history = analyze_history(runs)
+        self.assertAlmostEqual(history.pass_rate_trend[0], 50.0)
+
+    def test_unique_crashes(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="crash", crash_signature="sig1"),
+                _make_result("b", status="crash", crash_signature="sig2"),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result("a", status="crash", crash_signature="sig1"),
+            ],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        history = analyze_history(runs)
+        self.assertEqual(history.total_unique_crashes, 2)
+
+    def test_likely_fixed(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result("a", status="crash", crash_signature="sig1"),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result("a", status="pass"),
+            ],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        history = analyze_history(runs)
+        self.assertEqual(history.likely_fixed, 1)
+        self.assertEqual(history.currently_reproducing, 0)
+
+    def test_empty(self) -> None:
+        history = analyze_history([])
+        self.assertEqual(history.crash_trend, [])
+        self.assertEqual(history.total_unique_crashes, 0)
+
+
+class TestDetectFlakyPackages(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_oscillating(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="pass")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", status="fail")],
+        )
+        _write_run(
+            self.results_dir,
+            "run3",
+            results=[_make_result("a", status="pass")],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        flaky = detect_flaky_packages(runs, min_oscillations=2)
+        self.assertEqual(len(flaky), 1)
+        self.assertEqual(flaky[0][0], "a")
+
+    def test_ignores_crashes(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="pass")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", status="crash")],
+        )
+        _write_run(
+            self.results_dir,
+            "run3",
+            results=[_make_result("a", status="pass")],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        flaky = detect_flaky_packages(runs, min_oscillations=2)
+        # Crash is ignored, so pass→pass with crash in middle = 0 oscillations.
+        self.assertEqual(len(flaky), 0)
+
+    def test_same_python_only(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            python_version="3.15.0a5+",
+            results=[_make_result("a", status="pass")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            python_version="3.14.2",
+            results=[_make_result("a", status="fail")],
+        )
+        store = ResultsStore(self.results_dir)
+        runs = store.list_runs()
+        flaky = detect_flaky_packages(runs, min_oscillations=1)
+        # Different Python versions, so they're not compared.
+        self.assertEqual(len(flaky), 0)
+
+
+# ---------------------------------------------------------------------------
+# Package history tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePackage(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_basic(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("alpha", status="pass")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("alpha", status="fail")],
+        )
+        store = ResultsStore(self.results_dir)
+        history = analyze_package("alpha", store)
+        self.assertEqual(len(history.run_results), 2)
+
+    def test_crash_signatures(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="crash", crash_signature="SIGSEGV")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", status="crash", crash_signature="SIGSEGV")],
+        )
+        store = ResultsStore(self.results_dir)
+        history = analyze_package("a", store)
+        self.assertEqual(history.crash_signatures.get("SIGSEGV"), 2)
+
+    def test_likely_fixed(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("a", status="crash", crash_signature="SIGSEGV")],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[_make_result("a", status="pass")],
+        )
+        store = ResultsStore(self.results_dir)
+        history = analyze_package("a", store)
+        self.assertTrue(history.likely_fixed)
+
+    def test_dependency_changes(self) -> None:
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[
+                _make_result(
+                    "a",
+                    status="crash",
+                    installed_dependencies={"dep1": "1.0"},
+                ),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "run2",
+            results=[
+                _make_result(
+                    "a",
+                    status="pass",
+                    installed_dependencies={"dep1": "2.0"},
+                ),
+            ],
+        )
+        store = ResultsStore(self.results_dir)
+        history = analyze_package("a", store)
+        self.assertEqual(len(history.dependency_changes), 1)
+
+    def test_not_found(self) -> None:
+        store = ResultsStore(self.results_dir)
+        history = analyze_package("nonexistent", store)
+        self.assertEqual(len(history.run_results), 0)
+        self.assertFalse(history.likely_fixed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analyze_cli.py
+++ b/tests/test_analyze_cli.py
@@ -1,0 +1,506 @@
+"""Integration tests for labeille.analyze_cli — CLI commands."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from labeille.analyze_cli import analyze
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_run(
+    results_dir: Path,
+    run_id: str,
+    *,
+    python_version: str = "3.15.0a5+ (heads/main:abc1234)",
+    jit_enabled: bool = True,
+    results: list[dict[str, object]] | None = None,
+) -> None:
+    """Create a mock run directory."""
+    run_dir = results_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "crashes").mkdir(exist_ok=True)
+
+    meta = {
+        "run_id": run_id,
+        "started_at": f"{run_id}T00:00:00Z",
+        "finished_at": f"{run_id}T01:00:00Z",
+        "target_python": "/usr/bin/python3",
+        "python_version": python_version,
+        "jit_enabled": jit_enabled,
+        "hostname": "test",
+        "platform": "Linux",
+        "packages_tested": len(results or []),
+        "packages_skipped": 0,
+        "crashes_found": 0,
+        "total_duration_seconds": 0.0,
+    }
+    (run_dir / "run_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    if results:
+        lines = [json.dumps(r) for r in results]
+        (run_dir / "results.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _make_result(
+    package: str = "testpkg",
+    status: str = "pass",
+    duration: float = 10.0,
+    **kwargs: object,
+) -> dict[str, object]:
+    """Create a result dict for testing."""
+    return {
+        "package": package,
+        "status": status,
+        "duration_seconds": duration,
+        "install_duration_seconds": kwargs.get("install_duration", 2.0),
+        "exit_code": kwargs.get("exit_code", 0 if status == "pass" else 1),
+        "signal": kwargs.get("signal"),
+        "crash_signature": kwargs.get("crash_signature"),
+        "test_command": kwargs.get("test_command", "python -m pytest"),
+        "timeout_hit": status == "timeout",
+        "stderr_tail": kwargs.get("stderr_tail", ""),
+        "installed_dependencies": kwargs.get("installed_dependencies", {}),
+        "error_message": kwargs.get("error_message"),
+        "repo": kwargs.get("repo", f"https://github.com/user/{package}"),
+        "git_revision": kwargs.get("git_revision"),
+        "timestamp": "2026-02-23T00:00:00Z",
+    }
+
+
+def _write_package(
+    registry_dir: Path,
+    name: str,
+    *,
+    skip: bool = False,
+    skip_reason: str | None = None,
+    extension_type: str = "pure",
+) -> None:
+    """Create a package YAML file in the registry."""
+    data = {
+        "package": name,
+        "repo": f"https://github.com/user/{name}",
+        "pypi_url": f"https://pypi.org/project/{name}/",
+        "extension_type": extension_type,
+        "python_versions": [],
+        "install_method": "pip",
+        "install_command": "pip install -e '.[dev]'",
+        "test_command": "python -m pytest tests/",
+        "test_framework": "pytest",
+        "uses_xdist": False,
+        "timeout": None,
+        "skip": skip,
+        "skip_reason": skip_reason,
+        "skip_versions": {},
+        "notes": "",
+        "enriched": True,
+        "clone_depth": None,
+        "import_name": None,
+    }
+    pkg_dir = registry_dir / "packages"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / f"{name}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FixtureMixin:
+    """Mixin that sets up a temp directory with mock runs and registry."""
+
+    def _setup_fixtures(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmpdir.name)
+        self.results_dir = self.base / "results"
+        self.registry_dir = self.base / "registry"
+        self.results_dir.mkdir()
+        self.registry_dir.mkdir()
+
+        # Create packages.
+        for name in ["alpha", "beta", "gamma", "delta", "epsilon"]:
+            _write_package(self.registry_dir, name)
+        _write_package(self.registry_dir, "skipped", skip=True, skip_reason="PyO3 not supported")
+
+        # Create runs.
+        _write_run(
+            self.results_dir,
+            "2026-02-20T10-00-00",
+            results=[
+                _make_result("alpha", status="crash", signal=11, crash_signature="SIGSEGV"),
+                _make_result("beta", status="pass", duration=20.0),
+                _make_result("gamma", status="fail", duration=15.0),
+                _make_result("delta", status="install_error", error_message="build error"),
+                _make_result("epsilon", status="timeout", duration=600.0),
+            ],
+        )
+        _write_run(
+            self.results_dir,
+            "2026-02-22T10-00-00",
+            results=[
+                _make_result("alpha", status="pass", duration=12.0),
+                _make_result("beta", status="pass", duration=18.0),
+                _make_result("gamma", status="pass", duration=10.0),
+                _make_result("delta", status="fail", duration=25.0),
+                _make_result("epsilon", status="pass", duration=30.0),
+            ],
+        )
+
+        self.runner = CliRunner()
+
+    def _cleanup_fixtures(self) -> None:
+        self.tmpdir.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCommand(_FixtureMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._setup_fixtures()
+
+    def tearDown(self) -> None:
+        self._cleanup_fixtures()
+
+    def test_counts_output(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            ["registry", "--registry-dir", str(self.registry_dir)],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Registry:", result.output)
+        self.assertIn("active", result.output)
+        self.assertIn("skipped", result.output)
+
+    def test_table_output(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "registry",
+                "--format",
+                "table",
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("alpha", result.output)
+        self.assertIn("Package", result.output)
+
+    def test_with_where_filter(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "registry",
+                "--format",
+                "table",
+                "--where",
+                "skip:false",
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("skipped", result.output)
+
+
+class TestRunCommand(_FixtureMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._setup_fixtures()
+
+    def tearDown(self) -> None:
+        self._cleanup_fixtures()
+
+    def test_default_latest(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Run ID:", result.output)
+
+    def test_summary_format(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "2026-02-20T10-00-00",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Packages tested:", result.output)
+        self.assertIn("CRASH", result.output)
+
+    def test_table_format(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "--format",
+                "table",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("alpha", result.output)
+
+    def test_full_format(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "2026-02-20T10-00-00",
+                "--format",
+                "full",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_quiet_mode(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "2026-02-20T10-00-00",
+                "-q",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Should have crash info.
+        self.assertIn("crash", result.output.lower())
+
+    def test_quiet_no_crashes(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "2026-02-22T10-00-00",
+                "-q",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        # No crashes → no output.
+        self.assertEqual(result.output.strip(), "")
+
+    def test_nonexistent_id(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "run",
+                "nonexistent",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not found", result.output.lower())
+
+
+class TestCompareCommand(_FixtureMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._setup_fixtures()
+
+    def tearDown(self) -> None:
+        self._cleanup_fixtures()
+
+    def test_basic(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "compare",
+                "2026-02-20T10-00-00",
+                "2026-02-22T10-00-00",
+                "--results-dir",
+                str(self.results_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Comparing:", result.output)
+        self.assertIn("Status changes", result.output)
+
+    def test_only_changes(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "compare",
+                "2026-02-20T10-00-00",
+                "2026-02-22T10-00-00",
+                "--only-changes",
+                "--results-dir",
+                str(self.results_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("Unchanged:", result.output)
+
+    def test_bad_run_id(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "compare",
+                "nonexistent",
+                "2026-02-22T10-00-00",
+                "--results-dir",
+                str(self.results_dir),
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestHistoryCommand(_FixtureMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._setup_fixtures()
+
+    def tearDown(self) -> None:
+        self._cleanup_fixtures()
+
+    def test_table(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            ["history", "--results-dir", str(self.results_dir)],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Run history", result.output)
+        self.assertIn("Crash summary:", result.output)
+
+    def test_timeline(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "history",
+                "--format",
+                "timeline",
+                "--results-dir",
+                str(self.results_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("trend", result.output.lower())
+
+    def test_last_n(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "history",
+                "--last",
+                "1",
+                "--results-dir",
+                str(self.results_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("last 1", result.output)
+
+    def test_empty(self) -> None:
+        empty_dir = Path(self.tmpdir.name) / "empty_results"
+        empty_dir.mkdir()
+        result = self.runner.invoke(
+            analyze,
+            ["history", "--results-dir", str(empty_dir)],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No runs found", result.output)
+
+
+class TestPackageCommand(_FixtureMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        self._setup_fixtures()
+
+    def tearDown(self) -> None:
+        self._cleanup_fixtures()
+
+    def test_basic(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "package",
+                "alpha",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Package: alpha", result.output)
+        self.assertIn("Run history", result.output)
+
+    def test_not_found_in_registry(self) -> None:
+        result = self.runner.invoke(
+            analyze,
+            [
+                "package",
+                "nonexistent",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Package: nonexistent", result.output)
+        self.assertIn("No run history", result.output)
+
+    def test_no_runs(self) -> None:
+        # Package exists in registry but no runs contain it.
+        _write_package(self.registry_dir, "lonely")
+        result = self.runner.invoke(
+            analyze,
+            [
+                "package",
+                "lonely",
+                "--results-dir",
+                str(self.results_dir),
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No run history", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,202 @@
+"""Tests for labeille.formatting — shared text formatting helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from labeille.formatting import (
+    format_duration,
+    format_histogram,
+    format_percentage,
+    format_section_header,
+    format_sparkline,
+    format_status_icon,
+    format_table,
+    truncate,
+)
+
+
+class TestFormatDuration(unittest.TestCase):
+    def test_seconds(self) -> None:
+        self.assertEqual(format_duration(8.0), "8s")
+
+    def test_minutes(self) -> None:
+        self.assertEqual(format_duration(83.0), "1m 23s")
+
+    def test_hours(self) -> None:
+        self.assertEqual(format_duration(4354.0), "1h 12m 34s")
+
+    def test_zero(self) -> None:
+        self.assertEqual(format_duration(0.0), "0s")
+
+    def test_just_under_minute(self) -> None:
+        self.assertEqual(format_duration(59.9), "59s")
+
+    def test_exact_minute(self) -> None:
+        self.assertEqual(format_duration(60.0), "1m  0s")
+
+
+class TestFormatStatusIcon(unittest.TestCase):
+    def test_crash(self) -> None:
+        result = format_status_icon("crash")
+        self.assertIn("CRASH", result)
+
+    def test_timeout(self) -> None:
+        result = format_status_icon("timeout")
+        self.assertIn("TIMEOUT", result)
+
+    def test_fail(self) -> None:
+        result = format_status_icon("fail")
+        self.assertIn("FAIL", result)
+
+    def test_error(self) -> None:
+        result = format_status_icon("error")
+        self.assertIn("ERROR", result)
+
+    def test_pass(self) -> None:
+        result = format_status_icon("pass")
+        self.assertIn("PASS", result)
+
+    def test_skip(self) -> None:
+        result = format_status_icon("skip")
+        self.assertIn("SKIP", result)
+
+
+class TestFormatTable(unittest.TestCase):
+    def test_basic(self) -> None:
+        headers = ["Name", "Value"]
+        rows = [["alpha", "100"], ["beta", "200"]]
+        text = format_table(headers, rows)
+        self.assertIn("Name", text)
+        self.assertIn("alpha", text)
+        self.assertIn("200", text)
+        lines = text.splitlines()
+        self.assertEqual(len(lines), 3)  # header + 2 rows
+
+    def test_truncation(self) -> None:
+        headers = ["Name", "Value"]
+        rows = [["a" * 50, "short"]]
+        text = format_table(headers, rows, max_col_width={0: 10})
+        self.assertIn("...", text)
+        # Original long string should not appear in full.
+        self.assertNotIn("a" * 50, text)
+
+    def test_alignment(self) -> None:
+        headers = ["Name", "Count"]
+        rows = [["alpha", "100"], ["beta", "2"]]
+        text = format_table(headers, rows, alignments=["l", "r"])
+        lines = text.splitlines()
+        # Count column should be right-aligned.
+        for line in lines:
+            # The count value in the last column.
+            self.assertTrue(len(line) > 0)
+
+    def test_empty_rows(self) -> None:
+        headers = ["Name", "Value"]
+        text = format_table(headers, [])
+        self.assertIn("Name", text)
+        lines = text.splitlines()
+        self.assertEqual(len(lines), 1)  # header only
+
+    def test_empty_headers(self) -> None:
+        text = format_table([], [["a", "b"]])
+        self.assertEqual(text, "")
+
+
+class TestFormatHistogram(unittest.TestCase):
+    def test_basic(self) -> None:
+        buckets = [("small", 10), ("medium", 5), ("large", 2)]
+        text = format_histogram(buckets)
+        self.assertIn("small", text)
+        self.assertIn("medium", text)
+        self.assertIn("large", text)
+        lines = text.splitlines()
+        self.assertEqual(len(lines), 3)
+
+    def test_single_bucket(self) -> None:
+        buckets = [("only", 42)]
+        text = format_histogram(buckets)
+        self.assertIn("only", text)
+        self.assertIn("42", text)
+        # Single bucket should get full bar.
+        self.assertIn("\u2588", text)
+
+    def test_empty(self) -> None:
+        text = format_histogram([])
+        self.assertEqual(text, "")
+
+    def test_percentages(self) -> None:
+        buckets = [("a", 50), ("b", 50)]
+        text = format_histogram(buckets, show_percentages=True, total=100)
+        self.assertIn("50%", text)
+
+    def test_no_percentages(self) -> None:
+        buckets = [("a", 10)]
+        text = format_histogram(buckets, show_percentages=False)
+        self.assertNotIn("%", text)
+
+
+class TestFormatSparkline(unittest.TestCase):
+    def test_basic(self) -> None:
+        values = [0.0, 0.5, 1.0]
+        result = format_sparkline(values, width=3)
+        self.assertEqual(len(result), 3)
+        # First should be lowest char, last should be highest.
+        self.assertEqual(result[0], "\u2581")
+        self.assertEqual(result[-1], "\u2588")
+
+    def test_constant(self) -> None:
+        values = [5.0, 5.0, 5.0]
+        result = format_sparkline(values, width=3)
+        self.assertEqual(len(result), 3)
+        # All same value → all same char.
+        self.assertEqual(len(set(result)), 1)
+
+    def test_empty(self) -> None:
+        result = format_sparkline([])
+        self.assertEqual(result, "")
+
+    def test_width_expansion(self) -> None:
+        values = [1.0, 2.0]
+        result = format_sparkline(values, width=5)
+        self.assertEqual(len(result), 5)
+
+
+class TestTruncate(unittest.TestCase):
+    def test_short(self) -> None:
+        self.assertEqual(truncate("hello", 10), "hello")
+
+    def test_long(self) -> None:
+        result = truncate("hello world", 8)
+        self.assertEqual(len(result), 8)
+        self.assertTrue(result.endswith("..."))
+
+    def test_exact_length(self) -> None:
+        self.assertEqual(truncate("hello", 5), "hello")
+
+
+class TestFormatSectionHeader(unittest.TestCase):
+    def test_basic(self) -> None:
+        header = format_section_header("Test")
+        self.assertIn("Test", header)
+        self.assertIn("\u2500", header)
+
+    def test_width(self) -> None:
+        header = format_section_header("Title", width=40)
+        self.assertEqual(len(header), 40)
+
+
+class TestFormatPercentage(unittest.TestCase):
+    def test_normal(self) -> None:
+        self.assertEqual(format_percentage(44, 100), "44.0%")
+
+    def test_zero_total(self) -> None:
+        self.assertEqual(format_percentage(0, 0), "-")
+
+    def test_precision(self) -> None:
+        result = format_percentage(1, 3)
+        self.assertIn("33.3%", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `labeille analyze` CLI subgroup with five subcommands: `registry` (composition overview), `run` (single run analysis), `compare` (two-run diff), `history` (multi-run trends), `package` (per-package deep dive).
- Add `formatting.py` shared module with tables, histograms, sparklines, duration formatting, and status icons.
- Add `analyze.py` data loading and analysis module with lazy-loading run data, registry stats, comparison, flaky detection, and package history.
- Refactor `summary.py` to import shared formatters from `formatting.py`.

## Test plan
- [x] 106 new tests across 3 test files (test_formatting.py, test_analyze.py, test_analyze_cli.py)
- [x] All 429 tests pass
- [x] ruff format and ruff check pass
- [x] mypy strict mode passes
- [x] Existing test_summary.py tests still pass after summary.py refactoring

Closes #19

Generated with [Claude Code](https://claude.com/claude-code)