### PR TITLE
feat: add system profiling for benchmark reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `bench` subpackage with `system.py` module for capturing system profiles (CPU, RAM, OS, disk) and Python interpreter profiles (version, JIT/GIL state, build flags) for benchmark reproducibility.
+- `SystemProfile`, `PythonProfile`, `StabilityCheck`, and `SystemSnapshot` dataclasses with JSON serialization and terminal display formatting.
+- `check_stability()` pre-benchmark validation (load average, available RAM).
 - `labeille bisect` command to binary-search a package's git history and find the first commit that introduced a crash.
 - `bisect.py` module with `BisectConfig`, `BisectStep`, `BisectResult` dataclasses and the `run_bisect` algorithm with skip-neighbor handling for unbuildable commits.
 - Commit-aware run comparison: `analyze compare` and `analyze run` show git commit changes alongside status changes with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression").

--- a/src/labeille/bench/__init__.py
+++ b/src/labeille/bench/__init__.py
@@ -1,0 +1,6 @@
+"""Benchmarking subsystem for labeille.
+
+Provides tools for running reproducible benchmarks of package test
+suites under different conditions (interpreters, tools, env vars)
+and statistically comparing the results.
+"""

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -1,0 +1,607 @@
+"""System characterization for benchmark reproducibility.
+
+Captures hardware, OS, Python, and runtime state information so
+benchmark results can be properly contextualized and compared.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# SystemProfile
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SystemProfile:
+    """Complete characterization of the system running a benchmark."""
+
+    # CPU
+    cpu_model: str = "unknown"
+    cpu_cores_physical: int = 0
+    cpu_cores_logical: int = 0
+    cpu_freq_mhz: float | None = None
+    cpu_freq_max_mhz: float | None = None
+    cpu_architecture: str = ""
+
+    # Memory
+    ram_total_gb: float = 0.0
+    ram_available_gb: float = 0.0
+    swap_total_gb: float = 0.0
+
+    # OS
+    os_name: str = ""
+    os_kernel_version: str = ""
+    os_distro: str = ""
+
+    # Python (of the benchmarking process itself, not the target)
+    host_python_version: str = ""
+    host_python_implementation: str = ""
+
+    # System state at capture time
+    load_avg_1m: float = 0.0
+    load_avg_5m: float = 0.0
+    load_avg_15m: float = 0.0
+    running_processes: int = 0
+
+    # Disk
+    disk_type: str = "unknown"  # ssd / hdd / unknown
+    disk_available_gb: float = 0.0
+
+    # Environment
+    hostname: str = ""
+    timestamp: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SystemProfile:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, text: str) -> SystemProfile:
+        """Deserialize from a JSON string."""
+        return cls.from_dict(json.loads(text))
+
+
+# ---------------------------------------------------------------------------
+# PythonProfile
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PythonProfile:
+    """Characterization of a target Python interpreter."""
+
+    path: str = ""
+    version: str = ""
+    implementation: str = ""  # CPython, PyPy, etc.
+    compiler: str = ""  # e.g. "GCC 13.2.0"
+    build_flags: list[str] = field(default_factory=list)
+    jit_available: bool = False
+    jit_enabled: bool = False
+    gil_disabled: bool = False
+    debug_build: bool = False
+    hash_randomization: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PythonProfile:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+# ---------------------------------------------------------------------------
+# StabilityCheck
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StabilityCheck:
+    """Result of checking system stability for benchmarking."""
+
+    stable: bool
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# SystemSnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SystemSnapshot:
+    """Lightweight system state captured before/after each iteration."""
+
+    timestamp: float  # time.monotonic()
+    load_avg_1m: float = 0.0
+    ram_available_gb: float = 0.0
+
+    @classmethod
+    def capture(cls) -> SystemSnapshot:
+        """Capture current system state."""
+        snap = cls(timestamp=time.monotonic())
+        try:
+            snap.load_avg_1m = round(os.getloadavg()[0], 2)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            meminfo = Path("/proc/meminfo").read_text()
+            for line in meminfo.splitlines():
+                if line.startswith("MemAvailable:"):
+                    snap.ram_available_gb = round(int(line.split()[1]) / (1024 * 1024), 2)
+                    break
+        except Exception:  # noqa: BLE001
+            pass
+        return snap
+
+
+# ---------------------------------------------------------------------------
+# Capture functions
+# ---------------------------------------------------------------------------
+
+
+def capture_system_profile() -> SystemProfile:
+    """Capture a complete system profile.
+
+    Gathers CPU, memory, OS, disk, and runtime state information.
+    All operations are best-effort — individual failures produce
+    default values rather than exceptions.
+    """
+    profile = SystemProfile(
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        hostname=platform.node(),
+        cpu_architecture=platform.machine(),
+        os_name=platform.system(),
+        os_kernel_version=platform.release(),
+        host_python_version=platform.python_version(),
+        host_python_implementation=platform.python_implementation(),
+    )
+
+    _capture_cpu_info(profile)
+    _capture_memory_info(profile)
+    _capture_os_info(profile)
+    _capture_load(profile)
+    _capture_disk_info(profile)
+
+    return profile
+
+
+def _capture_cpu_info(profile: SystemProfile) -> None:
+    """Populate CPU fields from /proc/cpuinfo and os.cpu_count."""
+    try:
+        profile.cpu_cores_logical = os.cpu_count() or 0
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Physical cores from /proc/cpuinfo (count unique core ids).
+    try:
+        cpuinfo = Path("/proc/cpuinfo").read_text()
+        # Model name — take the first one (all cores report the same).
+        for line in cpuinfo.splitlines():
+            if line.startswith("model name"):
+                profile.cpu_model = line.split(":", 1)[1].strip()
+                break
+
+        # Physical cores: count unique (physical id, core id) pairs.
+        physical_ids: set[tuple[str, str]] = set()
+        current_physical: str | None = None
+        for line in cpuinfo.splitlines():
+            if line.startswith("physical id"):
+                current_physical = line.split(":", 1)[1].strip()
+            elif line.startswith("core id") and current_physical is not None:
+                core_id = line.split(":", 1)[1].strip()
+                physical_ids.add((current_physical, core_id))
+                current_physical = None
+        if physical_ids:
+            profile.cpu_cores_physical = len(physical_ids)
+        else:
+            # Fallback: assume no hyperthreading.
+            profile.cpu_cores_physical = profile.cpu_cores_logical
+    except Exception:  # noqa: BLE001
+        pass
+
+    # CPU frequency from /sys or /proc/cpuinfo.
+    try:
+        # Try scaling_cur_freq first (more accurate, in kHz).
+        freq_path = Path("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq")
+        if freq_path.exists():
+            profile.cpu_freq_mhz = int(freq_path.read_text().strip()) / 1000
+
+        max_path = Path("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq")
+        if max_path.exists():
+            profile.cpu_freq_max_mhz = int(max_path.read_text().strip()) / 1000
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Fallback: parse "cpu MHz" from /proc/cpuinfo.
+    if profile.cpu_freq_mhz is None:
+        try:
+            cpuinfo = Path("/proc/cpuinfo").read_text()
+            for line in cpuinfo.splitlines():
+                if line.startswith("cpu MHz"):
+                    profile.cpu_freq_mhz = float(line.split(":", 1)[1].strip())
+                    break
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _capture_memory_info(profile: SystemProfile) -> None:
+    """Populate memory fields from /proc/meminfo."""
+    try:
+        meminfo = Path("/proc/meminfo").read_text()
+        mem: dict[str, int] = {}
+        for line in meminfo.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                key = parts[0].rstrip(":")
+                # Values are in kB.
+                value_kb = int(parts[1])
+                mem[key] = value_kb
+
+        profile.ram_total_gb = mem.get("MemTotal", 0) / (1024 * 1024)
+        profile.ram_available_gb = mem.get("MemAvailable", 0) / (1024 * 1024)
+        profile.swap_total_gb = mem.get("SwapTotal", 0) / (1024 * 1024)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _capture_os_info(profile: SystemProfile) -> None:
+    """Populate OS distro from /etc/os-release or platform."""
+    try:
+        os_release = Path("/etc/os-release").read_text()
+        for line in os_release.splitlines():
+            if line.startswith("PRETTY_NAME="):
+                profile.os_distro = line.split("=", 1)[1].strip().strip('"')
+                break
+    except Exception:  # noqa: BLE001
+        # Fallback.
+        try:
+            profile.os_distro = f"{platform.system()} {platform.release()}"
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _capture_load(profile: SystemProfile) -> None:
+    """Capture system load average and process count."""
+    try:
+        load = os.getloadavg()
+        profile.load_avg_1m = round(load[0], 2)
+        profile.load_avg_5m = round(load[1], 2)
+        profile.load_avg_15m = round(load[2], 2)
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        # Count running processes from /proc/stat.
+        stat = Path("/proc/stat").read_text()
+        for line in stat.splitlines():
+            if line.startswith("procs_running"):
+                profile.running_processes = int(line.split()[1])
+                break
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _capture_disk_info(profile: SystemProfile) -> None:
+    """Capture disk type and available space."""
+    try:
+        stat = os.statvfs("/")
+        profile.disk_available_gb = round((stat.f_bavail * stat.f_frsize) / (1024**3), 1)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Detect SSD vs HDD from /sys/block.
+    try:
+        # Find the root device.
+        with open("/proc/mounts") as f:
+            dev: str | None = None
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == "/":
+                    dev = parts[0]
+                    break
+
+        if dev is None:
+            return
+
+        # Extract the base device name (e.g., /dev/sda1 → sda).
+        dev_name = Path(dev).name
+        # Strip partition number.
+        base_dev = re.sub(r"\d+$", "", dev_name)
+        # Strip 'p' partition prefix for nvme (nvme0n1p1 → nvme0n1).
+        if base_dev.startswith("nvme"):
+            base_dev = re.sub(r"p\d*$", "", dev_name)
+
+        rotational = Path(f"/sys/block/{base_dev}/queue/rotational")
+        if rotational.exists():
+            is_rotational = rotational.read_text().strip() == "1"
+            profile.disk_type = "hdd" if is_rotational else "ssd"
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Target Python profiling
+# ---------------------------------------------------------------------------
+
+_PYTHON_PROBE_SCRIPT = """\
+import json
+import platform
+import sys
+import sysconfig
+
+result = {
+    "version": platform.python_version(),
+    "implementation": platform.python_implementation(),
+    "compiler": platform.python_compiler(),
+    "debug_build": hasattr(sys, "gettotalrefcount"),
+    "hash_randomization": bool(
+        getattr(sys.flags, "hash_randomization", True)
+    ),
+}
+
+# Build flags from sysconfig.
+config_args = sysconfig.get_config_var("CONFIG_ARGS") or ""
+result["build_flags"] = [
+    arg.strip("'\\\"") for arg in config_args.split()
+    if arg.startswith("--enable-") or arg.startswith("--with-")
+]
+
+# JIT availability (CPython 3.15+).
+try:
+    result["jit_available"] = hasattr(sys.flags, "jit")
+    result["jit_enabled"] = bool(getattr(sys.flags, "jit", False))
+except Exception:
+    result["jit_available"] = False
+    result["jit_enabled"] = False
+
+# GIL status (CPython 3.13+ free-threading).
+try:
+    result["gil_disabled"] = not sys._is_gil_enabled()
+except AttributeError:
+    result["gil_disabled"] = False
+
+print(json.dumps(result))
+"""
+
+
+def capture_python_profile(
+    python_path: Path,
+    env: dict[str, str] | None = None,
+) -> PythonProfile:
+    """Characterize a target Python interpreter.
+
+    Runs a small script in the target Python to extract version,
+    build configuration, and runtime flags.
+
+    Args:
+        python_path: Path to the Python executable.
+        env: Environment variables (e.g., PYTHON_JIT=1) to set
+             when probing the interpreter.
+    """
+    profile = PythonProfile(path=str(python_path))
+
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+    # Don't let host PYTHONHOME/PYTHONPATH contaminate the probe.
+    run_env.pop("PYTHONHOME", None)
+    run_env.pop("PYTHONPATH", None)
+    run_env["ASAN_OPTIONS"] = "detect_leaks=0"
+
+    try:
+        proc = subprocess.run(
+            [str(python_path), "-c", _PYTHON_PROBE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=run_env,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            data = json.loads(proc.stdout.strip())
+            profile.version = data.get("version", "")
+            profile.implementation = data.get("implementation", "")
+            profile.compiler = data.get("compiler", "")
+            profile.build_flags = data.get("build_flags", [])
+            profile.jit_available = data.get("jit_available", False)
+            profile.jit_enabled = data.get("jit_enabled", False)
+            profile.gil_disabled = data.get("gil_disabled", False)
+            profile.debug_build = data.get("debug_build", False)
+            profile.hash_randomization = data.get("hash_randomization", True)
+        else:
+            log.warning(
+                "Python profile probe failed (exit %d): %s",
+                proc.returncode,
+                proc.stderr.strip()[:200],
+            )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        log.warning("Could not profile Python at %s: %s", python_path, exc)
+
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Stability check
+# ---------------------------------------------------------------------------
+
+
+def check_stability(
+    *,
+    max_load: float = 1.0,
+    min_available_ram_gb: float = 2.0,
+) -> StabilityCheck:
+    """Check whether the system is stable enough for benchmarking.
+
+    Args:
+        max_load: Maximum acceptable 1-minute load average.
+        min_available_ram_gb: Minimum available RAM in GB.
+
+    Returns:
+        StabilityCheck with pass/fail and diagnostic messages.
+    """
+    result = StabilityCheck(stable=True)
+
+    try:
+        load = os.getloadavg()
+        if load[0] > max_load:
+            result.stable = False
+            result.errors.append(
+                f"1-minute load average is {load[0]:.1f} "
+                f"(threshold: {max_load:.1f}). "
+                f"System is under load — benchmark results will "
+                f"be unreliable."
+            )
+        elif load[0] > max_load * 0.7:
+            result.warnings.append(
+                f"1-minute load average is {load[0]:.1f} "
+                f"(approaching threshold of {max_load:.1f})."
+            )
+    except Exception:  # noqa: BLE001
+        result.warnings.append("Could not read load average.")
+
+    try:
+        meminfo = Path("/proc/meminfo").read_text()
+        for line in meminfo.splitlines():
+            if line.startswith("MemAvailable:"):
+                avail_kb = int(line.split()[1])
+                avail_gb = avail_kb / (1024 * 1024)
+                if avail_gb < min_available_ram_gb:
+                    result.stable = False
+                    result.errors.append(
+                        f"Available RAM is {avail_gb:.1f} GB "
+                        f"(minimum: {min_available_ram_gb:.1f} GB). "
+                        f"Low memory may cause swapping and "
+                        f"unreliable timings."
+                    )
+                break
+    except Exception:  # noqa: BLE001
+        result.warnings.append("Could not read memory info.")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+
+def format_system_profile(profile: SystemProfile) -> str:
+    """Format a system profile for terminal display."""
+    lines = [
+        "System Profile",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+    ]
+
+    # CPU
+    cores = f"{profile.cpu_cores_physical} cores"
+    if profile.cpu_cores_logical != profile.cpu_cores_physical:
+        cores += f" / {profile.cpu_cores_logical} threads"
+    freq = ""
+    if profile.cpu_freq_mhz:
+        freq = f", {profile.cpu_freq_mhz:.0f} MHz"
+        if profile.cpu_freq_max_mhz:
+            freq += f" (max {profile.cpu_freq_max_mhz:.0f} MHz)"
+    lines.append(f"CPU:      {profile.cpu_model} ({cores}{freq})")
+
+    # Memory
+    lines.append(
+        f"RAM:      {profile.ram_total_gb:.1f} GB total, "
+        f"{profile.ram_available_gb:.1f} GB available"
+    )
+    if profile.swap_total_gb > 0:
+        lines.append(f"Swap:     {profile.swap_total_gb:.1f} GB")
+
+    # OS
+    lines.append(f"OS:       {profile.os_distro} (Linux {profile.os_kernel_version})")
+
+    # Disk
+    lines.append(
+        f"Disk:     {profile.disk_type.upper()}, {profile.disk_available_gb:.0f} GB available"
+    )
+
+    # Load
+    lines.append(
+        f"Load:     {profile.load_avg_1m} / {profile.load_avg_5m} / {profile.load_avg_15m}"
+    )
+
+    # Host Python
+    lines.append(
+        f"Host:     Python {profile.host_python_version} ({profile.host_python_implementation})"
+    )
+
+    lines.append(f"Hostname: {profile.hostname}")
+    lines.append(f"Time:     {profile.timestamp}")
+
+    return "\n".join(lines)
+
+
+def format_python_profile(profile: PythonProfile) -> str:
+    """Format a Python profile for terminal display."""
+    lines = [f"Python:   {profile.version} ({profile.implementation})"]
+    lines.append(f"Compiler: {profile.compiler}")
+
+    flags: list[str] = []
+    if profile.jit_enabled:
+        flags.append("JIT enabled")
+    elif profile.jit_available:
+        flags.append("JIT available (disabled)")
+    if profile.gil_disabled:
+        flags.append("GIL disabled (free-threaded)")
+    if profile.debug_build:
+        flags.append("debug build")
+    if flags:
+        lines.append(f"Flags:    {', '.join(flags)}")
+
+    if profile.build_flags:
+        # Show the most interesting build flags.
+        interesting = [
+            f
+            for f in profile.build_flags
+            if any(
+                kw in f
+                for kw in (
+                    "jit",
+                    "gil",
+                    "debug",
+                    "optimiz",
+                    "lto",
+                    "asan",
+                    "msan",
+                    "tsan",
+                    "ubsan",
+                )
+            )
+        ]
+        if interesting:
+            lines.append(f"Build:    {' '.join(interesting)}")
+
+    return "\n".join(lines)

--- a/tests/test_bench_system.py
+++ b/tests/test_bench_system.py
@@ -1,0 +1,328 @@
+"""Tests for labeille.bench.system — system profiling for benchmarks."""
+
+from __future__ import annotations
+
+import platform
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from labeille.bench.system import (
+    PythonProfile,
+    StabilityCheck,
+    SystemProfile,
+    SystemSnapshot,
+    capture_python_profile,
+    capture_system_profile,
+    check_stability,
+    format_python_profile,
+    format_system_profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# SystemProfile tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureSystemProfile(unittest.TestCase):
+    """Tests for capture_system_profile."""
+
+    def test_capture_system_profile_returns_profile(self) -> None:
+        profile = capture_system_profile()
+        self.assertIsInstance(profile, SystemProfile)
+        self.assertNotEqual(profile.hostname, "")
+        self.assertNotEqual(profile.timestamp, "")
+        self.assertNotEqual(profile.os_name, "")
+        self.assertNotEqual(profile.cpu_architecture, "")
+
+    def test_profile_cpu_cores_positive(self) -> None:
+        profile = capture_system_profile()
+        self.assertGreater(profile.cpu_cores_logical, 0)
+
+    def test_profile_ram_positive(self) -> None:
+        profile = capture_system_profile()
+        self.assertGreater(profile.ram_total_gb, 0)
+
+    def test_profile_load_avg_nonnegative(self) -> None:
+        profile = capture_system_profile()
+        self.assertGreaterEqual(profile.load_avg_1m, 0)
+
+    def test_profile_disk_info_nonnegative(self) -> None:
+        profile = capture_system_profile()
+        self.assertGreaterEqual(profile.disk_available_gb, 0)
+
+
+class TestSystemProfileSerialization(unittest.TestCase):
+    """Tests for SystemProfile serialization."""
+
+    def test_profile_serialization_roundtrip(self) -> None:
+        profile = capture_system_profile()
+        data = profile.to_dict()
+        restored = SystemProfile.from_dict(data)
+        self.assertEqual(profile.hostname, restored.hostname)
+        self.assertEqual(profile.timestamp, restored.timestamp)
+        self.assertEqual(profile.cpu_model, restored.cpu_model)
+        self.assertEqual(profile.cpu_cores_logical, restored.cpu_cores_logical)
+        self.assertEqual(profile.ram_total_gb, restored.ram_total_gb)
+        self.assertEqual(profile.os_name, restored.os_name)
+
+    def test_profile_json_roundtrip(self) -> None:
+        profile = capture_system_profile()
+        json_str = profile.to_json()
+        restored = SystemProfile.from_json(json_str)
+        self.assertEqual(profile.hostname, restored.hostname)
+        self.assertEqual(profile.timestamp, restored.timestamp)
+        self.assertEqual(profile.cpu_cores_logical, restored.cpu_cores_logical)
+
+    def test_profile_from_dict_ignores_unknown_keys(self) -> None:
+        data = {"hostname": "test", "unknown_field": "value", "extra": 42}
+        profile = SystemProfile.from_dict(data)
+        self.assertEqual(profile.hostname, "test")
+        self.assertFalse(hasattr(profile, "unknown_field"))
+
+    def test_profile_from_dict_missing_keys(self) -> None:
+        data = {"hostname": "partial"}
+        profile = SystemProfile.from_dict(data)
+        self.assertEqual(profile.hostname, "partial")
+        self.assertEqual(profile.cpu_model, "unknown")
+        self.assertEqual(profile.cpu_cores_logical, 0)
+        self.assertEqual(profile.ram_total_gb, 0.0)
+
+
+class TestCaptureGracefulDegradation(unittest.TestCase):
+    """Tests that capture functions handle missing /proc files gracefully."""
+
+    @patch("labeille.bench.system.Path.read_text", side_effect=FileNotFoundError)
+    @patch("labeille.bench.system.os.cpu_count", return_value=4)
+    def test_capture_cpu_info_no_proc(self, _mock_cpu: MagicMock, _mock_read: MagicMock) -> None:
+        from labeille.bench.system import _capture_cpu_info
+
+        profile = SystemProfile()
+        _capture_cpu_info(profile)
+        # Should get logical cores from os.cpu_count, but no model name.
+        self.assertEqual(profile.cpu_cores_logical, 4)
+        self.assertEqual(profile.cpu_model, "unknown")
+
+    @patch("labeille.bench.system.Path.read_text", side_effect=FileNotFoundError)
+    def test_capture_memory_info_no_proc(self, _mock_read: MagicMock) -> None:
+        from labeille.bench.system import _capture_memory_info
+
+        profile = SystemProfile()
+        _capture_memory_info(profile)
+        self.assertEqual(profile.ram_total_gb, 0.0)
+        self.assertEqual(profile.ram_available_gb, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# PythonProfile tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapturePythonProfile(unittest.TestCase):
+    """Tests for capture_python_profile."""
+
+    def test_capture_python_profile_self(self) -> None:
+        profile = capture_python_profile(Path(sys.executable))
+        self.assertIsInstance(profile, PythonProfile)
+        self.assertNotEqual(profile.version, "")
+        self.assertNotEqual(profile.implementation, "")
+
+    def test_python_profile_version_matches(self) -> None:
+        profile = capture_python_profile(Path(sys.executable))
+        self.assertEqual(profile.version, platform.python_version())
+
+    def test_python_profile_nonexistent_interpreter(self) -> None:
+        profile = capture_python_profile(Path("/nonexistent/python"))
+        self.assertIsInstance(profile, PythonProfile)
+        self.assertEqual(profile.version, "")
+        self.assertEqual(profile.path, "/nonexistent/python")
+
+    def test_python_profile_serialization_roundtrip(self) -> None:
+        profile = capture_python_profile(Path(sys.executable))
+        data = profile.to_dict()
+        restored = PythonProfile.from_dict(data)
+        self.assertEqual(profile.version, restored.version)
+        self.assertEqual(profile.implementation, restored.implementation)
+        self.assertEqual(profile.compiler, restored.compiler)
+        self.assertEqual(profile.build_flags, restored.build_flags)
+        self.assertEqual(profile.jit_available, restored.jit_available)
+        self.assertEqual(profile.debug_build, restored.debug_build)
+
+    def test_python_profile_with_env(self) -> None:
+        profile = capture_python_profile(Path(sys.executable), env={"PYTHON_JIT": "1"})
+        self.assertIsInstance(profile, PythonProfile)
+        self.assertNotEqual(profile.version, "")
+
+
+# ---------------------------------------------------------------------------
+# StabilityCheck tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStability(unittest.TestCase):
+    """Tests for check_stability."""
+
+    def test_check_stability_passes_normally(self) -> None:
+        # Use generous thresholds so this passes on typical dev/CI machines.
+        result = check_stability(max_load=50.0, min_available_ram_gb=0.1)
+        self.assertIsInstance(result, StabilityCheck)
+        self.assertTrue(result.stable)
+
+    @patch("labeille.bench.system.os.getloadavg", return_value=(5.0, 3.0, 2.0))
+    def test_check_stability_high_load(self, _mock_load: MagicMock) -> None:
+        result = check_stability(max_load=1.0)
+        self.assertFalse(result.stable)
+        self.assertTrue(any("load" in e.lower() for e in result.errors))
+
+    @patch(
+        "labeille.bench.system.Path.read_text",
+        return_value="MemAvailable:   512000 kB\n",
+    )
+    def test_check_stability_low_ram(self, _mock_read: MagicMock) -> None:
+        result = check_stability(min_available_ram_gb=2.0)
+        self.assertFalse(result.stable)
+        self.assertTrue(any("ram" in e.lower() for e in result.errors))
+
+    @patch("labeille.bench.system.os.getloadavg", return_value=(0.5, 0.3, 0.2))
+    def test_check_stability_custom_thresholds(self, _mock_load: MagicMock) -> None:
+        result = check_stability(max_load=0.1)
+        self.assertFalse(result.stable)
+
+    @patch("labeille.bench.system.os.getloadavg", return_value=(0.8, 0.5, 0.3))
+    def test_check_stability_warning_near_threshold(self, _mock_load: MagicMock) -> None:
+        result = check_stability(max_load=1.0)
+        self.assertTrue(any("approaching" in w for w in result.warnings))
+
+
+# ---------------------------------------------------------------------------
+# SystemSnapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestSystemSnapshot(unittest.TestCase):
+    """Tests for SystemSnapshot."""
+
+    def test_snapshot_capture(self) -> None:
+        snap = SystemSnapshot.capture()
+        self.assertGreater(snap.timestamp, 0)
+        self.assertGreaterEqual(snap.load_avg_1m, 0)
+
+    def test_snapshot_timing(self) -> None:
+        snap1 = SystemSnapshot.capture()
+        time.sleep(0.05)
+        snap2 = SystemSnapshot.capture()
+        self.assertGreater(snap2.timestamp, snap1.timestamp)
+
+
+# ---------------------------------------------------------------------------
+# Display tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSystemProfile(unittest.TestCase):
+    """Tests for format_system_profile."""
+
+    def test_format_system_profile_contains_hostname(self) -> None:
+        profile = SystemProfile(hostname="test-host")
+        output = format_system_profile(profile)
+        self.assertIn("test-host", output)
+
+    def test_format_system_profile_contains_cpu(self) -> None:
+        profile = SystemProfile(cpu_model="Test CPU")
+        output = format_system_profile(profile)
+        self.assertIn("Test CPU", output)
+
+    def test_format_system_profile_shows_threads(self) -> None:
+        profile = SystemProfile(cpu_cores_physical=4, cpu_cores_logical=8)
+        output = format_system_profile(profile)
+        self.assertIn("4 cores", output)
+        self.assertIn("8 threads", output)
+
+    def test_format_system_profile_no_threads_when_equal(self) -> None:
+        profile = SystemProfile(cpu_cores_physical=4, cpu_cores_logical=4)
+        output = format_system_profile(profile)
+        self.assertIn("4 cores", output)
+        self.assertNotIn("threads", output)
+
+    def test_format_system_profile_shows_freq(self) -> None:
+        profile = SystemProfile(cpu_freq_mhz=3600.0, cpu_freq_max_mhz=4800.0)
+        output = format_system_profile(profile)
+        self.assertIn("3600 MHz", output)
+        self.assertIn("max 4800 MHz", output)
+
+    def test_format_system_profile_shows_swap(self) -> None:
+        profile = SystemProfile(swap_total_gb=8.0)
+        output = format_system_profile(profile)
+        self.assertIn("Swap:", output)
+        self.assertIn("8.0 GB", output)
+
+    def test_format_system_profile_hides_zero_swap(self) -> None:
+        profile = SystemProfile(swap_total_gb=0.0)
+        output = format_system_profile(profile)
+        self.assertNotIn("Swap:", output)
+
+
+class TestFormatPythonProfile(unittest.TestCase):
+    """Tests for format_python_profile."""
+
+    def test_format_python_profile_jit_flag(self) -> None:
+        profile = PythonProfile(version="3.15.0", implementation="CPython", jit_enabled=True)
+        output = format_python_profile(profile)
+        self.assertIn("JIT enabled", output)
+
+    def test_format_python_profile_jit_available_not_enabled(self) -> None:
+        profile = PythonProfile(
+            version="3.15.0",
+            implementation="CPython",
+            jit_available=True,
+            jit_enabled=False,
+        )
+        output = format_python_profile(profile)
+        self.assertIn("JIT available (disabled)", output)
+
+    def test_format_python_profile_freethreaded(self) -> None:
+        profile = PythonProfile(version="3.13.0", implementation="CPython", gil_disabled=True)
+        output = format_python_profile(profile)
+        self.assertIn("free-threaded", output)
+
+    def test_format_python_profile_debug_build(self) -> None:
+        profile = PythonProfile(version="3.15.0", implementation="CPython", debug_build=True)
+        output = format_python_profile(profile)
+        self.assertIn("debug build", output)
+
+    def test_format_python_profile_build_flags(self) -> None:
+        profile = PythonProfile(
+            version="3.15.0",
+            implementation="CPython",
+            build_flags=["--enable-experimental-jit", "--with-lto"],
+        )
+        output = format_python_profile(profile)
+        self.assertIn("--enable-experimental-jit", output)
+        self.assertIn("--with-lto", output)
+
+    def test_format_python_profile_no_interesting_flags(self) -> None:
+        profile = PythonProfile(
+            version="3.15.0",
+            implementation="CPython",
+            build_flags=["--prefix=/usr"],
+        )
+        output = format_python_profile(profile)
+        self.assertNotIn("Build:", output)
+
+    def test_format_python_profile_basic(self) -> None:
+        profile = PythonProfile(
+            version="3.15.0a5",
+            implementation="CPython",
+            compiler="GCC 13.2.0",
+        )
+        output = format_python_profile(profile)
+        self.assertIn("3.15.0a5", output)
+        self.assertIn("CPython", output)
+        self.assertIn("GCC 13.2.0", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `bench` subpackage with `system.py` module for capturing system and Python interpreter profiles.
- `SystemProfile` (CPU, RAM, OS, disk, load), `PythonProfile` (version, JIT/GIL/debug state, build flags), `StabilityCheck`, and `SystemSnapshot` dataclasses with JSON serialization and terminal display formatting.
- All capture functions are best-effort — individual failures produce defaults, not exceptions.

## Test plan
- [x] 37 new tests in `tests/test_bench_system.py`
- [x] All 815 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes
- [x] Demo capture verified on current system
- [x] CHANGELOG updated

Closes #58

Generated with [Claude Code](https://claude.com/claude-code)