### PR TITLE
feat: timing capture and benchmark result format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `check_stability()` pre-benchmark validation (load average, available RAM).
 - `stats.py` module in `bench` subpackage with pure-Python statistical functions: `describe()`, `welch_ttest()`, `cohens_d()`, `bootstrap_ci()`, `detect_outliers()`, and `compute_overhead()` for benchmark comparison.
 - `DescriptiveStats`, `TTestResult`, `EffectSize`, `BootstrapCI`, and `OverheadResult` dataclasses with scipy fallback for t-test p-values.
+- `timing.py` module in `bench` subpackage with `run_timed()` and `run_timed_in_venv()` for capturing wall time, CPU time (via `resource.getrusage` delta), and peak RSS (via GNU `/usr/bin/time` with `ru_maxrss` fallback).
+- `results.py` module in `bench` subpackage with `BenchIteration`, `BenchConditionResult`, `BenchPackageResult`, `ConditionDef`, and `BenchMeta` dataclasses for the full benchmark result hierarchy, plus JSONL/JSON serialization via `save_bench_run()`, `load_bench_run()`, and `append_package_result()`.
 - `labeille bisect` command to binary-search a package's git history and find the first commit that introduced a crash.
 - `bisect.py` module with `BisectConfig`, `BisectStep`, `BisectResult` dataclasses and the `run_bisect` algorithm with skip-neighbor handling for unbuildable commits.
 - Commit-aware run comparison: `analyze compare` and `analyze run` show git commit changes alongside status changes with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression").

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -1,0 +1,411 @@
+"""Benchmark result data structures and serialization.
+
+Hierarchy::
+
+    BenchMeta (top level — one benchmark execution)
+      → conditions: dict[str, ConditionDef]
+      → python_profiles: dict[str, PythonProfile]
+      → system: SystemProfile
+
+    BenchPackageResult (per package)
+      → conditions: dict[str, BenchConditionResult]
+        → iterations: list[BenchIteration]
+        → wall_time_stats / user_time_stats / … : DescriptiveStats
+
+Files produced::
+
+    bench_meta.json      — BenchMeta (system, config, conditions)
+    bench_results.jsonl   — one BenchPackageResult per line
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from labeille.bench.stats import DescriptiveStats, describe, detect_outliers
+from labeille.bench.system import PythonProfile, SystemProfile
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# Iteration-level result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchIteration:
+    """Result of a single test suite execution."""
+
+    index: int  # 1-based iteration number
+    warmup: bool  # True if this is a warm-up iteration
+    wall_time_s: float
+    user_time_s: float
+    sys_time_s: float
+    peak_rss_mb: float
+    exit_code: int
+    status: str  # "ok", "fail", "timeout", "error"
+    outlier: bool = False  # Set by post-processing
+    load_avg_start: float = 0.0
+    load_avg_end: float = 0.0
+    ram_available_start_gb: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "index": self.index,
+            "warmup": self.warmup,
+            "wall_time_s": round(self.wall_time_s, 6),
+            "user_time_s": round(self.user_time_s, 6),
+            "sys_time_s": round(self.sys_time_s, 6),
+            "peak_rss_mb": round(self.peak_rss_mb, 1),
+            "exit_code": self.exit_code,
+            "status": self.status,
+            "outlier": self.outlier,
+            "load_avg_start": self.load_avg_start,
+            "load_avg_end": self.load_avg_end,
+            "ram_available_start_gb": self.ram_available_start_gb,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BenchIteration:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+# ---------------------------------------------------------------------------
+# Condition-level result (per package per condition)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchConditionResult:
+    """Results for one condition applied to one package."""
+
+    condition_name: str
+    iterations: list[BenchIteration] = field(default_factory=list)
+    # Stats computed from measured (non-warmup) iterations:
+    wall_time_stats: DescriptiveStats | None = None
+    user_time_stats: DescriptiveStats | None = None
+    sys_time_stats: DescriptiveStats | None = None
+    peak_rss_stats: DescriptiveStats | None = None
+    # Setup timing (not part of the benchmark):
+    install_duration_s: float = 0.0
+    venv_setup_duration_s: float = 0.0
+
+    def compute_stats(self) -> None:
+        """Compute summary statistics from measured iterations.
+
+        Call this after all iterations are complete.  Filters out
+        warm-up iterations and marks outliers.
+        """
+        measured = [it for it in self.iterations if not it.warmup]
+        if not measured:
+            return
+
+        wall_times = [it.wall_time_s for it in measured]
+        user_times = [it.user_time_s for it in measured]
+        sys_times = [it.sys_time_s for it in measured]
+        rss_values = [it.peak_rss_mb for it in measured]
+
+        # Detect and mark outliers on wall time.
+        outlier_flags = detect_outliers(wall_times)
+        for it, is_outlier in zip(measured, outlier_flags):
+            it.outlier = is_outlier
+
+        self.wall_time_stats = describe(wall_times)
+        self.user_time_stats = describe(user_times)
+        self.sys_time_stats = describe(sys_times)
+        self.peak_rss_stats = describe(rss_values)
+
+    @property
+    def measured_iterations(self) -> list[BenchIteration]:
+        """Non-warmup iterations."""
+        return [it for it in self.iterations if not it.warmup]
+
+    @property
+    def wall_times(self) -> list[float]:
+        """Wall times from measured iterations."""
+        return [it.wall_time_s for it in self.measured_iterations]
+
+    @property
+    def n_outliers(self) -> int:
+        """Number of measured iterations flagged as outliers."""
+        return sum(1 for it in self.measured_iterations if it.outlier)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        d: dict[str, Any] = {
+            "condition_name": self.condition_name,
+            "iterations": [it.to_dict() for it in self.iterations],
+            "install_duration_s": round(self.install_duration_s, 2),
+            "venv_setup_duration_s": round(self.venv_setup_duration_s, 2),
+        }
+        if self.wall_time_stats:
+            d["wall_time_stats"] = self.wall_time_stats.to_dict()
+        if self.user_time_stats:
+            d["user_time_stats"] = self.user_time_stats.to_dict()
+        if self.sys_time_stats:
+            d["sys_time_stats"] = self.sys_time_stats.to_dict()
+        if self.peak_rss_stats:
+            d["peak_rss_stats"] = self.peak_rss_stats.to_dict()
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BenchConditionResult:
+        """Deserialize from a dict.  Recomputes stats for consistency."""
+        result = cls(condition_name=data["condition_name"])
+        result.iterations = [BenchIteration.from_dict(it) for it in data.get("iterations", [])]
+        result.install_duration_s = data.get("install_duration_s", 0.0)
+        result.venv_setup_duration_s = data.get("venv_setup_duration_s", 0.0)
+        # Recompute stats rather than deserializing — ensures consistency.
+        result.compute_stats()
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Package-level result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchPackageResult:
+    """Benchmark results for one package across all conditions."""
+
+    package: str
+    conditions: dict[str, BenchConditionResult] = field(default_factory=dict)
+    clone_duration_s: float = 0.0
+    skipped: bool = False
+    skip_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "package": self.package,
+            "conditions": {name: cond.to_dict() for name, cond in self.conditions.items()},
+            "clone_duration_s": round(self.clone_duration_s, 2),
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BenchPackageResult:
+        """Deserialize from a dict."""
+        result = cls(
+            package=data["package"],
+            clone_duration_s=data.get("clone_duration_s", 0.0),
+            skipped=data.get("skipped", False),
+            skip_reason=data.get("skip_reason", ""),
+        )
+        for name, cond_data in data.get("conditions", {}).items():
+            result.conditions[name] = BenchConditionResult.from_dict(cond_data)
+        return result
+
+    def to_jsonl_line(self) -> str:
+        """Serialize to a single JSONL line."""
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+    @classmethod
+    def from_jsonl_line(cls, line: str) -> BenchPackageResult:
+        """Deserialize from a single JSONL line."""
+        return cls.from_dict(json.loads(line))
+
+
+# ---------------------------------------------------------------------------
+# Condition definition (for bench_meta.json)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConditionDef:
+    """Definition of a benchmark condition (stored in metadata)."""
+
+    name: str
+    description: str = ""
+    target_python: str = ""
+    env: dict[str, str] = field(default_factory=dict)
+    extra_deps: list[str] = field(default_factory=list)
+    test_command_override: str | None = None
+    test_command_prefix: str | None = None
+    test_command_suffix: str | None = None
+    install_command: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (sparse: omits defaults)."""
+        d: dict[str, Any] = {"name": self.name}
+        if self.description:
+            d["description"] = self.description
+        if self.target_python:
+            d["target_python"] = self.target_python
+        if self.env:
+            d["env"] = self.env
+        if self.extra_deps:
+            d["extra_deps"] = self.extra_deps
+        if self.test_command_override:
+            d["test_command_override"] = self.test_command_override
+        if self.test_command_prefix:
+            d["test_command_prefix"] = self.test_command_prefix
+        if self.test_command_suffix:
+            d["test_command_suffix"] = self.test_command_suffix
+        if self.install_command:
+            d["install_command"] = self.install_command
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConditionDef:
+        """Deserialize from a dict."""
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            target_python=data.get("target_python", ""),
+            env=data.get("env", {}),
+            extra_deps=data.get("extra_deps", []),
+            test_command_override=data.get("test_command_override"),
+            test_command_prefix=data.get("test_command_prefix"),
+            test_command_suffix=data.get("test_command_suffix"),
+            install_command=data.get("install_command"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run-level metadata
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchMeta:
+    """Metadata for a complete benchmark run."""
+
+    bench_id: str
+    name: str = ""
+    description: str = ""
+    system: SystemProfile = field(default_factory=SystemProfile)
+    python_profiles: dict[str, PythonProfile] = field(default_factory=dict)
+    conditions: dict[str, ConditionDef] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
+    cli_args: list[str] = field(default_factory=list)
+    start_time: str = ""
+    end_time: str = ""
+    packages_total: int = 0
+    packages_completed: int = 0
+    packages_skipped: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "bench_id": self.bench_id,
+            "name": self.name,
+            "description": self.description,
+            "system": self.system.to_dict(),
+            "python_profiles": {name: pp.to_dict() for name, pp in self.python_profiles.items()},
+            "conditions": {name: cond.to_dict() for name, cond in self.conditions.items()},
+            "config": self.config,
+            "cli_args": self.cli_args,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "packages_total": self.packages_total,
+            "packages_completed": self.packages_completed,
+            "packages_skipped": self.packages_skipped,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BenchMeta:
+        """Deserialize from a dict."""
+        meta = cls(bench_id=data["bench_id"])
+        meta.name = data.get("name", "")
+        meta.description = data.get("description", "")
+        meta.system = SystemProfile.from_dict(data.get("system", {}))
+        meta.python_profiles = {
+            name: PythonProfile.from_dict(pp)
+            for name, pp in data.get("python_profiles", {}).items()
+        }
+        meta.conditions = {
+            name: ConditionDef.from_dict(cond) for name, cond in data.get("conditions", {}).items()
+        }
+        meta.config = data.get("config", {})
+        meta.cli_args = data.get("cli_args", [])
+        meta.start_time = data.get("start_time", "")
+        meta.end_time = data.get("end_time", "")
+        meta.packages_total = data.get("packages_total", 0)
+        meta.packages_completed = data.get("packages_completed", 0)
+        meta.packages_skipped = data.get("packages_skipped", 0)
+        return meta
+
+
+# ---------------------------------------------------------------------------
+# I/O functions
+# ---------------------------------------------------------------------------
+
+
+def save_bench_run(
+    output_dir: Path,
+    meta: BenchMeta,
+    results: list[BenchPackageResult],
+) -> None:
+    """Save a complete benchmark run to disk.
+
+    Creates ``output_dir/bench_meta.json`` and
+    ``output_dir/bench_results.jsonl``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    meta_path = output_dir / "bench_meta.json"
+    meta_path.write_text(json.dumps(meta.to_dict(), indent=2) + "\n")
+    log.info("Wrote %s", meta_path)
+
+    results_path = output_dir / "bench_results.jsonl"
+    with open(results_path, "w") as f:
+        for result in results:
+            f.write(result.to_jsonl_line() + "\n")
+    log.info("Wrote %d package results to %s", len(results), results_path)
+
+
+def load_bench_run(
+    run_dir: Path,
+) -> tuple[BenchMeta, list[BenchPackageResult]]:
+    """Load a benchmark run from disk.
+
+    Args:
+        run_dir: Directory containing ``bench_meta.json`` and
+            ``bench_results.jsonl``.
+
+    Returns:
+        Tuple of (BenchMeta, list of BenchPackageResult).
+
+    Raises:
+        FileNotFoundError: If ``bench_meta.json`` is missing.
+    """
+    meta_path = run_dir / "bench_meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No bench_meta.json in {run_dir}")
+
+    meta = BenchMeta.from_dict(json.loads(meta_path.read_text()))
+
+    results: list[BenchPackageResult] = []
+    results_path = run_dir / "bench_results.jsonl"
+    if results_path.exists():
+        for line in results_path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                results.append(BenchPackageResult.from_jsonl_line(line))
+
+    return meta, results
+
+
+def append_package_result(
+    results_path: Path,
+    result: BenchPackageResult,
+) -> None:
+    """Append a single package result to the JSONL file.
+
+    Used for incremental writing during long benchmark runs so
+    that results are preserved if the process is interrupted.
+    """
+    with open(results_path, "a") as f:
+        f.write(result.to_jsonl_line() + "\n")

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -1,0 +1,250 @@
+"""Timing capture for benchmark iterations.
+
+Measures wall-clock time, user CPU time, system CPU time, and peak
+resident set size for subprocess executions.  Uses resource.getrusage
+for CPU times and ``/usr/bin/time -v`` for per-process peak RSS.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import resource
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# TimedResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TimedResult:
+    """Result of a timed subprocess execution."""
+
+    wall_time_s: float
+    user_time_s: float
+    sys_time_s: float
+    peak_rss_mb: float
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+    @property
+    def cpu_time_s(self) -> float:
+        """Total CPU time (user + system)."""
+        return self.user_time_s + self.sys_time_s
+
+
+# ---------------------------------------------------------------------------
+# Core timing implementation
+# ---------------------------------------------------------------------------
+
+
+def run_timed(
+    command: str | list[str],
+    *,
+    cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 600,
+    use_time_wrapper: bool = True,
+) -> TimedResult:
+    """Execute a command and capture timing and resource usage.
+
+    Args:
+        command: Shell command string or argument list.
+        cwd: Working directory for the subprocess.
+        env: Environment variables for the subprocess.
+        timeout: Maximum execution time in seconds.
+        use_time_wrapper: If True and ``/usr/bin/time`` exists, wrap
+            the command to get accurate per-invocation peak RSS.
+
+    Returns:
+        TimedResult with timing data and process output.
+    """
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+
+    # Determine if we can use /usr/bin/time for RSS measurement.
+    time_output_file: str | None = None
+    if use_time_wrapper and Path("/usr/bin/time").exists():
+        import tempfile
+
+        fd, time_output_file = tempfile.mkstemp(
+            prefix="labeille-time-",
+            suffix=".txt",
+        )
+        os.close(fd)
+        # GNU time with verbose output to a file.
+        if isinstance(command, str):
+            cmd_str = command
+        else:
+            cmd_str = " ".join(shlex.quote(c) for c in command)
+        command = (
+            f"/usr/bin/time -v -o {shlex.quote(time_output_file)} sh -c {shlex.quote(cmd_str)}"
+        )
+
+    # Snapshot children's resource usage before.
+    pre_rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    wall_start = time.monotonic()
+
+    timed_out = False
+    proc = subprocess.Popen(
+        command if isinstance(command, list) else command,
+        shell=isinstance(command, str),
+        cwd=str(cwd) if cwd else None,
+        env=run_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _kill_process_group(proc.pid)
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+        exit_code = -1
+
+    wall_time = time.monotonic() - wall_start
+
+    # Snapshot children's resource usage after.
+    post_rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+    user_time = post_rusage.ru_utime - pre_rusage.ru_utime
+    sys_time = post_rusage.ru_stime - pre_rusage.ru_stime
+
+    # Peak RSS.
+    peak_rss_mb = _extract_peak_rss(time_output_file, pre_rusage, post_rusage)
+
+    return TimedResult(
+        wall_time_s=round(wall_time, 6),
+        user_time_s=round(max(user_time, 0.0), 6),
+        sys_time_s=round(max(sys_time, 0.0), 6),
+        peak_rss_mb=round(peak_rss_mb, 1),
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        timed_out=timed_out,
+    )
+
+
+def _kill_process_group(pid: int) -> None:
+    """Attempt to kill the entire process group on timeout."""
+    import signal
+
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def _extract_peak_rss(
+    time_output_file: str | None,
+    pre_rusage: resource.struct_rusage,
+    post_rusage: resource.struct_rusage,
+) -> float:
+    """Extract peak RSS from GNU time output or rusage fallback.
+
+    Returns peak RSS in megabytes.
+    """
+    if time_output_file is not None:
+        rss = _parse_gnu_time_rss(time_output_file)
+        try:
+            os.unlink(time_output_file)
+        except OSError:
+            pass
+        if rss > 0:
+            return rss
+
+    # Fallback: delta in ru_maxrss.  On Linux, ru_maxrss is in KB.
+    # On macOS, ru_maxrss is in bytes.
+    import sys
+
+    divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
+    rss_delta = post_rusage.ru_maxrss - pre_rusage.ru_maxrss
+    if rss_delta > 0:
+        return rss_delta / divisor
+    # Can't determine per-iteration RSS; report the cumulative.
+    return post_rusage.ru_maxrss / divisor
+
+
+def _parse_gnu_time_rss(time_output_file: str) -> float:
+    """Parse peak RSS from GNU time verbose output.
+
+    GNU ``time -v`` outputs a line like::
+
+        Maximum resident set size (kbytes): 123456
+
+    Returns peak RSS in MB, or 0.0 if parsing fails.
+    """
+    try:
+        content = Path(time_output_file).read_text()
+        for line in content.splitlines():
+            if "Maximum resident set size" in line:
+                parts = line.split(":")
+                if len(parts) >= 2:
+                    kb = int(parts[-1].strip())
+                    return kb / 1024
+    except Exception:  # noqa: BLE001
+        pass
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Venv-aware execution helper
+# ---------------------------------------------------------------------------
+
+
+def run_timed_in_venv(
+    venv_path: Path,
+    test_command: str,
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    timeout: int = 600,
+) -> TimedResult:
+    """Execute a test command inside a virtual environment.
+
+    Sets up ``PATH`` and ``VIRTUAL_ENV`` so the venv's Python and
+    installed tools are used.
+
+    Args:
+        venv_path: Path to the virtual environment root.
+        test_command: The test command to run (e.g. ``python -m pytest``).
+        cwd: Working directory (typically the package repo).
+        env: Additional environment variables.
+        timeout: Maximum execution time in seconds.
+    """
+    venv_bin = venv_path / "bin"
+    run_env: dict[str, str] = {
+        "PATH": f"{venv_bin}:{os.environ.get('PATH', '')}",
+        "VIRTUAL_ENV": str(venv_path),
+        "HOME": os.environ.get("HOME", "/root"),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        # Ensure Python doesn't pick up host site-packages.
+        "PYTHONNOUSERSITE": "1",
+    }
+    if env:
+        run_env.update(env)
+
+    return run_timed(
+        test_command,
+        cwd=cwd,
+        env=run_env,
+        timeout=timeout,
+    )

--- a/tests/test_bench_results.py
+++ b/tests/test_bench_results.py
@@ -1,0 +1,550 @@
+"""Tests for labeille.bench.results — benchmark result structures and I/O."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from labeille.bench.results import (
+    BenchConditionResult,
+    BenchIteration,
+    BenchMeta,
+    BenchPackageResult,
+    ConditionDef,
+    append_package_result,
+    load_bench_run,
+    save_bench_run,
+)
+from labeille.bench.system import PythonProfile, SystemProfile
+
+
+# ---------------------------------------------------------------------------
+# BenchIteration tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchIteration(unittest.TestCase):
+    """Tests for BenchIteration dataclass."""
+
+    def _make_iteration(self, **kwargs: object) -> BenchIteration:
+        """Create a BenchIteration with sensible defaults."""
+        defaults: dict[str, object] = {
+            "index": 1,
+            "warmup": False,
+            "wall_time_s": 1.5,
+            "user_time_s": 1.2,
+            "sys_time_s": 0.1,
+            "peak_rss_mb": 120.5,
+            "exit_code": 0,
+            "status": "ok",
+            "outlier": False,
+            "load_avg_start": 0.5,
+            "load_avg_end": 0.6,
+            "ram_available_start_gb": 8.0,
+        }
+        defaults.update(kwargs)
+        return BenchIteration(**defaults)  # type: ignore[arg-type]
+
+    def test_iteration_to_dict_roundtrip(self) -> None:
+        """to_dict → from_dict should preserve all fields."""
+        it = self._make_iteration()
+        d = it.to_dict()
+        restored = BenchIteration.from_dict(d)
+        self.assertEqual(restored.index, it.index)
+        self.assertEqual(restored.warmup, it.warmup)
+        self.assertAlmostEqual(restored.wall_time_s, it.wall_time_s, places=5)
+        self.assertAlmostEqual(restored.user_time_s, it.user_time_s, places=5)
+        self.assertAlmostEqual(restored.sys_time_s, it.sys_time_s, places=5)
+        self.assertAlmostEqual(restored.peak_rss_mb, it.peak_rss_mb, places=0)
+        self.assertEqual(restored.exit_code, it.exit_code)
+        self.assertEqual(restored.status, it.status)
+        self.assertEqual(restored.outlier, it.outlier)
+
+    def test_iteration_roundtrip_preserves_types(self) -> None:
+        """Types should survive a roundtrip through dict."""
+        it = self._make_iteration()
+        d = it.to_dict()
+        restored = BenchIteration.from_dict(d)
+        self.assertIsInstance(restored.index, int)
+        self.assertIsInstance(restored.warmup, bool)
+        self.assertIsInstance(restored.wall_time_s, float)
+        self.assertIsInstance(restored.exit_code, int)
+        self.assertIsInstance(restored.status, str)
+
+    def test_iteration_from_dict_ignores_unknown_fields(self) -> None:
+        """Unknown keys should be silently dropped."""
+        d = {
+            "index": 1,
+            "warmup": False,
+            "wall_time_s": 1.0,
+            "user_time_s": 0.5,
+            "sys_time_s": 0.1,
+            "peak_rss_mb": 50.0,
+            "exit_code": 0,
+            "status": "ok",
+            "future_field": "ignored",
+        }
+        it = BenchIteration.from_dict(d)
+        self.assertEqual(it.index, 1)
+        self.assertFalse(hasattr(it, "future_field"))
+
+
+# ---------------------------------------------------------------------------
+# BenchConditionResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchConditionResult(unittest.TestCase):
+    """Tests for BenchConditionResult dataclass."""
+
+    def _make_iteration(self, index: int, wall: float, warmup: bool = False) -> BenchIteration:
+        return BenchIteration(
+            index=index,
+            warmup=warmup,
+            wall_time_s=wall,
+            user_time_s=wall * 0.8,
+            sys_time_s=wall * 0.1,
+            peak_rss_mb=100.0,
+            exit_code=0,
+            status="ok",
+        )
+
+    def test_condition_compute_stats(self) -> None:
+        """Stats should be computed from non-warmup iterations."""
+        cond = BenchConditionResult(condition_name="baseline")
+        for i in range(1, 6):
+            cond.iterations.append(self._make_iteration(i, float(i)))
+        cond.compute_stats()
+        self.assertIsNotNone(cond.wall_time_stats)
+        assert cond.wall_time_stats is not None
+        self.assertEqual(cond.wall_time_stats.n, 5)
+        self.assertAlmostEqual(cond.wall_time_stats.mean, 3.0, places=5)
+        self.assertAlmostEqual(cond.wall_time_stats.median, 3.0, places=5)
+
+    def test_condition_warmup_excluded(self) -> None:
+        """Warmup iterations should not affect stats."""
+        cond = BenchConditionResult(condition_name="baseline")
+        # 2 warmup + 3 measured
+        cond.iterations.append(self._make_iteration(1, 100.0, warmup=True))
+        cond.iterations.append(self._make_iteration(2, 200.0, warmup=True))
+        cond.iterations.append(self._make_iteration(3, 1.0))
+        cond.iterations.append(self._make_iteration(4, 2.0))
+        cond.iterations.append(self._make_iteration(5, 3.0))
+        cond.compute_stats()
+        assert cond.wall_time_stats is not None
+        self.assertEqual(cond.wall_time_stats.n, 3)
+        self.assertAlmostEqual(cond.wall_time_stats.mean, 2.0, places=5)
+
+    def test_condition_outlier_detection(self) -> None:
+        """An extreme wall time should be flagged as an outlier."""
+        cond = BenchConditionResult(condition_name="baseline")
+        for i in range(1, 6):
+            cond.iterations.append(self._make_iteration(i, 1.0))
+        # Add an extreme value
+        cond.iterations.append(self._make_iteration(6, 100.0))
+        cond.compute_stats()
+        measured = cond.measured_iterations
+        outlier_flags = [it.outlier for it in measured]
+        self.assertTrue(outlier_flags[-1])  # 100.0 is an outlier
+
+    def test_condition_measured_iterations_property(self) -> None:
+        """measured_iterations should filter out warmup."""
+        cond = BenchConditionResult(condition_name="test")
+        cond.iterations.append(self._make_iteration(1, 1.0, warmup=True))
+        cond.iterations.append(self._make_iteration(2, 2.0))
+        cond.iterations.append(self._make_iteration(3, 3.0))
+        self.assertEqual(len(cond.measured_iterations), 2)
+
+    def test_condition_wall_times_property(self) -> None:
+        """wall_times should return a list of floats."""
+        cond = BenchConditionResult(condition_name="test")
+        cond.iterations.append(self._make_iteration(1, 1.5))
+        cond.iterations.append(self._make_iteration(2, 2.5))
+        self.assertEqual(cond.wall_times, [1.5, 2.5])
+
+    def test_condition_n_outliers_property(self) -> None:
+        """n_outliers should count correctly after compute_stats."""
+        cond = BenchConditionResult(condition_name="test")
+        for i in range(1, 6):
+            cond.iterations.append(self._make_iteration(i, 1.0))
+        cond.iterations.append(self._make_iteration(6, 100.0))
+        cond.compute_stats()
+        self.assertGreater(cond.n_outliers, 0)
+
+    def test_condition_serialization_roundtrip(self) -> None:
+        """to_dict → from_dict should preserve structure and recompute stats."""
+        cond = BenchConditionResult(condition_name="jit_on")
+        cond.install_duration_s = 5.5
+        cond.venv_setup_duration_s = 2.3
+        for i in range(1, 4):
+            cond.iterations.append(self._make_iteration(i, float(i)))
+        cond.compute_stats()
+
+        d = cond.to_dict()
+        restored = BenchConditionResult.from_dict(d)
+        self.assertEqual(restored.condition_name, "jit_on")
+        self.assertEqual(len(restored.iterations), 3)
+        self.assertAlmostEqual(restored.install_duration_s, 5.5, places=1)
+        self.assertAlmostEqual(restored.venv_setup_duration_s, 2.3, places=1)
+        # Stats should be recomputed.
+        self.assertIsNotNone(restored.wall_time_stats)
+
+    def test_condition_empty_iterations(self) -> None:
+        """compute_stats with no iterations should not crash."""
+        cond = BenchConditionResult(condition_name="empty")
+        cond.compute_stats()
+        self.assertIsNone(cond.wall_time_stats)
+        self.assertIsNone(cond.user_time_stats)
+
+    def test_condition_only_warmup_iterations(self) -> None:
+        """compute_stats with only warmup iterations leaves stats as None."""
+        cond = BenchConditionResult(condition_name="warmup_only")
+        cond.iterations.append(self._make_iteration(1, 1.0, warmup=True))
+        cond.iterations.append(self._make_iteration(2, 2.0, warmup=True))
+        cond.compute_stats()
+        self.assertIsNone(cond.wall_time_stats)
+
+
+# ---------------------------------------------------------------------------
+# BenchPackageResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchPackageResult(unittest.TestCase):
+    """Tests for BenchPackageResult dataclass."""
+
+    def _make_condition(self, name: str, n_iters: int = 3) -> BenchConditionResult:
+        cond = BenchConditionResult(condition_name=name)
+        for i in range(1, n_iters + 1):
+            cond.iterations.append(
+                BenchIteration(
+                    index=i,
+                    warmup=False,
+                    wall_time_s=float(i),
+                    user_time_s=float(i) * 0.8,
+                    sys_time_s=float(i) * 0.1,
+                    peak_rss_mb=100.0,
+                    exit_code=0,
+                    status="ok",
+                )
+            )
+        cond.compute_stats()
+        return cond
+
+    def test_package_result_to_dict_roundtrip(self) -> None:
+        """Two conditions should survive a roundtrip."""
+        pkg = BenchPackageResult(package="requests", clone_duration_s=1.5)
+        pkg.conditions["baseline"] = self._make_condition("baseline")
+        pkg.conditions["jit"] = self._make_condition("jit")
+
+        d = pkg.to_dict()
+        restored = BenchPackageResult.from_dict(d)
+        self.assertEqual(restored.package, "requests")
+        self.assertAlmostEqual(restored.clone_duration_s, 1.5, places=1)
+        self.assertIn("baseline", restored.conditions)
+        self.assertIn("jit", restored.conditions)
+        self.assertEqual(len(restored.conditions["baseline"].iterations), 3)
+
+    def test_package_result_jsonl_roundtrip(self) -> None:
+        """JSONL serialization should preserve all fields."""
+        pkg = BenchPackageResult(package="click", clone_duration_s=2.0)
+        pkg.conditions["baseline"] = self._make_condition("baseline", n_iters=2)
+
+        line = pkg.to_jsonl_line()
+        restored = BenchPackageResult.from_jsonl_line(line)
+        self.assertEqual(restored.package, "click")
+        self.assertAlmostEqual(restored.clone_duration_s, 2.0, places=1)
+        self.assertEqual(len(restored.conditions["baseline"].iterations), 2)
+
+    def test_package_result_skipped(self) -> None:
+        """Skipped packages should roundtrip correctly."""
+        pkg = BenchPackageResult(
+            package="numpy",
+            skipped=True,
+            skip_reason="no repo",
+        )
+        d = pkg.to_dict()
+        restored = BenchPackageResult.from_dict(d)
+        self.assertTrue(restored.skipped)
+        self.assertEqual(restored.skip_reason, "no repo")
+
+
+# ---------------------------------------------------------------------------
+# ConditionDef tests
+# ---------------------------------------------------------------------------
+
+
+class TestConditionDef(unittest.TestCase):
+    """Tests for ConditionDef dataclass."""
+
+    def test_condition_def_to_dict_minimal(self) -> None:
+        """Minimal condition should only have 'name' key."""
+        cond = ConditionDef(name="baseline")
+        d = cond.to_dict()
+        self.assertEqual(d, {"name": "baseline"})
+
+    def test_condition_def_to_dict_full(self) -> None:
+        """All fields set should all be present in dict."""
+        cond = ConditionDef(
+            name="jit_on",
+            description="With JIT enabled",
+            target_python="/usr/bin/python3.15",
+            env={"PYTHON_JIT": "1"},
+            extra_deps=["coverage"],
+            test_command_override="coverage run -m pytest",
+            test_command_prefix="nice -n 19",
+            test_command_suffix="-v --tb=short",
+            install_command="pip install -e .",
+        )
+        d = cond.to_dict()
+        self.assertEqual(d["name"], "jit_on")
+        self.assertEqual(d["description"], "With JIT enabled")
+        self.assertEqual(d["target_python"], "/usr/bin/python3.15")
+        self.assertEqual(d["env"], {"PYTHON_JIT": "1"})
+        self.assertEqual(d["extra_deps"], ["coverage"])
+        self.assertEqual(d["test_command_override"], "coverage run -m pytest")
+        self.assertEqual(d["test_command_prefix"], "nice -n 19")
+        self.assertEqual(d["test_command_suffix"], "-v --tb=short")
+        self.assertEqual(d["install_command"], "pip install -e .")
+
+    def test_condition_def_roundtrip(self) -> None:
+        """from_dict(to_dict(x)) should produce equivalent object."""
+        cond = ConditionDef(
+            name="test",
+            description="A test condition",
+            env={"FOO": "bar"},
+            extra_deps=["dep1", "dep2"],
+        )
+        d = cond.to_dict()
+        restored = ConditionDef.from_dict(d)
+        self.assertEqual(restored.name, cond.name)
+        self.assertEqual(restored.description, cond.description)
+        self.assertEqual(restored.env, cond.env)
+        self.assertEqual(restored.extra_deps, cond.extra_deps)
+        self.assertIsNone(restored.test_command_override)
+
+
+# ---------------------------------------------------------------------------
+# BenchMeta tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchMeta(unittest.TestCase):
+    """Tests for BenchMeta dataclass."""
+
+    def test_meta_roundtrip(self) -> None:
+        """Full BenchMeta should survive a to_dict/from_dict roundtrip."""
+        meta = BenchMeta(
+            bench_id="bench-20260227-001",
+            name="JIT overhead",
+            description="Measure JIT overhead on top-50 packages",
+            config={"iterations": 5, "warmup": 1},
+            cli_args=["bench", "--iterations", "5"],
+            start_time="2026-02-27T10:00:00",
+            end_time="2026-02-27T12:00:00",
+            packages_total=50,
+            packages_completed=48,
+            packages_skipped=2,
+        )
+        meta.conditions["baseline"] = ConditionDef(
+            name="baseline",
+            description="Without JIT",
+            env={"PYTHON_JIT": "0"},
+        )
+        meta.conditions["jit"] = ConditionDef(
+            name="jit",
+            description="With JIT",
+            env={"PYTHON_JIT": "1"},
+        )
+
+        d = meta.to_dict()
+        restored = BenchMeta.from_dict(d)
+        self.assertEqual(restored.bench_id, "bench-20260227-001")
+        self.assertEqual(restored.name, "JIT overhead")
+        self.assertEqual(restored.packages_total, 50)
+        self.assertEqual(restored.packages_completed, 48)
+        self.assertIn("baseline", restored.conditions)
+        self.assertIn("jit", restored.conditions)
+
+    def test_meta_with_python_profiles(self) -> None:
+        """PythonProfile entries should survive roundtrip."""
+        meta = BenchMeta(bench_id="test-001")
+        meta.python_profiles["baseline"] = PythonProfile(
+            path="/usr/bin/python3.15",
+            version="3.15.0a4",
+            implementation="CPython",
+            jit_enabled=False,
+        )
+        meta.python_profiles["jit"] = PythonProfile(
+            path="/usr/bin/python3.15",
+            version="3.15.0a4",
+            implementation="CPython",
+            jit_enabled=True,
+        )
+
+        d = meta.to_dict()
+        restored = BenchMeta.from_dict(d)
+        self.assertIn("baseline", restored.python_profiles)
+        self.assertIn("jit", restored.python_profiles)
+        self.assertFalse(restored.python_profiles["baseline"].jit_enabled)
+        self.assertTrue(restored.python_profiles["jit"].jit_enabled)
+
+    def test_meta_with_system_profile(self) -> None:
+        """SystemProfile should survive roundtrip."""
+        meta = BenchMeta(bench_id="test-002")
+        meta.system = SystemProfile(
+            cpu_model="Intel Core i9",
+            cpu_cores_physical=8,
+            ram_total_gb=32.0,
+        )
+
+        d = meta.to_dict()
+        restored = BenchMeta.from_dict(d)
+        self.assertEqual(restored.system.cpu_model, "Intel Core i9")
+        self.assertEqual(restored.system.cpu_cores_physical, 8)
+        self.assertAlmostEqual(restored.system.ram_total_gb, 32.0, places=1)
+
+    def test_meta_defaults(self) -> None:
+        """Default values should be sane."""
+        meta = BenchMeta(bench_id="minimal")
+        d = meta.to_dict()
+        self.assertEqual(d["bench_id"], "minimal")
+        self.assertEqual(d["name"], "")
+        self.assertEqual(d["packages_total"], 0)
+        self.assertEqual(d["conditions"], {})
+        self.assertEqual(d["python_profiles"], {})
+
+
+# ---------------------------------------------------------------------------
+# I/O tests
+# ---------------------------------------------------------------------------
+
+
+class TestIO(unittest.TestCase):
+    """Tests for save_bench_run, load_bench_run, append_package_result."""
+
+    def _make_package_result(self, name: str) -> BenchPackageResult:
+        """Create a BenchPackageResult with one condition and iterations."""
+        cond = BenchConditionResult(condition_name="baseline")
+        for i in range(1, 4):
+            cond.iterations.append(
+                BenchIteration(
+                    index=i,
+                    warmup=(i == 1),
+                    wall_time_s=float(i),
+                    user_time_s=float(i) * 0.8,
+                    sys_time_s=float(i) * 0.1,
+                    peak_rss_mb=100.0,
+                    exit_code=0,
+                    status="ok",
+                )
+            )
+        cond.compute_stats()
+        pkg = BenchPackageResult(package=name, clone_duration_s=1.0)
+        pkg.conditions["baseline"] = cond
+        return pkg
+
+    def test_save_and_load_bench_run(self) -> None:
+        """Save and load should produce equivalent data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "bench-001"
+            meta = BenchMeta(
+                bench_id="bench-001",
+                name="Test run",
+                packages_total=2,
+                packages_completed=2,
+            )
+            results = [
+                self._make_package_result("requests"),
+                self._make_package_result("click"),
+            ]
+
+            save_bench_run(out_dir, meta, results)
+
+            # Verify files exist.
+            self.assertTrue((out_dir / "bench_meta.json").exists())
+            self.assertTrue((out_dir / "bench_results.jsonl").exists())
+
+            loaded_meta, loaded_results = load_bench_run(out_dir)
+            self.assertEqual(loaded_meta.bench_id, "bench-001")
+            self.assertEqual(loaded_meta.name, "Test run")
+            self.assertEqual(len(loaded_results), 2)
+            self.assertEqual(loaded_results[0].package, "requests")
+            self.assertEqual(loaded_results[1].package, "click")
+
+    def test_load_missing_dir(self) -> None:
+        """Loading from a nonexistent directory should raise."""
+        with self.assertRaises(FileNotFoundError):
+            load_bench_run(Path("/nonexistent/bench-dir"))
+
+    def test_append_package_result(self) -> None:
+        """Appending results should produce valid JSONL lines."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results_path = Path(tmpdir) / "bench_results.jsonl"
+            append_package_result(results_path, self._make_package_result("flask"))
+            append_package_result(results_path, self._make_package_result("django"))
+
+            lines = results_path.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 2)
+
+            pkg1 = BenchPackageResult.from_jsonl_line(lines[0])
+            pkg2 = BenchPackageResult.from_jsonl_line(lines[1])
+            self.assertEqual(pkg1.package, "flask")
+            self.assertEqual(pkg2.package, "django")
+
+    def test_incremental_write_readable(self) -> None:
+        """save_bench_run then append_package_result should all load."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "bench-inc"
+            meta = BenchMeta(bench_id="bench-inc", packages_total=3)
+            initial_results = [self._make_package_result("requests")]
+
+            save_bench_run(out_dir, meta, initial_results)
+
+            # Append a second result incrementally.
+            results_path = out_dir / "bench_results.jsonl"
+            append_package_result(results_path, self._make_package_result("click"))
+
+            loaded_meta, loaded_results = load_bench_run(out_dir)
+            self.assertEqual(loaded_meta.bench_id, "bench-inc")
+            self.assertEqual(len(loaded_results), 2)
+            self.assertEqual(loaded_results[0].package, "requests")
+            self.assertEqual(loaded_results[1].package, "click")
+
+    def test_save_creates_directories(self) -> None:
+        """save_bench_run should create parent directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deep_dir = Path(tmpdir) / "a" / "b" / "c"
+            meta = BenchMeta(bench_id="deep")
+            save_bench_run(deep_dir, meta, [])
+            self.assertTrue((deep_dir / "bench_meta.json").exists())
+
+    def test_load_empty_results(self) -> None:
+        """Loading with no JSONL file should return empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "bench-empty"
+            meta = BenchMeta(bench_id="empty")
+            save_bench_run(out_dir, meta, [])
+
+            loaded_meta, loaded_results = load_bench_run(out_dir)
+            self.assertEqual(loaded_meta.bench_id, "empty")
+            self.assertEqual(len(loaded_results), 0)
+
+    def test_meta_json_is_valid(self) -> None:
+        """bench_meta.json should be valid, pretty-printed JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "bench-json"
+            meta = BenchMeta(bench_id="json-test", name="Pretty")
+            save_bench_run(out_dir, meta, [])
+
+            content = (out_dir / "bench_meta.json").read_text()
+            parsed = json.loads(content)
+            self.assertEqual(parsed["bench_id"], "json-test")
+            # Should be indented (pretty-printed).
+            self.assertIn("\n", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_timing.py
+++ b/tests/test_bench_timing.py
@@ -1,0 +1,241 @@
+"""Tests for labeille.bench.timing — timing capture for benchmark iterations."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+import venv
+from pathlib import Path
+
+from labeille.bench.timing import (
+    TimedResult,
+    _parse_gnu_time_rss,
+    run_timed,
+    run_timed_in_venv,
+)
+
+
+# ---------------------------------------------------------------------------
+# TimedResult property tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimedResult(unittest.TestCase):
+    """Tests for TimedResult dataclass."""
+
+    def test_cpu_time_property(self) -> None:
+        """cpu_time_s should be user + system time."""
+        r = TimedResult(
+            wall_time_s=5.0,
+            user_time_s=1.5,
+            sys_time_s=0.5,
+            peak_rss_mb=100.0,
+            exit_code=0,
+            stdout="",
+            stderr="",
+        )
+        self.assertAlmostEqual(r.cpu_time_s, 2.0, places=5)
+
+    def test_cpu_time_zero(self) -> None:
+        """cpu_time_s should be 0 when both components are 0."""
+        r = TimedResult(
+            wall_time_s=1.0,
+            user_time_s=0.0,
+            sys_time_s=0.0,
+            peak_rss_mb=0.0,
+            exit_code=0,
+            stdout="",
+            stderr="",
+        )
+        self.assertAlmostEqual(r.cpu_time_s, 0.0, places=5)
+
+
+# ---------------------------------------------------------------------------
+# run_timed tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunTimed(unittest.TestCase):
+    """Tests for run_timed() function."""
+
+    def test_run_timed_simple_command(self) -> None:
+        """Running 'echo hello' should succeed with output."""
+        result = run_timed("echo hello")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("hello", result.stdout)
+        self.assertGreater(result.wall_time_s, 0)
+
+    def test_run_timed_captures_wall_time(self) -> None:
+        """sleep 0.5 should take approximately 0.5 seconds."""
+        result = run_timed("sleep 0.5", use_time_wrapper=False)
+        self.assertGreater(result.wall_time_s, 0.4)
+        self.assertLess(result.wall_time_s, 2.0)
+
+    def test_run_timed_captures_cpu_time(self) -> None:
+        """A CPU-bound Python script should register user CPU time."""
+        result = run_timed(
+            f"{sys.executable} -c 'sum(range(10**7))'",
+            use_time_wrapper=False,
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertGreater(result.user_time_s, 0)
+
+    def test_run_timed_captures_exit_code(self) -> None:
+        """Non-zero exit code should be captured."""
+        result = run_timed("bash -c 'exit 42'")
+        self.assertEqual(result.exit_code, 42)
+
+    def test_run_timed_timeout(self) -> None:
+        """A command exceeding the timeout should be killed."""
+        result = run_timed("sleep 60", timeout=1, use_time_wrapper=False)
+        self.assertTrue(result.timed_out)
+        self.assertLess(result.wall_time_s, 5.0)
+
+    def test_run_timed_stderr(self) -> None:
+        """stderr output should be captured."""
+        result = run_timed("echo err >&2")
+        self.assertIn("err", result.stderr)
+
+    def test_run_timed_captures_rss(self) -> None:
+        """peak_rss_mb should be greater than zero for any process."""
+        result = run_timed(f"{sys.executable} -c 'pass'")
+        self.assertGreater(result.peak_rss_mb, 0)
+
+    def test_run_timed_without_time_wrapper(self) -> None:
+        """Should still work when time wrapper is disabled."""
+        result = run_timed("echo hello", use_time_wrapper=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("hello", result.stdout)
+        self.assertGreater(result.wall_time_s, 0)
+        self.assertGreater(result.peak_rss_mb, 0)
+
+    def test_run_timed_cwd(self) -> None:
+        """Commands should run in the specified working directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            testfile = Path(tmpdir) / "testfile.txt"
+            testfile.write_text("hello from cwd")
+            result = run_timed("cat testfile.txt", cwd=tmpdir)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("hello from cwd", result.stdout)
+
+    def test_run_timed_env(self) -> None:
+        """Custom environment variables should be passed to the command."""
+        result = run_timed("echo $LABEILLE_TEST_VAR", env={"LABEILLE_TEST_VAR": "bar"})
+        self.assertIn("bar", result.stdout)
+
+    def test_run_timed_list_command(self) -> None:
+        """Command can be passed as a list."""
+        result = run_timed(["echo", "hello", "world"], use_time_wrapper=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("hello world", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# run_timed_in_venv tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunTimedInVenv(unittest.TestCase):
+    """Tests for run_timed_in_venv() function.
+
+    These tests create a real venv and may take a few seconds.
+    """
+
+    _venv_dir: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Create a temporary venv for all tests in this class."""
+        cls._venv_dir = tempfile.mkdtemp(prefix="labeille-test-venv-")
+        venv.create(cls._venv_dir, with_pip=False)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up the temporary venv."""
+        import shutil
+
+        shutil.rmtree(cls._venv_dir, ignore_errors=True)
+
+    def test_run_timed_in_venv_uses_venv_python(self) -> None:
+        """Python should report the venv path as its prefix."""
+        venv_path = Path(self._venv_dir)
+        result = run_timed_in_venv(
+            venv_path,
+            "python -c 'import sys; print(sys.prefix)'",
+            cwd=Path.cwd(),
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(self._venv_dir, result.stdout)
+
+    def test_run_timed_in_venv_isolation(self) -> None:
+        """The Python executable should be inside the venv."""
+        venv_path = Path(self._venv_dir)
+        result = run_timed_in_venv(
+            venv_path,
+            "python -c 'import sys; print(sys.executable)'",
+            cwd=Path.cwd(),
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(self._venv_dir, result.stdout)
+
+    def test_run_timed_in_venv_with_extra_env(self) -> None:
+        """Extra env vars should be passed through."""
+        venv_path = Path(self._venv_dir)
+        result = run_timed_in_venv(
+            venv_path,
+            "python -c 'import os; print(os.environ[\"LABEILLE_FLAG\"])'",
+            cwd=Path.cwd(),
+            env={"LABEILLE_FLAG": "yes"},
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("yes", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# _parse_gnu_time_rss tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseGnuTimeRss(unittest.TestCase):
+    """Tests for _parse_gnu_time_rss() helper."""
+
+    def test_parse_rss_valid(self) -> None:
+        """Should parse a well-formed GNU time output."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(
+                '\tCommand being timed: "sleep 0"\n'
+                "\tUser time (seconds): 0.00\n"
+                "\tSystem time (seconds): 0.00\n"
+                "\tMaximum resident set size (kbytes): 123456\n"
+                "\tMinor (reclaiming a frame) page faults: 100\n"
+            )
+            tmp_path = f.name
+        try:
+            rss_mb = _parse_gnu_time_rss(tmp_path)
+            self.assertAlmostEqual(rss_mb, 123456 / 1024, places=1)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_parse_rss_missing_file(self) -> None:
+        """Missing file should return 0.0."""
+        self.assertAlmostEqual(
+            _parse_gnu_time_rss("/nonexistent/path/file.txt"),
+            0.0,
+            places=5,
+        )
+
+    def test_parse_rss_malformed(self) -> None:
+        """Malformed content should return 0.0."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("this is garbage\nno rss here\n")
+            tmp_path = f.name
+        try:
+            self.assertAlmostEqual(_parse_gnu_time_rss(tmp_path), 0.0, places=5)
+        finally:
+            os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `timing.py` to `bench` subpackage with `run_timed()` and `run_timed_in_venv()` for capturing wall time, CPU time (via `resource.getrusage` delta), and peak RSS (via GNU `/usr/bin/time` with `ru_maxrss` fallback). Uses `Popen` with `start_new_session` for proper process group cleanup on timeout.
- Add `results.py` to `bench` subpackage with `BenchIteration`, `BenchConditionResult`, `BenchPackageResult`, `ConditionDef`, and `BenchMeta` dataclasses for the full benchmark result hierarchy, plus JSONL/JSON serialization via `save_bench_run()`, `load_bench_run()`, and `append_package_result()`.
- 48 new tests across `test_bench_timing.py` and `test_bench_results.py`.

## Test plan
- [x] `ruff format` — clean
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues found in 24 source files
- [x] All 964 tests pass (6 skipped — macOS-only on Linux)
- [x] Quick demo: `run_timed()` captures wall/cpu/rss for a Python computation

Closes #64

Generated with [Claude Code](https://claude.com/claude-code)