### PR TITLE
Fix: tighten migration skip detection and add namespace package warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Rewrote `batch_set_field` to use line-level manipulation instead of PyYAML round-trip, preserving YAML formatting.
 - Added `set_field_value` to `yaml_lines.py` for in-place field value replacement.
 - `format_yaml_value` and `parse_default_value` now handle `None`/`null` values.
+- `_is_version_specific_skip` now uses word-boundary regex patterns to prevent false positives (e.g. "trust" no longer matches the "rust" pattern).
+- `scan-deps` now warns about namespace packages (`google`, `azure`, `zope`, etc.) where pip resolution is uncertain, and tries full import paths before falling back to top-level modules.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -456,6 +456,8 @@ def _print_human_format(result: "ScanResult", install_command: str | None) -> No
             name_col = f"  {dep.pip_package:<20s}"
             source_col = f"({dep.source})"
             click.echo(f"{name_col} {source_col:<12s} {files_str}{cond}")
+            if dep.note:
+                click.echo(f"  {'':20s} \u26a0 {dep.note}")
         click.echo()
 
     if result.unresolved:

--- a/src/labeille/import_map.py
+++ b/src/labeille/import_map.py
@@ -77,6 +77,11 @@ IMPORT_TO_PIP: dict[str, str] = {
     "blinker": "blinker",
     # --- Cloud / Infrastructure ---
     "google": "google-cloud-core",
+    "google.cloud.storage": "google-cloud-storage",
+    "google.cloud.bigquery": "google-cloud-bigquery",
+    "google.cloud.pubsub": "google-cloud-pubsub",
+    "google.cloud.firestore": "google-cloud-firestore",
+    "google.cloud.logging": "google-cloud-logging",
     "boto3": "boto3",
     "botocore": "botocore",
     "azure": "azure-core",

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -371,7 +371,15 @@ class TestIsVersionSpecificSkip(unittest.TestCase):
         self.assertTrue(_is_version_specific_skip("JIT crash (_PyOptimizer_Optimize abort)"))
 
     def test_cython_fails(self) -> None:
-        self.assertTrue(_is_version_specific_skip("Cython build step fails"))
+        self.assertTrue(_is_version_specific_skip("Cython build step fails on 3.15"))
+
+    def test_cython_editable_build_fails(self) -> None:
+        self.assertTrue(
+            _is_version_specific_skip(
+                "C extension source files not generated "
+                "(Cython build step fails on editable install for 3.15)."
+            )
+        )
 
     def test_rust_binary_no_tests(self) -> None:
         self.assertFalse(_is_version_specific_skip("Rust binary with no Python test suite"))
@@ -395,6 +403,45 @@ class TestIsVersionSpecificSkip(unittest.TestCase):
 
     def test_no_repo_url(self) -> None:
         self.assertFalse(_is_version_specific_skip("No repository URL found."))
+
+    # --- False positive prevention tests ---
+
+    def test_trust_store_not_matched(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Trust store configuration issues"))
+
+    def test_robust_not_matched(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Robust error handling required"))
+
+    def test_frustrated_not_matched(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Package author frustrated with CI failures"))
+
+    def test_version_mention_not_matched(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Only tested on 3.15 and later"))
+
+    # --- Regression tests with actual skip reasons from registry ---
+
+    def test_real_reason_aiobotocore(self) -> None:
+        self.assertTrue(
+            _is_version_specific_skip(
+                "moto requires pydantic-core (Rust/PyO3) which doesn't support Python 3.15 yet"
+            )
+        )
+
+    def test_real_reason_aiohttp(self) -> None:
+        self.assertTrue(
+            _is_version_specific_skip(
+                "C extension source files not generated "
+                "(Cython build step fails on editable install for 3.15)."
+            )
+        )
+
+    def test_real_reason_ruff(self) -> None:
+        self.assertFalse(_is_version_specific_skip("Rust binary with no Python test suite"))
+
+    def test_real_reason_stub(self) -> None:
+        self.assertFalse(
+            _is_version_specific_skip("Type stub package with no meaningful test suite")
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Replace loose substring matching in `_is_version_specific_skip` with word-boundary regex patterns to prevent false positives (e.g. "trust" no longer matches "rust", "robust" no longer matches "rust")
- Add namespace package awareness to `scan-deps`: tries full import paths (e.g. `google.cloud.storage`) before falling back to top-level module, warns about namespace packages where pip resolution is uncertain
- Add Google Cloud sub-package mappings to `import_map.py`

## Test plan
- [x] 599 tests pass (`unittest discover`)
- [x] mypy strict mode clean
- [x] ruff format and check clean
- [x] Manual verification of all existing registry skip reasons against new regex patterns
- [x] False positive prevention tests (trust, robust, frustrated, bare version mention)
- [x] Regression tests with real-world skip reasons from the registry
- [x] Namespace package resolution and warning tests

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)