### PR TITLE
Deduplicate helpers, fix public API boundaries, minor bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Deduplicated `_signal_name` (3 copies → `format_signal_name` in `formatting.py`).
+- Deduplicated `_result_detail` (3 copies → public `result_detail` in `analyze.py`).
+- Made `_extract_minor_version` public as `extract_minor_version` in `analyze.py`.
+- Removed redundant zero-check in `compare_runs` duration percentage calculation.
+- Fixed timeout documentation (300s → 600s) in `doc/enrichment.md`.
+
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.
 - Applied `skip-to-skip-versions` migration on 36 packages (PyO3, maturin, Cython, JIT crashes).

--- a/doc/enrichment.md
+++ b/doc/enrichment.md
@@ -66,7 +66,7 @@ schema with explanations.
 | `test_command` | string | The exact shell command to run the test suite. `python` in this command gets replaced with the venv's Python automatically. Runs with `shell=True`, so quotes and pipes work. |
 | `test_framework` | string | `pytest`, `unittest`, or `custom`. Informational. |
 | `uses_xdist` | bool | Whether the project uses pytest-xdist for parallel testing. If true, the test command should include `-p no:xdist` to disable it — parallel workers mask JIT-specific crashes. |
-| `timeout` | int or null | Per-package timeout in seconds. Null means use the runner's default (300s). Set higher for packages with large test suites. |
+| `timeout` | int or null | Per-package timeout in seconds. Null means use the runner's default (600s). Set higher for packages with large test suites. |
 
 ### Control
 

--- a/src/labeille/formatting.py
+++ b/src/labeille/formatting.py
@@ -239,6 +239,21 @@ def truncate(text: str, max_len: int, suffix: str = "...") -> str:
     return text[: max_len - len(suffix)] + suffix
 
 
+def format_signal_name(sig: int | None) -> str:
+    """Convert a signal number to its name, e.g. 11 → 'SIGSEGV'.
+
+    Returns ``""`` if *sig* is ``None``.
+    """
+    if sig is None:
+        return ""
+    import signal as signal_module
+
+    try:
+        return signal_module.Signals(sig).name
+    except (ValueError, AttributeError):
+        return f"SIG{sig}"
+
+
 def format_percentage(count: int, total: int) -> str:
     """Format as percentage: ``'44.2%'``. Returns ``'-'`` if *total* is 0."""
     if total == 0:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,15 +4,14 @@ import signal
 import unittest
 from pathlib import Path
 
+from labeille.analyze import result_detail
+from labeille.formatting import format_duration, format_signal_name
 from labeille.runner import PackageResult, RunnerConfig, RunSummary
 from labeille.summary import (
-    _detail,
     _format_aggregate,
     _format_crash_detail,
     _format_package_table,
     _format_run_header,
-    _signal_name,
-    format_duration,
     format_summary,
 )
 
@@ -111,41 +110,41 @@ class TestFormatDuration(unittest.TestCase):
         self.assertEqual(format_duration(61.0), "1m  1s")
 
 
-class TestSignalName(unittest.TestCase):
+class TestFormatSignalName(unittest.TestCase):
     def test_none(self) -> None:
-        self.assertEqual(_signal_name(None), "")
+        self.assertEqual(format_signal_name(None), "")
 
     def test_sigsegv(self) -> None:
-        self.assertEqual(_signal_name(signal.SIGSEGV), "SIGSEGV")
+        self.assertEqual(format_signal_name(signal.SIGSEGV), "SIGSEGV")
 
     def test_sigabrt(self) -> None:
-        self.assertEqual(_signal_name(signal.SIGABRT), "SIGABRT")
+        self.assertEqual(format_signal_name(signal.SIGABRT), "SIGABRT")
 
 
-class TestDetail(unittest.TestCase):
+class TestResultDetail(unittest.TestCase):
     def test_crash(self) -> None:
         r = PackageResult(package="p", status="crash", crash_signature="Fatal error in something")
-        self.assertEqual(_detail(r), "Fatal error in something")
+        self.assertEqual(result_detail(r), "Fatal error in something")
 
     def test_crash_truncates_at_60(self) -> None:
         r = PackageResult(package="p", status="crash", crash_signature="A" * 80)
-        self.assertEqual(len(_detail(r)), 60)
+        self.assertEqual(len(result_detail(r)), 60)
 
     def test_timeout(self) -> None:
         r = PackageResult(package="p", status="timeout", duration_seconds=900.0)
-        self.assertEqual(_detail(r), "(timeout: 900s)")
+        self.assertEqual(result_detail(r), "(timeout: 900s)")
 
     def test_fail(self) -> None:
         r = PackageResult(package="p", status="fail", exit_code=2)
-        self.assertEqual(_detail(r), "exit code 2")
+        self.assertEqual(result_detail(r), "exit code 2")
 
     def test_error(self) -> None:
         r = PackageResult(package="p", status="install_error", error_message="build failed")
-        self.assertEqual(_detail(r), "build failed")
+        self.assertEqual(result_detail(r), "build failed")
 
     def test_pass(self) -> None:
         r = PackageResult(package="p", status="pass")
-        self.assertEqual(_detail(r), "")
+        self.assertEqual(result_detail(r), "")
 
 
 class TestFormatRunHeader(unittest.TestCase):
@@ -193,7 +192,7 @@ class TestFormatPackageTable(unittest.TestCase):
         self.assertIn("CRASH", data_lines[0])
         self.assertIn("PASS", data_lines[-1])
 
-    def test_truncates_long_detail(self) -> None:
+    def test_truncates_longresult_detail(self) -> None:
         results = [
             PackageResult(
                 package="long",
@@ -349,7 +348,7 @@ class TestFormatSummary(unittest.TestCase):
         text = format_summary([], summary, config, "3.15.0", True, 0.0, mode="default")
         self.assertIn("Packages tested: 0 / 5", text)
 
-    def test_run_dir_in_crash_detail(self) -> None:
+    def test_run_dir_in_crashresult_detail(self) -> None:
         results = _make_results()
         summary = _make_summary(results)
         config = _make_config()


### PR DESCRIPTION
## Summary
- Deduplicate `_signal_name` (3 copies in summary.py, analyze_cli.py, formatting.py) into canonical `format_signal_name()` in `formatting.py`.
- Deduplicate `_result_detail` (3 copies in analyze.py, analyze_cli.py, summary.py) into public `result_detail()` in `analyze.py`.
- Make `_extract_minor_version` public as `extract_minor_version` in `analyze.py`, update all call sites.
- Remove redundant zero-check in `compare_runs` duration percentage calculation.
- Fix timeout documentation (300s → 600s) in `doc/enrichment.md` to match CLI default.

## Test plan
- [x] All 546 tests pass
- [x] mypy strict: no issues found
- [x] ruff format + check: clean
- [x] Grep confirms no remaining references to old function names

Closes #27

Generated with [Claude Code](https://claude.com/claude-code)