### PR TITLE
Batched improvements: index optimization, classifier, sessions, scan-deps accuracy, git reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `compare_runs` and `_compute_status_changes` use `result_for()` instead of building ad-hoc dicts.
 - Subprocess helpers (`build_env`, `check_jit_enabled`, `create_venv`, `validate_target_python`) now strip `PYTHONHOME`/`PYTHONPATH` via `_clean_env()` to prevent environment pollution.
 - CLI warns when only one of `--repos-dir`/`--venvs-dir` is set, since the other will use a temporary directory.
+- `update_index_from_packages` accepts optional `modified_packages` set to avoid O(N) disk reads when only a few packages changed.
+- `_PLATFORM_INDICATORS` now detects bare `linux_x86_64`/`linux_aarch64` wheels in addition to `manylinux`/`musllinux`.
+- `fetch_pypi_metadata` and `resolve_package` accept an optional `requests.Session` for connection reuse; `resolve_all` uses shared/thread-local sessions.
+- `_is_import_error_handler` no longer treats `except Exception` as an import error handler, reducing false conditional import flags.
+- `_parse_install_packages` uses a regex instead of chained `.split()` to handle all PEP 440 specifiers (`~=`, `!=`, `;` markers).
+- `pull_repo` uses `git fetch` + `reset --hard FETCH_HEAD` + `clean -fdx` instead of `git pull --ff-only`, handling dirty working trees left by test suites.
 
 ### Added
 - 350 enriched package configurations with full test commands, install commands, and metadata.

--- a/src/labeille/classifier.py
+++ b/src/labeille/classifier.py
@@ -18,7 +18,7 @@ log = get_logger("classifier")
 
 # Patterns that indicate a platform-specific (native extension) wheel.
 _PLATFORM_INDICATORS = re.compile(
-    r"manylinux|musllinux|macosx|win32|win_amd64|win_arm64", re.IGNORECASE
+    r"manylinux|musllinux|macosx|win32|win_amd64|win_arm64|linux_", re.IGNORECASE
 )
 
 

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -256,17 +256,24 @@ def save_package(entry: PackageEntry, registry_path: Path) -> None:
     log.debug("Saved package %s to %s", entry.package, p)
 
 
-def update_index_from_packages(index: Index, registry_path: Path) -> None:
+def update_index_from_packages(
+    index: Index,
+    registry_path: Path,
+    modified_packages: set[str] | None = None,
+) -> None:
     """Refresh index entries with current data from package YAML files.
 
-    For each entry in the index that has a corresponding package file, updates
-    ``extension_type``, ``enriched``, and ``skip`` from the package file.
+    If *modified_packages* is provided, only those entries are re-read
+    from disk.  Otherwise all entries are refreshed (existing behaviour).
 
     Args:
         index: The index to update (modified in place).
         registry_path: Path to the registry directory.
+        modified_packages: When given, only reload these package names.
     """
     for entry in index.packages:
+        if modified_packages is not None and entry.name not in modified_packages:
+            continue
         if package_exists(entry.name, registry_path):
             pkg = load_package(entry.name, registry_path)
             entry.extension_type = pkg.extension_type

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -46,6 +46,14 @@ class TestHasPlatformWheel(unittest.TestCase):
     def test_empty_list(self) -> None:
         self.assertFalse(has_platform_wheel([]))
 
+    def test_linux_x86_64(self) -> None:
+        files = ["pkg-1.0-cp312-cp312-linux_x86_64.whl"]
+        self.assertTrue(has_platform_wheel(files))
+
+    def test_linux_aarch64(self) -> None:
+        files = ["pkg-1.0-cp312-cp312-linux_aarch64.whl"]
+        self.assertTrue(has_platform_wheel(files))
+
 
 class TestClassifyFromUrls(unittest.TestCase):
     def test_pure_python(self) -> None:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -256,6 +256,21 @@ class TestFetchPypiMetadata(unittest.TestCase):
         self.assertIn("User-Agent", kwargs["headers"])
         self.assertIn("labeille/", kwargs["headers"]["User-Agent"])
 
+    def test_with_session(self) -> None:
+        """When a session is passed, session.get() is called instead of requests.get()."""
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _mock_response(200, {"info": {}})
+        result = fetch_pypi_metadata("testpkg", session=session)
+        session.get.assert_called_once()
+        self.assertIsNotNone(result)
+
+    @patch("labeille.resolve.requests.get")
+    def test_without_session(self, mock_get: MagicMock) -> None:
+        """Without a session, requests.get() is called (existing behaviour)."""
+        mock_get.return_value = _mock_response(200, {"info": {}})
+        fetch_pypi_metadata("testpkg")
+        mock_get.assert_called_once()
+
 
 class TestInputReading(unittest.TestCase):
     def test_read_from_args(self) -> None:


### PR DESCRIPTION
## Summary
- **Fix 1**: `update_index_from_packages` accepts `modified_packages` set for selective sync; `resolve_all` passes only resolved packages.
- **Fix 2**: `_PLATFORM_INDICATORS` detects bare `linux_x86_64`/`linux_aarch64` wheels.
- **Fix 3**: `fetch_pypi_metadata`/`resolve_package` accept `requests.Session`; `resolve_all` uses shared session (sequential) and thread-local sessions (parallel).
- **Fix 4**: `_is_import_error_handler` no longer treats `except Exception` as conditional import handler.
- **Fix 5**: `_parse_install_packages` uses regex for PEP 440 specifiers (`~=`, `!=`, `;` markers).
- **Fix 6**: `pull_repo` uses `fetch` + `reset --hard FETCH_HEAD` + `clean -fdx` instead of `pull --ff-only`.

## Test plan
- [x] ruff format — clean
- [x] ruff check — all passed
- [x] mypy strict — no issues
- [x] 672 tests pass (18 new: 2 index selective sync, 2 linux platform wheels, 2 session tests, 4 conditional import, 4 pip parsing, 4 pull_repo)

Closes #43

Generated with [Claude Code](https://claude.com/claude-code)