### PR TITLE
feat: runtime customization — extra deps, command override/suffix, repo URL override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `pull_repo` uses `git fetch` + `reset --hard FETCH_HEAD` + `clean -fdx` instead of `git pull --ff-only`, handling dirty working trees left by test suites.
 
 ### Added
+- `--extra-deps` option to inject additional packages into every venv after the package's own dependencies.
+- `--test-command-override` option to replace the test command for all packages in a run.
+- `--test-command-suffix` option to append flags to each package's existing test command.
+- `--repo-override PKG=URL` option (repeatable) to test forks or PR branches without modifying registry.
 - `--clone-depth` and `--no-shallow` CLI options to override per-package clone depth; `--clone-depth=0` or `--no-shallow` for full clones.
 - Per-package git revision support via `--packages=pkg@revision` syntax; accepts commit hashes, branches, tags, or relative refs like `HEAD~10`.
 - `checkout_revision` helper for checking out specific git refs after cloning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,16 @@ Update index after editing package files: `load_index()` → `update_index_from_
 - Each migration runs once — re-application is blocked with the original date shown.
 - Add new migrations by decorating a function with `@register_migration(name, description)` in `migrations.py`.
 
+## Quick investigation overrides
+
+These CLI options let you experiment without touching registry YAMLs:
+- `--extra-deps "pkg1,pkg2"` — inject deps into every venv
+- `--test-command-override "..."` — replace all test commands
+- `--test-command-suffix "..."` — append flags to test commands
+- `--repo-override "pkg=url"` — use a fork's repo (repeatable)
+- `--packages=pkg@revision` — test at a specific git revision
+- `--no-shallow` — full clone (needed for old revisions)
+
 ## Investigating a crash at a specific revision
 
 If a crash was found at commit abc123:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ Revision overrides are ephemeral — they apply to the current run only
 and are not written back to the registry. The exact CLI invocation is
 recorded in `run_meta.json` for reproducibility.
 
+### Runtime customization
+
+Override test behavior without modifying the registry:
+
+```bash
+# Run with coverage
+labeille run --extra-deps coverage \
+    --test-command-override "coverage run -m pytest"
+
+# Add verbose output to all test commands
+labeille run --test-command-suffix "--tb=long -v"
+
+# Test a fork
+labeille run --packages=requests \
+    --repo-override "requests=https://github.com/fork/requests"
+
+# Combine: test a specific revision of a fork with extra deps
+labeille run --packages=requests@fix-branch \
+    --repo-override "requests=https://github.com/fork/requests" \
+    --extra-deps "coverage" --no-shallow
+```
+
 ## How It Works
 
 labeille operates in two phases:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -488,6 +488,126 @@ class TestRunIntegration(unittest.TestCase):
         # In dry-run mode the package should be listed as skipped.
         self.assertIn("Skipped:", result.output)
 
+    def test_extra_deps_option(self) -> None:
+        """--extra-deps is accepted by the CLI."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-extradeps",
+                "--extra-deps",
+                "coverage,pytest-timeout",
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_test_command_override_option(self) -> None:
+        """--test-command-override is accepted by the CLI."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-cmdoverride",
+                "--test-command-override",
+                "python -m pytest -x",
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_test_command_suffix_option(self) -> None:
+        """--test-command-suffix is accepted by the CLI."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-cmdsuffix",
+                "--test-command-suffix",
+                "--tb=long -v",
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_repo_override_option(self) -> None:
+        """--repo-override is accepted by the CLI."""
+        save_index(Index(), self.registry_dir)
+
+        import sys
+
+        target = sys.executable
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--dry-run",
+                "--target-python",
+                target,
+                "--registry-dir",
+                str(self.registry_dir),
+                "--results-dir",
+                str(self.results_dir),
+                "--run-id",
+                "test-repooverride",
+                "--repo-override",
+                "fakepkg=https://example.com/fork",
+                "--log-file",
+                str(self.base / "run.log"),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `--extra-deps` option to inject additional packages into every venv after package install
- Add `--test-command-override` and `--test-command-suffix` options for test command customization
- Add `--repo-override PKG=URL` option (repeatable) to test forks or PR branches without modifying registry
- All options are ephemeral (run-level only, never written back to YAML)

## Test plan
- [x] 23 new unit tests (parse_repo_overrides, extra_deps, test_command_override, test_command_suffix, repo_override)
- [x] 4 new CLI integration tests
- [x] ruff format/check clean
- [x] mypy strict clean
- [x] 716 tests pass

Closes #49

Generated with [Claude Code](https://claude.com/claude-code)