### PR TITLE
Fix: index skip_versions awareness, validation rules, and type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `format_yaml_value` and `parse_default_value` now handle `None`/`null` values.
 - `_is_version_specific_skip` now uses word-boundary regex patterns to prevent false positives (e.g. "trust" no longer matches the "rust" pattern).
 - `scan-deps` now warns about namespace packages (`google`, `azure`, `zope`, etc.) where pip resolution is uncertain, and tries full import paths before falling back to top-level modules.
+- `IndexEntry` now tracks `skip_versions_keys` for fast version-skip filtering without loading full YAML files.
+- `filter_packages` uses index-level `skip_versions_keys` to skip packages before loading YAML.
+- `_dict_to_package` coerces `notes: null` to empty string for type safety.
+- `_dict_to_package` logs unknown YAML keys at debug level to surface typos.
+- `validate_registry` checks `uses_xdist`/`-p no:xdist` consistency in both directions.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -680,6 +680,28 @@ def validate_registry(
                         )
                     )
 
+        # Check uses_xdist consistency.
+        if not raw.get("skip", False):
+            test_cmd = raw.get("test_command", "")
+            if raw.get("uses_xdist", False):
+                if test_cmd and "-p no:xdist" not in test_cmd:
+                    issues.append(
+                        ValidationIssue(
+                            f.name,
+                            "warning",
+                            "uses_xdist is true but test_command does not include '-p no:xdist'",
+                        )
+                    )
+            else:
+                if test_cmd and "-p no:xdist" in test_cmd:
+                    issues.append(
+                        ValidationIssue(
+                            f.name,
+                            "warning",
+                            "test_command includes '-p no:xdist' but uses_xdist is false",
+                        )
+                    )
+
     return issues
 
 
@@ -719,6 +741,7 @@ def rebuild_index(registry_dir: Path) -> int:
                         extension_type=pkg.extension_type,
                         enriched=pkg.enriched,
                         skip=pkg.skip,
+                        skip_versions_keys=sorted(pkg.skip_versions.keys()),
                     )
                 )
 


### PR DESCRIPTION
## Summary
- Add `skip_versions_keys` field to `IndexEntry` for fast version-skip filtering in `filter_packages` without loading full YAML files
- Add `uses_xdist`/`-p no:xdist` consistency validation in `validate_registry` (both directions, skipped packages excluded)
- Coerce `notes: null` to empty string in `_dict_to_package` for type safety
- Log unknown YAML keys at debug level in `_dict_to_package` to surface typos like `skip_reaason`
- Update `rebuild_index` and `update_index_from_packages` to sync `skip_versions_keys`

## Test plan
- [x] 614 tests pass (`unittest discover`)
- [x] mypy strict mode clean
- [x] ruff format and check clean
- [x] xdist validation catches 24 real inconsistencies in the registry
- [x] Index skip_versions_keys round-trip through YAML
- [x] Backward compatibility with index files missing skip_versions_keys

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)