### PR TITLE
Rewrite batch_set_field to preserve YAML formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Fixed timeout documentation (300s → 600s) in `doc/enrichment.md`.
 - `_quote_yaml_scalar` now quotes all numeric strings (integers, scientific notation, octal-like), tilde, and additional YAML special characters.
 - `find_field_extent` no longer consumes trailing blank lines after scalar fields, fixing `insert_field_after` placement near blank lines.
+- Rewrote `batch_set_field` to use line-level manipulation instead of PyYAML round-trip, preserving YAML formatting.
+- Added `set_field_value` to `yaml_lines.py` for in-place field value replacement.
+- `format_yaml_value` and `parse_default_value` now handle `None`/`null` values.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.


### PR DESCRIPTION
## Summary
- Added `set_field_value()` to `yaml_lines.py` for line-level field value replacement (scalar, block-dict, block-list fields).
- Rewrote `batch_set_field` in `registry_ops.py` to use `set_field_value()` instead of PyYAML round-trip (`yaml.safe_load` → modify → `yaml.dump`), so only the changed field is modified and all other formatting is preserved byte-for-byte.
- Added `None`/`null` handling to `format_yaml_value()` and `parse_default_value()`, enabling `labeille registry set-field <field> null`.

## Test plan
- [x] All 584 tests pass (21 new)
- [x] mypy strict: no issues found in 18 source files
- [x] ruff format + check: clean
- [x] New `set_field_value` tests cover: simple scalars, null↔string, integers, booleans, block dict→empty, empty→block dict, block list replacement, preserves-other-fields, not-found error
- [x] New `batch_set_field` formatting tests verify byte-identical preservation of untouched lines, null value setting, and quoted string preservation

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)