### PR TITLE
Fix YAML scalar quoting and field extent handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Made `_extract_minor_version` public as `extract_minor_version` in `analyze.py`.
 - Removed redundant zero-check in `compare_runs` duration percentage calculation.
 - Fixed timeout documentation (300s → 600s) in `doc/enrichment.md`.
+- `_quote_yaml_scalar` now quotes all numeric strings (integers, scientific notation, octal-like), tilde, and additional YAML special characters.
+- `find_field_extent` no longer consumes trailing blank lines after scalar fields, fixing `insert_field_after` placement near blank lines.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.


### PR DESCRIPTION
## Summary
- `_quote_yaml_scalar` now quotes all numeric strings (integers, scientific notation, octal-like), tilde (`~`), and additional YAML special characters (`!`, `%`, `@`, `` ` ``) to prevent type loss on round-trip.
- `find_field_extent` no longer consumes trailing blank lines after scalar fields — for scalar fields the extent is always one line. Block fields still correctly include internal blank lines but exclude trailing ones.
- Added 17 new tests covering quoting edge cases and extent behavior with blank lines.

## Test plan
- [x] All 563 tests pass
- [x] mypy strict: no issues found in 18 source files
- [x] ruff format + check: clean
- [x] New tests cover: bare integers, negative numbers, floats, scientific notation, octal-like, tilde, booleans, empty strings, special chars, scalar/block extent with trailing/internal blank lines, insert-after-scalar-before-blank-line

Closes #29

Generated with [Claude Code](https://claude.com/claude-code)