### PR TITLE
Fix: JIT detection, null field serialization, install command parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `_dict_to_package` coerces `notes: null` to empty string for type safety.
 - `_dict_to_package` logs unknown YAML keys at debug level to surface typos.
 - `validate_registry` checks `uses_xdist`/`-p no:xdist` consistency in both directions.
+- `check_jit_enabled` now uses explicit `sys.flags.jit` check instead of nonexistent `sys._jit`, with exact stdout comparison.
+- `_parse_install_packages` now handles `python -m pip install`, `python3 -m pip install`, and path-qualified pip invocations.
+- `_package_to_dict` accepts `omit_defaults` parameter to exclude default-valued fields from output.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -79,16 +79,31 @@ class Index:
 # ---------------------------------------------------------------------------
 
 
-def _package_to_dict(entry: PackageEntry) -> dict[str, Any]:
+def _package_to_dict(
+    entry: PackageEntry,
+    *,
+    omit_defaults: bool = False,
+) -> dict[str, Any]:
     """Convert a PackageEntry to an ordered dict suitable for YAML output.
 
     Ensures ``skip_versions`` keys are strings so that YAML round-trips
     correctly (prevents PyYAML from emitting bare floats like ``3.15``).
+
+    Args:
+        entry: The package entry to convert.
+        omit_defaults: If True, omit fields whose values match the defaults
+            for a freshly-created ``PackageEntry(package=...)``.  The
+            ``package`` field is always included.
     """
     data = asdict(entry)
     sv = data.get("skip_versions")
     if isinstance(sv, dict):
         data["skip_versions"] = {str(k): str(v) for k, v in sv.items()}
+
+    if omit_defaults:
+        default_dict = asdict(PackageEntry(package=entry.package))
+        data = {k: v for k, v in data.items() if k == "package" or v != default_dict.get(k)}
+
     return data
 
 


### PR DESCRIPTION
## Summary
- Rewrite `check_jit_enabled` to use explicit `sys.flags.jit` check instead of nonexistent `sys._jit`, with exact `strip() == "True"` comparison
- Add `omit_defaults` parameter to `_package_to_dict` for compact YAML output (strictly additive, no behavior change)
- Add `_normalize_pip_command` helper so `_parse_install_packages` handles `python -m pip install`, `python3 -m pip install`, `pip3 install`, and path-qualified pip invocations

## Test plan
- [x] 641 tests pass (`unittest discover`)
- [x] mypy strict mode clean
- [x] ruff format and check clean
- [x] 6 new tests for `check_jit_enabled` (true/false/timeout/file-not-found/substring/empty)
- [x] 7 new tests for `_normalize_pip_command` (all variants + non-pip)
- [x] 9 new tests for `_parse_install_packages` (python -m pip, venv pip, chaining, extras)
- [x] 5 new tests for `_package_to_dict` omit_defaults

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)