### PR TITLE
Fix: kill entire process tree on timeout (orphaned grandchildren)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `check_jit_enabled` now uses explicit `sys.flags.jit` check instead of nonexistent `sys._jit`, with exact stdout comparison.
 - `_parse_install_packages` now handles `python -m pip install`, `python3 -m pip install`, and path-qualified pip invocations.
 - `_package_to_dict` accepts `omit_defaults` parameter to exclude default-valued fields from output.
+- `run_test_command` and `install_package` now kill the entire process tree on timeout via `os.killpg`, preventing orphaned grandchild processes from accumulating during batch runs.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ Update index after editing package files: `load_index()` → `update_index_from_
 - For large batch runs (50+ packages), consider a non-ASAN JIT build: most JIT crashes (segfaults, aborts, assertion failures) reproduce identically without ASAN, and you can run --workers 4-8 comfortably
 - Specific crashes can be reproduced under ASAN afterward for detailed memory error analysis
 
+### Orphaned process cleanup
+- labeille kills the entire process group on timeout (`os.killpg`), which catches most grandchild processes
+- However, if you interrupt labeille itself (Ctrl+C), subprocesses may still survive — check with `ps aux | grep pytest` and clean up as needed
+
 ## Registry batch operations
 
 - Always dry-run first (omit --apply), review the preview, then re-run with --apply.

--- a/doc/enrichment.md
+++ b/doc/enrichment.md
@@ -638,9 +638,10 @@ grep "enriched: false" registry/index.yaml
   For ASAN builds, `--workers 2-3` is the practical limit. For non-ASAN
   builds, `--workers 4-8` works well on most machines.
 
-- **Check for orphaned processes after killing labeille.** If you interrupt a
-  labeille run, pytest subprocesses may survive and consume significant memory.
-  Check with `ps aux | grep pytest` and clean up as needed.
+- **Check for orphaned processes after interrupting labeille.** Timeouts now
+  kill the entire process group automatically. However, if you interrupt
+  labeille itself (Ctrl+C), pytest subprocesses may survive and consume
+  significant memory. Check with `ps aux | grep pytest` and clean up as needed.
 
 - **Verify YAML after every edit.** One broken YAML file blocks all packages.
   A quick `python -c "import yaml; yaml.safe_load(open('file.yaml'))"` saves


### PR DESCRIPTION
## Summary
- Add `_run_in_process_group` helper that uses `subprocess.Popen` with `start_new_session=True` and kills the entire process group via `os.killpg(SIGKILL)` on timeout
- Update `run_test_command` and `install_package` to use it, preventing orphaned grandchild processes from accumulating during batch runs
- Re-raised `TimeoutExpired` carries partial stdout/stderr from post-kill `communicate()` call
- Leave other subprocess calls (clone_repo, check_jit_enabled, create_venv, etc.) unchanged since they don't spawn process trees
- Update CLAUDE.md and doc/enrichment.md with orphaned process cleanup guidance

## Test plan
- [x] 646 tests pass (`unittest discover`)
- [x] mypy strict mode clean
- [x] ruff format and check clean
- [x] 5 new tests for `_run_in_process_group` (success, timeout kills group, process already exited, partial output, double timeout fallback)
- [x] Verified no stale `subprocess.run` mocks in install/test contexts
- [x] Existing `TestRunPackage` tests pass unchanged (they mock `install_package`/`run_test_command` at function level)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)