### PR TITLE
feat: git revision support — clone depth, per-package revisions, commit verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `pull_repo` uses `git fetch` + `reset --hard FETCH_HEAD` + `clean -fdx` instead of `git pull --ff-only`, handling dirty working trees left by test suites.
 
 ### Added
+- `--clone-depth` and `--no-shallow` CLI options to override per-package clone depth; `--clone-depth=0` or `--no-shallow` for full clones.
+- Per-package git revision support via `--packages=pkg@revision` syntax; accepts commit hashes, branches, tags, or relative refs like `HEAD~10`.
+- `checkout_revision` helper for checking out specific git refs after cloning.
+- `parse_package_specs` function for parsing `name@revision` package spec syntax.
+- `requested_revision` field in `PackageResult` to distinguish explicitly requested revisions from HEAD.
 - 350 enriched package configurations with full test commands, install commands, and metadata.
 - Applied `skip-to-skip-versions` migration on 36 packages (PyO3, maturin, Cython, JIT crashes).
 - Config fixes for python-dateutil, pyyaml, msgpack, hatchling, openai, numpy, pytz, sqlalchemy, and 3 archived google packages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,5 +117,13 @@ Update index after editing package files: `load_index()` → `update_index_from_
 - Each migration runs once — re-application is blocked with the original date shown.
 - Add new migrations by decorating a function with `@register_migration(name, description)` in `migrations.py`.
 
+## Investigating a crash at a specific revision
+
+If a crash was found at commit abc123:
+1. Reproduce: `labeille run --packages=mypkg@abc123 --no-shallow ...`
+2. Check if HEAD still crashes: `labeille run --packages=mypkg ...`
+3. If HEAD doesn't crash, the package fixed the issue.
+4. If HEAD still crashes, the issue persists — file upstream or investigate the JIT side.
+
 ## Workflow
 - Use `/task-workflow <description>` for the full issue → branch → code → test → commit → PR → merge cycle

--- a/README.md
+++ b/README.md
@@ -77,7 +77,30 @@ labeille run --target-python /path/to/jit-python --stop-after-crash 1
 
 # Run tests in parallel (4 workers)
 labeille run --target-python /path/to/jit-python --workers 4
+
+# Test a specific package at a specific git revision
+labeille run --target-python /path/to/jit-python \
+    --packages=requests@abc1234 --no-shallow
 ```
+
+### Testing specific revisions
+
+To test a package at a specific git revision (useful for reproducing
+crashes or bisecting regressions):
+
+```bash
+labeille run --target-python /path/to/python \
+    --packages=requests@abc1234 --no-shallow
+```
+
+The `@revision` accepts any git ref: commit hashes, branch names,
+tags, or relative refs like `HEAD~10`. Use `--no-shallow` (or
+`--clone-depth=0`) when the target revision may be beyond the default
+shallow clone depth.
+
+Revision overrides are ephemeral — they apply to the current run only
+and are not written back to the registry. The exact CLI invocation is
+recorded in `run_meta.json` for reproducibility.
 
 ## How It Works
 

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -79,6 +79,7 @@ class PackageResult:
     stderr_tail: str = ""
     installed_dependencies: dict[str, str] = field(default_factory=dict)
     error_message: str | None = None
+    requested_revision: str | None = None
     timestamp: str = ""
 
     @classmethod
@@ -100,6 +101,7 @@ class PackageResult:
             stderr_tail=data.get("stderr_tail", ""),
             installed_dependencies=data.get("installed_dependencies", {}),
             error_message=data.get("error_message"),
+            requested_revision=data.get("requested_revision"),
             timestamp=data.get("timestamp", ""),
         )
 


### PR DESCRIPTION
## Summary
- Add `--clone-depth` and `--no-shallow` CLI options to override per-package clone depth from registry YAML; `--clone-depth=0` or `--no-shallow` for full clones (needed for old revisions).
- Add `--packages=pkg@revision` syntax for testing packages at specific git refs (commit hashes, branches, tags, `HEAD~N`). Ephemeral — not written back to registry.
- Add `requested_revision` field to `PackageResult` to distinguish explicit revision requests from HEAD.
- Verify and document the full commit hash recording pipeline (`clone_repo`/`pull_repo` → `PackageResult.git_revision` → JSONL → `analyze.py`).

## Test plan
- [x] `ruff format` — 1 file reformatted
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues found in 18 source files
- [x] 693 tests pass (19 new: parse_package_specs, checkout_revision, commit recording, clone depth override, revision override, CLI integration)
- [x] `labeille run --help` shows `--clone-depth`, `--no-shallow` options

Closes #47

Generated with [Claude Code](https://claude.com/claude-code)