### PR TITLE
Fix: O(1) result lookups, environment isolation, partial-dir warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `_parse_install_packages` now handles `python -m pip install`, `python3 -m pip install`, and path-qualified pip invocations.
 - `_package_to_dict` accepts `omit_defaults` parameter to exclude default-valued fields from output.
 - `run_test_command` and `install_package` now kill the entire process tree on timeout via `os.killpg`, preventing orphaned grandchild processes from accumulating during batch runs.
+- `RunData.result_for()` now uses O(1) dict lookup instead of O(N) linear scan, with lazily-built `_results_by_pkg` cache.
+- `compare_runs` and `_compute_status_changes` use `result_for()` instead of building ad-hoc dicts.
+- Subprocess helpers (`build_env`, `check_jit_enabled`, `create_venv`, `validate_target_python`) now strip `PYTHONHOME`/`PYTHONPATH` via `_clean_env()` to prevent environment pollution.
+- CLI warns when only one of `--repos-dir`/`--venvs-dir` is set, since the other will use a temporary directory.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -269,6 +269,15 @@ def run_cmd(
         if venvs_dir is None:
             venvs_dir = work_dir / "venvs"
 
+    # Warn when only one of --repos-dir / --venvs-dir is set: the other
+    # directory will use a temporary path and be cleaned up after the run.
+    if (repos_dir is None) != (venvs_dir is None):
+        missing = "--venvs-dir" if venvs_dir is None else "--repos-dir"
+        click.echo(
+            f"Warning: {missing} is not set; those directories will be temporary.",
+            err=True,
+        )
+
     config = RunnerConfig(
         target_python=target_python,
         registry_dir=registry_dir,

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -170,6 +170,22 @@ class TestRunData(unittest.TestCase):
         run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
         self.assertIsNone(run.result_for("nonexistent"))
 
+    def test_result_for_cache_built_once(self) -> None:
+        """The _results_by_pkg dict is built lazily on first call."""
+        _write_run(
+            self.results_dir,
+            "run1",
+            results=[_make_result("alpha"), _make_result("beta")],
+        )
+        run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
+        self.assertIsNone(run._results_by_pkg)
+        run.result_for("alpha")
+        self.assertIsNotNone(run._results_by_pkg)
+        # Second call reuses the same dict (no rebuild).
+        cache = run._results_by_pkg
+        run.result_for("beta")
+        self.assertIs(run._results_by_pkg, cache)
+
     def test_results_by_status(self) -> None:
         _write_run(
             self.results_dir,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -286,6 +286,70 @@ class TestRunIntegration(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
+    def test_run_partial_dir_warning_repos_only(self) -> None:
+        """Warn when --repos-dir is set but --venvs-dir is not."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+        repos = self.base / "repos"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-partial",
+                "--repos-dir",
+                str(repos),
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("--venvs-dir is not set", result.output)
+
+    def test_run_partial_dir_warning_venvs_only(self) -> None:
+        """Warn when --venvs-dir is set but --repos-dir is not."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+        venvs = self.base / "venvs"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-partial",
+                "--venvs-dir",
+                str(venvs),
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("--repos-dir is not set", result.output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `RunData.result_for()` now uses a lazily-built `_results_by_pkg` dict cache for O(1) lookups instead of O(N) linear scans; `compare_runs` and `_compute_status_changes` use it instead of ad-hoc dicts.
- New `_clean_env()` helper strips `PYTHONHOME`/`PYTHONPATH` from subprocess environments, used by `build_env`, `check_jit_enabled`, `create_venv`, and `validate_target_python`.
- CLI warns when only one of `--repos-dir`/`--venvs-dir` is set, since the other will use a temporary directory.

## Test plan
- [x] ruff format — no changes
- [x] ruff check — all passed
- [x] mypy strict — no issues
- [x] 654 tests pass (8 new: 4 _clean_env, 1 build_env stripping, 1 result_for cache, 2 CLI partial-dir warning)

Closes #41

Generated with [Claude Code](https://claude.com/claude-code)