### PR TITLE
Add Anthropic acknowledgment to README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Registry schema and data structures.
 
 ### Documentation
+- Added Anthropic support acknowledgment section to README.md.
 - Added security warnings to README.md, runner.py module docstring, and CLAUDE.md.
 - Added Gemini acknowledgment to CREDITS.md.
 - Comprehensive enrichment guide with manual workflow, troubleshooting, and Claude Code prompts (doc/enrichment.md).

--- a/README.md
+++ b/README.md
@@ -413,6 +413,12 @@ and real-world workloads.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and
 the pull request process.
 
+## Acknowledgments
+
+[Anthropic](https://www.anthropic.com/) provided financial support that enabled access to
+advanced AI capabilities for labeille's development. See [CREDITS.md](CREDITS.md) for full
+details.
+
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
This PR adds an acknowledgments section to the README recognizing Anthropic's financial support for labeille's development, and updates the CHANGELOG to document this addition.

## Changes
- Added new "Acknowledgments" section to README.md that credits Anthropic for providing financial support and access to advanced AI capabilities
- Referenced CREDITS.md for full details on acknowledgments
- Updated CHANGELOG.md to document the addition of the Anthropic support acknowledgment

## Details
The acknowledgments section is positioned between the Contributing and License sections in the README, following standard documentation conventions. This change maintains transparency about the project's development support while keeping the main README concise by deferring detailed credits to CREDITS.md.

https://claude.ai/code/session_01WEx8Jh6wGXeNmQJPi1qdcr