### PR TITLE
feat: add registry migrate command with skip-to-skip-versions migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `labeille registry migrate` command with a migration framework for registry schema transformations.
+- `skip-to-skip-versions` migration to convert 3.15-specific `skip:true` entries to `skip_versions["3.15"]`.
+- Migration log (`migrations.log`) to track applied migrations and prevent re-application.
+- Dry-run support for migrations with preview of affected packages.
 - `labeille scan-deps` command for static test dependency discovery via AST-based import analysis.
 - `import_map.py` module with 100+ import-name-to-pip-package mappings for common mismatches (PIL->Pillow, yaml->PyYAML, etc.).
 - Three output formats for scan-deps: human-readable (default), JSON, and pip (for direct shell use).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 - `crash.py` — Crash detection from exit codes and stderr patterns
 - `classifier.py` — Pure Python vs C extension classification from wheel tags
 - `registry.py` — YAML registry I/O (index + per-package configs)
-- `registry_cli.py` — Batch registry management CLI (add/remove/rename/set fields, validate)
+- `registry_cli.py` — Batch registry management CLI (add/remove/rename/set fields, validate, migrate)
+- `migrations.py` — Registry migration framework (named transformations with logging and dry-run)
 - `registry_ops.py` — Batch operations with filtering, atomic writes, dry-run previews
 - `analyze.py` — Data loading and analysis (run data, registry stats, comparison, flaky detection)
 - `analyze_cli.py` — Analysis CLI (registry, run, compare, history, package subcommands)
@@ -52,7 +53,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 ## Testing notes
 - Integration tests mock `fetch_pypi_metadata` to avoid network calls
 - Runner tests mock `subprocess.run` and `clone_repo` extensively
-- 497 tests total across 14 test files
+- 546 tests total across 15 test files
 
 ## Enriching packages
 
@@ -100,6 +101,14 @@ Update index after editing package files: `load_index()` → `update_index_from_
 - Use --lenient when resuming an interrupted operation or when you expect some files to already have the field.
 - Use --after to control field placement in the YAML for readability.
 - Run `labeille registry validate` after batch edits to catch issues.
+
+## Registry migrations
+
+- `labeille registry migrate --list` shows available migrations and their applied status.
+- `labeille registry migrate <name>` previews changes (dry-run by default).
+- `labeille registry migrate <name> --apply` applies changes and logs to `migrations.log`.
+- Each migration runs once — re-application is blocked with the original date shown.
+- Add new migrations by decorating a function with `@register_migration(name, description)` in `migrations.py`.
 
 ## Workflow
 - Use `/task-workflow <description>` for the full issue → branch → code → test → commit → PR → merge cycle

--- a/src/labeille/migrations.py
+++ b/src/labeille/migrations.py
@@ -1,0 +1,374 @@
+"""Registry migration framework.
+
+Migrations are named transformations applied to registry YAML files.
+Each migration is a Python function registered with ``@register_migration``.
+Migrations are logged to ``{registry_dir}/migrations.log`` to prevent
+accidental re-application.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+from labeille.logging import get_logger
+from labeille.registry import _dict_to_package, _package_to_dict
+
+log = get_logger("migrations")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MigrationResult:
+    """Result of applying a migration to a single file."""
+
+    package: str
+    modified: bool
+    description: str
+
+
+@dataclass
+class MigrationSpec:
+    """A registered migration."""
+
+    name: str
+    description: str
+    func: Callable[[Path, dict[str, Any]], MigrationResult]
+
+
+@dataclass
+class MigrationLogEntry:
+    """A record of a migration that has been applied."""
+
+    migration: str
+    applied_at: str
+    files_modified: int
+    files_skipped: int
+
+
+@dataclass
+class MigrationDryRun:
+    """Preview of what a migration would do."""
+
+    migration: MigrationSpec
+    affected_count: int
+    skipped_count: int
+    sample_results: list[MigrationResult] = field(default_factory=list)
+
+
+@dataclass
+class MigrationExecution:
+    """Result of applying a migration."""
+
+    migration: MigrationSpec
+    modified_count: int
+    skipped_count: int
+    results: list[MigrationResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Migration registry
+# ---------------------------------------------------------------------------
+
+_MIGRATIONS: dict[str, MigrationSpec] = {}
+
+
+def register_migration(
+    name: str,
+    description: str,
+) -> Callable[
+    [Callable[[Path, dict[str, Any]], MigrationResult]],
+    Callable[[Path, dict[str, Any]], MigrationResult],
+]:
+    """Decorator to register a migration function."""
+
+    def decorator(
+        func: Callable[[Path, dict[str, Any]], MigrationResult],
+    ) -> Callable[[Path, dict[str, Any]], MigrationResult]:
+        _MIGRATIONS[name] = MigrationSpec(name=name, description=description, func=func)
+        return func
+
+    return decorator
+
+
+def get_migration(name: str) -> MigrationSpec | None:
+    """Look up a migration by name."""
+    return _MIGRATIONS.get(name)
+
+
+def list_migrations() -> list[MigrationSpec]:
+    """Return all registered migrations in registration order."""
+    return list(_MIGRATIONS.values())
+
+
+# ---------------------------------------------------------------------------
+# Migration log
+# ---------------------------------------------------------------------------
+
+
+def _log_path(registry_dir: Path) -> Path:
+    """Return the path to the migration log file."""
+    return registry_dir / "migrations.log"
+
+
+def read_migration_log(registry_dir: Path) -> list[MigrationLogEntry]:
+    """Read the migration log. Returns empty list if file doesn't exist."""
+    path = _log_path(registry_dir)
+    if not path.exists():
+        return []
+    entries: list[MigrationLogEntry] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            entries.append(
+                MigrationLogEntry(
+                    migration=data["migration"],
+                    applied_at=data["applied_at"],
+                    files_modified=data["files_modified"],
+                    files_skipped=data["files_skipped"],
+                )
+            )
+        except (json.JSONDecodeError, KeyError):
+            log.warning("Skipping malformed migration log entry: %s", line)
+    return entries
+
+
+def append_migration_log(registry_dir: Path, entry: MigrationLogEntry) -> None:
+    """Append an entry to the migration log."""
+    path = _log_path(registry_dir)
+    data = {
+        "migration": entry.migration,
+        "applied_at": entry.applied_at,
+        "files_modified": entry.files_modified,
+        "files_skipped": entry.files_skipped,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(data) + "\n")
+
+
+def has_been_applied(registry_dir: Path, migration_name: str) -> bool:
+    """Check if a migration has already been applied."""
+    entries = read_migration_log(registry_dir)
+    return any(e.migration == migration_name for e in entries)
+
+
+def get_applied_date(registry_dir: Path, migration_name: str) -> str | None:
+    """Return the date a migration was applied, or None if not applied."""
+    for entry in read_migration_log(registry_dir):
+        if entry.migration == migration_name:
+            return entry.applied_at
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Migration execution engine
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to a file atomically."""
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def execute_migration(
+    migration: MigrationSpec,
+    registry_dir: Path,
+    *,
+    dry_run: bool = True,
+) -> MigrationDryRun | MigrationExecution:
+    """Run a migration across all package YAML files.
+
+    For each file in ``registry_dir/packages/``:
+    1. Load the YAML as a dict.
+    2. Call ``migration.func(file_path, data)``.
+    3. If modified and not dry_run: re-serialize and write atomically.
+    4. Return aggregate results.
+    """
+    packages_dir = registry_dir / "packages"
+    if not packages_dir.is_dir():
+        if dry_run:
+            return MigrationDryRun(migration=migration, affected_count=0, skipped_count=0)
+        return MigrationExecution(migration=migration, modified_count=0, skipped_count=0)
+
+    files = sorted(packages_dir.glob("*.yaml"))
+
+    modified_count = 0
+    skipped_count = 0
+    results: list[MigrationResult] = []
+
+    for f in files:
+        raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            skipped_count += 1
+            continue
+
+        result = migration.func(f, raw)
+
+        if result.modified:
+            modified_count += 1
+            results.append(result)
+
+            if not dry_run:
+                # Re-serialize through the registry module for consistent output.
+                entry = _dict_to_package(raw)
+                data = _package_to_dict(entry)
+                text = yaml.dump(
+                    data,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
+                _atomic_write(f, text)
+        else:
+            skipped_count += 1
+
+    if dry_run:
+        return MigrationDryRun(
+            migration=migration,
+            affected_count=modified_count,
+            skipped_count=skipped_count,
+            sample_results=results[:5],
+        )
+
+    # Log the migration.
+    log_entry = MigrationLogEntry(
+        migration=migration.name,
+        applied_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        files_modified=modified_count,
+        files_skipped=skipped_count,
+    )
+    append_migration_log(registry_dir, log_entry)
+
+    return MigrationExecution(
+        migration=migration,
+        modified_count=modified_count,
+        skipped_count=skipped_count,
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Built-in migration: skip-to-skip-versions
+# ---------------------------------------------------------------------------
+
+
+def _is_version_specific_skip(reason: str) -> bool:
+    """Determine if a skip reason is specific to Python 3.15.
+
+    Returns True for reasons related to:
+    - PyO3 / maturin / Rust not supporting 3.15
+    - Dependencies on pydantic-core, rpds-py (PyO3 packages)
+    - Cython build failures on 3.15
+    - JIT crashes during install (fixed by CPython rebuild)
+    - 3.15-specific incompatibilities
+
+    Returns False for structural reasons:
+    - No test suite / stub package
+    - Cloud credentials required
+    - Monorepo / complex build
+    - No repo URL
+    - Deprecated / obsolete packages
+    """
+    r = reason.lower()
+
+    # Structural reasons — don't convert even if they mention Rust/PyO3.
+    structural_keywords = [
+        "no test suite",
+        "no meaningful test",
+        "no python test suite",
+        "no separate test suite",
+        "no source test",
+        "binary with no",
+    ]
+    if any(kw in r for kw in structural_keywords):
+        return False
+
+    # Version-specific keywords.
+    version_specific_keywords = [
+        "pyo3",
+        "maturin",
+        "rust",
+        "pydantic-core",
+        "rpds-py",
+        "rpds",
+        "doesn't support python 3.15",
+        "doesn't support 3.15",
+        "not support 3.15",
+        "no 3.15 support",
+        "no 3.15",
+        "3.15",
+        "cython build step fails",
+        "cython build fails",
+        "cython) editable build fails",
+        "jit crash",
+    ]
+
+    return any(kw in r for kw in version_specific_keywords)
+
+
+@register_migration(
+    "skip-to-skip-versions",
+    "Convert 3.15-specific skip:true to skip_versions",
+)
+def migrate_skip_to_skip_versions(
+    file_path: Path,
+    data: dict[str, Any],
+) -> MigrationResult:
+    """Move version-specific skip reasons from skip/skip_reason to skip_versions.
+
+    Converts packages where:
+    - ``skip`` is True, AND
+    - ``skip_reason`` indicates a 3.15-specific issue
+
+    Does NOT convert packages with structural skip reasons.
+    """
+    package = data.get("package", file_path.stem)
+
+    if not data.get("skip", False):
+        return MigrationResult(package=package, modified=False, description="not skipped")
+
+    reason = data.get("skip_reason", "") or ""
+
+    if not _is_version_specific_skip(reason):
+        return MigrationResult(
+            package=package, modified=False, description="structural skip (not version-specific)"
+        )
+
+    # Apply the transformation.
+    data["skip"] = False
+    data["skip_reason"] = None
+
+    if "skip_versions" not in data:
+        data["skip_versions"] = {}
+    data["skip_versions"]["3.15"] = reason
+
+    desc = reason[:60] + "..." if len(reason) > 60 else reason
+    return MigrationResult(
+        package=package,
+        modified=True,
+        description=f'skip:true -> skip_versions["3.15"]: {desc}',
+    )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,538 @@
+"""Tests for labeille.migrations — migration framework and built-in migrations."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from labeille.migrations import (
+    MigrationDryRun,
+    MigrationExecution,
+    MigrationLogEntry,
+    MigrationResult,
+    MigrationSpec,
+    _is_version_specific_skip,
+    append_migration_log,
+    execute_migration,
+    get_migration,
+    has_been_applied,
+    list_migrations,
+    migrate_skip_to_skip_versions,
+    read_migration_log,
+)
+from labeille.registry_cli import registry
+
+
+def _write_package(
+    registry_dir: Path,
+    name: str,
+    *,
+    skip: bool = False,
+    skip_reason: str | None = None,
+    skip_versions: dict[str, str] | None = None,
+    enriched: bool = True,
+) -> Path:
+    """Create a package YAML file for testing."""
+    data: dict[str, object] = {
+        "package": name,
+        "repo": f"https://github.com/user/{name}",
+        "pypi_url": f"https://pypi.org/project/{name}/",
+        "extension_type": "pure",
+        "python_versions": [],
+        "install_method": "pip",
+        "install_command": "pip install -e .",
+        "test_command": "python -m pytest tests/",
+        "test_framework": "pytest",
+        "uses_xdist": False,
+        "timeout": None,
+        "skip": skip,
+        "skip_reason": skip_reason,
+        "skip_versions": skip_versions or {},
+        "notes": "",
+        "enriched": enriched,
+        "clone_depth": None,
+        "import_name": None,
+    }
+    pkg_dir = registry_dir / "packages"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    p = pkg_dir / f"{name}.yaml"
+    p.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return p
+
+
+# ===========================================================================
+# Framework tests
+# ===========================================================================
+
+
+class TestMigrationRegistry(unittest.TestCase):
+    def test_register_migration(self) -> None:
+        # The skip-to-skip-versions migration is already registered.
+        spec = get_migration("skip-to-skip-versions")
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.name, "skip-to-skip-versions")
+
+    def test_get_migration_exists(self) -> None:
+        spec = get_migration("skip-to-skip-versions")
+        self.assertIsNotNone(spec)
+        self.assertIsInstance(spec, MigrationSpec)
+        self.assertTrue(callable(spec.func))
+
+    def test_get_migration_not_found(self) -> None:
+        self.assertIsNone(get_migration("nonexistent-migration"))
+
+    def test_list_migrations(self) -> None:
+        migrations = list_migrations()
+        self.assertGreaterEqual(len(migrations), 1)
+        names = [m.name for m in migrations]
+        self.assertIn("skip-to-skip-versions", names)
+
+
+class TestMigrationLog(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.registry_dir = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_migration_log_empty(self) -> None:
+        entries = read_migration_log(self.registry_dir)
+        self.assertEqual(entries, [])
+
+    def test_migration_log_write_read(self) -> None:
+        entry = MigrationLogEntry(
+            migration="test-migration",
+            applied_at="2026-02-23T14:00:00Z",
+            files_modified=5,
+            files_skipped=10,
+        )
+        append_migration_log(self.registry_dir, entry)
+        entries = read_migration_log(self.registry_dir)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].migration, "test-migration")
+        self.assertEqual(entries[0].files_modified, 5)
+        self.assertEqual(entries[0].files_skipped, 10)
+
+    def test_has_been_applied_false(self) -> None:
+        self.assertFalse(has_been_applied(self.registry_dir, "nonexistent"))
+
+    def test_has_been_applied_true(self) -> None:
+        entry = MigrationLogEntry(
+            migration="applied-one",
+            applied_at="2026-02-23T14:00:00Z",
+            files_modified=1,
+            files_skipped=0,
+        )
+        append_migration_log(self.registry_dir, entry)
+        self.assertTrue(has_been_applied(self.registry_dir, "applied-one"))
+        self.assertFalse(has_been_applied(self.registry_dir, "other"))
+
+
+class TestExecuteMigration(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.registry_dir = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_execute_migration_dry_run(self) -> None:
+        _write_package(
+            self.registry_dir,
+            "rpds-py",
+            skip=True,
+            skip_reason="Requires PyO3/maturin. Not buildable until PyO3 supports 3.15.",
+        )
+        _write_package(self.registry_dir, "click", skip=False)
+
+        spec = get_migration("skip-to-skip-versions")
+        assert spec is not None
+        result = execute_migration(spec, self.registry_dir, dry_run=True)
+
+        self.assertIsInstance(result, MigrationDryRun)
+        assert isinstance(result, MigrationDryRun)
+        self.assertEqual(result.affected_count, 1)
+        self.assertEqual(result.skipped_count, 1)
+
+        # File should NOT be modified in dry run.
+        raw = yaml.safe_load((self.registry_dir / "packages" / "rpds-py.yaml").read_text())
+        self.assertTrue(raw["skip"])
+
+    def test_execute_migration_apply(self) -> None:
+        _write_package(
+            self.registry_dir,
+            "rpds-py",
+            skip=True,
+            skip_reason="Requires PyO3/maturin. Not buildable until PyO3 supports 3.15.",
+        )
+        _write_package(self.registry_dir, "click", skip=False)
+
+        spec = get_migration("skip-to-skip-versions")
+        assert spec is not None
+        result = execute_migration(spec, self.registry_dir, dry_run=False)
+
+        self.assertIsInstance(result, MigrationExecution)
+        assert isinstance(result, MigrationExecution)
+        self.assertEqual(result.modified_count, 1)
+        self.assertEqual(result.skipped_count, 1)
+
+        # File should be modified.
+        raw = yaml.safe_load((self.registry_dir / "packages" / "rpds-py.yaml").read_text())
+        self.assertFalse(raw["skip"])
+        self.assertIsNone(raw["skip_reason"])
+        self.assertIn("3.15", raw["skip_versions"])
+
+        # Log entry should exist.
+        self.assertTrue(has_been_applied(self.registry_dir, "skip-to-skip-versions"))
+
+    def test_execute_migration_empty_registry(self) -> None:
+        spec = get_migration("skip-to-skip-versions")
+        assert spec is not None
+        result = execute_migration(spec, self.registry_dir, dry_run=True)
+        self.assertIsInstance(result, MigrationDryRun)
+        assert isinstance(result, MigrationDryRun)
+        self.assertEqual(result.affected_count, 0)
+
+
+# ===========================================================================
+# skip-to-skip-versions migration tests
+# ===========================================================================
+
+
+class TestSkipToSkipVersionsMigration(unittest.TestCase):
+    def _run_migration(
+        self,
+        *,
+        skip: bool = True,
+        skip_reason: str | None = None,
+        skip_versions: dict[str, str] | None = None,
+    ) -> tuple[MigrationResult, dict[str, object]]:
+        """Helper to run the migration on a single data dict."""
+        data: dict[str, object] = {
+            "package": "testpkg",
+            "skip": skip,
+            "skip_reason": skip_reason,
+            "skip_versions": skip_versions or {},
+        }
+        result = migrate_skip_to_skip_versions(Path("testpkg.yaml"), data)
+        return result, data
+
+    def test_converts_pyo3_skip(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin for source builds.",
+        )
+        self.assertTrue(result.modified)
+        self.assertFalse(data["skip"])
+        self.assertIsNone(data["skip_reason"])
+        sv = data["skip_versions"]
+        assert isinstance(sv, dict)
+        self.assertIn("3.15", sv)
+        self.assertIn("PyO3", sv["3.15"])
+
+    def test_converts_pydantic_core_dep(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Depends on pydantic-core (PyO3, no 3.15 support).",
+        )
+        self.assertTrue(result.modified)
+        self.assertFalse(data["skip"])
+
+    def test_converts_rpds_dep(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Depends on rpds-py (PyO3).",
+        )
+        self.assertTrue(result.modified)
+
+    def test_converts_maturin(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin for source builds. Not buildable until PyO3 supports 3.15.",
+        )
+        self.assertTrue(result.modified)
+
+    def test_converts_jit_crash(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="JIT crash (_PyOptimizer_Optimize abort) during pip install.",
+        )
+        self.assertTrue(result.modified)
+
+    def test_converts_cython_build(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="C extension source files not generated (Cython build step fails on editable install for 3.15).",
+        )
+        self.assertTrue(result.modified)
+
+    def test_preserves_no_test_suite(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Type stub package with no meaningful test suite.",
+        )
+        self.assertFalse(result.modified)
+        self.assertTrue(data["skip"])
+
+    def test_preserves_cloud_credentials(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Tests require cloud credentials.",
+        )
+        self.assertFalse(result.modified)
+        self.assertTrue(data["skip"])
+
+    def test_preserves_monorepo(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Monorepo package in azure-sdk-for-python. Complex to test standalone.",
+        )
+        self.assertFalse(result.modified)
+
+    def test_preserves_no_repo_url(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="No repository URL found.",
+        )
+        self.assertFalse(result.modified)
+
+    def test_preserves_rust_binary_no_tests(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Rust binary with no Python test suite.",
+        )
+        self.assertFalse(result.modified)
+
+    def test_preserves_non_skipped(self) -> None:
+        result, data = self._run_migration(skip=False, skip_reason=None)
+        self.assertFalse(result.modified)
+
+    def test_preserves_existing_skip_versions(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin.",
+            skip_versions={"3.14": "Some other reason"},
+        )
+        self.assertTrue(result.modified)
+        sv = data["skip_versions"]
+        assert isinstance(sv, dict)
+        self.assertEqual(sv["3.14"], "Some other reason")
+        self.assertIn("3.15", sv)
+
+    def test_skip_reason_set_to_null(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin.",
+        )
+        self.assertTrue(result.modified)
+        self.assertIsNone(data["skip_reason"])
+
+    def test_skip_set_to_false(self) -> None:
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin.",
+        )
+        self.assertTrue(result.modified)
+        self.assertFalse(data["skip"])
+
+    def test_yaml_key_is_string(self) -> None:
+        """After conversion, the '3.15' key must be a string, not a float."""
+        result, data = self._run_migration(
+            skip_reason="Requires PyO3/maturin.",
+        )
+        self.assertTrue(result.modified)
+        sv = data["skip_versions"]
+        assert isinstance(sv, dict)
+        keys = list(sv.keys())
+        self.assertEqual(keys, ["3.15"])
+        self.assertIsInstance(keys[0], str)
+
+
+# ===========================================================================
+# _is_version_specific_skip tests
+# ===========================================================================
+
+
+class TestIsVersionSpecificSkip(unittest.TestCase):
+    def test_pyo3_keyword(self) -> None:
+        self.assertTrue(_is_version_specific_skip("Requires PyO3/maturin"))
+
+    def test_maturin_keyword(self) -> None:
+        self.assertTrue(_is_version_specific_skip("maturin for source builds"))
+
+    def test_no_315_support(self) -> None:
+        self.assertTrue(_is_version_specific_skip("no 3.15 support"))
+
+    def test_doesnt_support_315(self) -> None:
+        self.assertTrue(_is_version_specific_skip("doesn't support Python 3.15"))
+
+    def test_pydantic_core_dep(self) -> None:
+        self.assertTrue(_is_version_specific_skip("pydantic-core (PyO3)"))
+
+    def test_rpds_dep(self) -> None:
+        self.assertTrue(_is_version_specific_skip("rpds-py (PyO3)"))
+
+    def test_jit_crash(self) -> None:
+        self.assertTrue(_is_version_specific_skip("JIT crash (_PyOptimizer_Optimize abort)"))
+
+    def test_cython_fails(self) -> None:
+        self.assertTrue(_is_version_specific_skip("Cython build step fails"))
+
+    def test_rust_binary_no_tests(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Rust binary with no Python test suite"))
+
+    def test_no_test_suite(self) -> None:
+        self.assertFalse(
+            _is_version_specific_skip("Type stub package with no meaningful test suite")
+        )
+
+    def test_cloud_credentials(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Tests require cloud credentials"))
+
+    def test_monorepo(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Monorepo package"))
+
+    def test_complex_c_build(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Complex C extension build"))
+
+    def test_empty_reason(self) -> None:
+        self.assertFalse(_is_version_specific_skip(""))
+
+    def test_no_repo_url(self) -> None:
+        self.assertFalse(_is_version_specific_skip("No repository URL found."))
+
+
+# ===========================================================================
+# CLI tests
+# ===========================================================================
+
+
+class TestMigrateCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.registry_dir = Path(self._tmpdir.name)
+        self.runner = CliRunner()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_migrate_list(self) -> None:
+        result = self.runner.invoke(
+            registry, ["migrate", "--list", "--registry-dir", str(self.registry_dir)]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("skip-to-skip-versions", result.output)
+        self.assertIn("not applied", result.output)
+
+    def test_migrate_dry_run(self) -> None:
+        _write_package(
+            self.registry_dir,
+            "rpds-py",
+            skip=True,
+            skip_reason="Requires PyO3/maturin. Not buildable until PyO3 supports 3.15.",
+        )
+        _write_package(self.registry_dir, "click", skip=False)
+
+        result = self.runner.invoke(
+            registry,
+            ["migrate", "skip-to-skip-versions", "--registry-dir", str(self.registry_dir)],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("DRY RUN", result.output)
+        self.assertIn("Would modify 1 files", result.output)
+        self.assertIn("rpds-py", result.output)
+
+        # File should NOT be modified.
+        raw = yaml.safe_load((self.registry_dir / "packages" / "rpds-py.yaml").read_text())
+        self.assertTrue(raw["skip"])
+
+    def test_migrate_apply(self) -> None:
+        _write_package(
+            self.registry_dir,
+            "rpds-py",
+            skip=True,
+            skip_reason="Requires PyO3/maturin. Not buildable until PyO3 supports 3.15.",
+        )
+
+        # Create index for rebuild.
+        index_data = {
+            "last_updated": "2026-02-23T00:00:00",
+            "packages": [
+                {"name": "rpds-py", "extension_type": "pure", "enriched": True, "skip": True}
+            ],
+        }
+        (self.registry_dir / "index.yaml").write_text(
+            yaml.dump(index_data, default_flow_style=False)
+        )
+
+        result = self.runner.invoke(
+            registry,
+            [
+                "migrate",
+                "skip-to-skip-versions",
+                "--apply",
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Applied migration", result.output)
+        self.assertIn("modified 1 files", result.output)
+
+        # File should be modified.
+        raw = yaml.safe_load((self.registry_dir / "packages" / "rpds-py.yaml").read_text())
+        self.assertFalse(raw["skip"])
+        self.assertIn("3.15", raw["skip_versions"])
+
+    def test_migrate_already_applied(self) -> None:
+        entry = {
+            "migration": "skip-to-skip-versions",
+            "applied_at": "2026-02-23T14:00:00Z",
+            "files_modified": 5,
+            "files_skipped": 10,
+        }
+        log_path = self.registry_dir / "migrations.log"
+        log_path.write_text(json.dumps(entry) + "\n")
+
+        result = self.runner.invoke(
+            registry,
+            [
+                "migrate",
+                "skip-to-skip-versions",
+                "--registry-dir",
+                str(self.registry_dir),
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("already applied", result.output)
+
+    def test_migrate_unknown_name(self) -> None:
+        result = self.runner.invoke(
+            registry,
+            ["migrate", "nonexistent-migration", "--registry-dir", str(self.registry_dir)],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("unknown migration", result.output)
+
+    def test_migrate_no_name_no_list(self) -> None:
+        result = self.runner.invoke(
+            registry,
+            ["migrate", "--registry-dir", str(self.registry_dir)],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--list", result.output)
+
+    def test_migrate_list_shows_applied_status(self) -> None:
+        entry = {
+            "migration": "skip-to-skip-versions",
+            "applied_at": "2026-02-23T14:00:00Z",
+            "files_modified": 5,
+            "files_skipped": 10,
+        }
+        log_path = self.registry_dir / "migrations.log"
+        log_path.write_text(json.dumps(entry) + "\n")
+
+        result = self.runner.invoke(
+            registry, ["migrate", "--list", "--registry-dir", str(self.registry_dir)]
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("applied on 2026-02-23T14:00:00Z", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `labeille registry migrate` command with a migration framework for named, logged, idempotent registry transformations.
- First migration `skip-to-skip-versions` converts 3.15-specific `skip:true` entries to `skip_versions["3.15"]`, preserving the original reason while distinguishing structural skips (no test suite, Rust binary) from version-specific ones (PyO3, maturin, Cython).
- 49 new tests covering framework, log, execution engine, classifier, and CLI.

## Test plan
- [x] ruff format — clean
- [x] ruff check — clean
- [x] mypy — clean
- [x] 546 tests pass (49 new)
- [x] Smoke test with 5 sample YAML files (3 converted, 2 preserved)
- [x] Re-application blocked with original date shown

Closes #23

Generated with [Claude Code](https://claude.com/claude-code)