### PR TITLE
feat: commit-aware run comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Commit-aware run comparison: `analyze compare` and `analyze run` show git commit changes alongside status changes with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression").
+- `PackageComparison` dataclass with `commit_changed`/`commit_unchanged` properties for per-package comparison data.
+- New crash summary statistics in compare output showing repo unchanged/changed/unknown counts.
+
 ### Enhanced
 - Switched build backend from setuptools to hatchling for better src layout support and lighter build dependencies.
 - Added minimum version pins to runtime dependencies (click>=8.0, pyyaml>=6.0, requests>=2.28).

--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ labeille analyze history --last 5
 labeille analyze package requests
 ```
 
+### Commit-aware comparison
+
+When comparing runs, labeille shows whether each package's repository
+changed between runs:
+
+```
+labeille analyze compare run_001 run_002
+
+Status changes:
+  requests: PASS → CRASH
+    Repo: abc1234 → abc1234 (unchanged — likely a CPython/JIT regression)
+```
+
+This helps triage new crashes: if the package code didn't change,
+the regression is almost certainly on the CPython/JIT side.
+
 ## Registry Management
 
 Batch operations for managing the package registry:


### PR DESCRIPTION
## Summary
- Add `old_commit`/`new_commit` fields to `StatusChange` and `PackageComparison` dataclass with `commit_changed`/`commit_unchanged` properties
- Display commit context in `analyze compare` and `analyze run` output with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression")
- Add new crash summary statistics showing repo unchanged/changed/unknown counts

## Test plan
- [x] 22 new tests (10 analyze, 12 analyze_cli)
- [x] ruff format/check clean
- [x] mypy strict clean (18 source files)
- [x] 738 tests pass

Closes #53

Generated with [Claude Code](https://claude.com/claude-code)