### PR TITLE
feat: benchmark configuration and condition profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `DescriptiveStats`, `TTestResult`, `EffectSize`, `BootstrapCI`, and `OverheadResult` dataclasses with scipy fallback for t-test p-values.
 - `timing.py` module in `bench` subpackage with `run_timed()` and `run_timed_in_venv()` for capturing wall time, CPU time (via `resource.getrusage` delta), and peak RSS (via GNU `/usr/bin/time` with `ru_maxrss` fallback).
 - `results.py` module in `bench` subpackage with `BenchIteration`, `BenchConditionResult`, `BenchPackageResult`, `ConditionDef`, and `BenchMeta` dataclasses for the full benchmark result hierarchy, plus JSONL/JSON serialization via `save_bench_run()`, `load_bench_run()`, and `append_package_result()`.
+- `config.py` module in `bench` subpackage with `BenchConfig` dataclass, YAML profile loading, inline condition parsing, test command resolution, environment/deps merging, and configuration validation.
 - `labeille bisect` command to binary-search a package's git history and find the first commit that introduced a crash.
 - `bisect.py` module with `BisectConfig`, `BisectStep`, `BisectResult` dataclasses and the `run_bisect` algorithm with skip-neighbor handling for unbuildable commits.
 - Commit-aware run comparison: `analyze compare` and `analyze run` show git commit changes alongside status changes with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression").

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -1,0 +1,568 @@
+"""Benchmark configuration and condition profile loading.
+
+Handles:
+- Loading benchmark profiles from YAML files.
+- Parsing inline condition definitions from CLI arguments.
+- Merging CLI options with profile defaults.
+- Resolving test commands per condition (override > prefix > suffix > registry).
+- Validating the final configuration before execution.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from labeille.bench.results import ConditionDef
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# BenchConfig
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchConfig:
+    """Resolved configuration for a benchmark run."""
+
+    # Identity
+    bench_id: str = ""  # Auto-generated if empty
+    name: str = ""  # Human-readable name
+    description: str = ""
+
+    # Conditions to compare
+    conditions: dict[str, ConditionDef] = field(default_factory=dict)
+
+    # Iteration control
+    iterations: int = 5  # Number of measured iterations
+    warmup: int = 1  # Number of warm-up iterations
+    timeout: int = 600  # Per-iteration timeout in seconds
+
+    # Execution strategy
+    alternate: bool | None = None  # None = auto (True if multi-condition)
+    interleave: bool = False
+
+    # Package selection (same semantics as labeille run)
+    packages_filter: list[str] | None = None
+    top_n: int | None = None
+    skip_packages: list[str] | None = None
+
+    # Shared options (applied to ALL conditions unless overridden)
+    default_target_python: str = ""
+    default_env: dict[str, str] = field(default_factory=dict)
+    default_extra_deps: list[str] = field(default_factory=list)
+    default_test_command_suffix: str | None = None
+
+    # Paths
+    registry_dir: Path | None = None
+    repos_dir: Path | None = None
+    venvs_dir: Path | None = None
+    results_dir: Path = field(default_factory=lambda: Path("results"))
+
+    # Stability
+    check_stability: bool = False
+    wait_for_stability: bool = False
+    max_load: float = 1.0
+    min_available_ram_gb: float = 2.0
+
+    # CLI provenance
+    cli_args: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.bench_id:
+            self.bench_id = f"bench_{time.strftime('%Y%m%d_%H%M%S')}"
+
+    @property
+    def total_iterations(self) -> int:
+        """Total iterations per package per condition (warmup + measured)."""
+        return self.warmup + self.iterations
+
+    @property
+    def should_alternate(self) -> bool:
+        """Whether to alternate conditions per package."""
+        if self.alternate is not None:
+            return self.alternate
+        # Auto: alternate if there are multiple conditions.
+        return len(self.conditions) > 1
+
+    @property
+    def output_dir(self) -> Path:
+        """The output directory for this benchmark run."""
+        return self.results_dir / self.bench_id
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationError:
+    """A single configuration validation error."""
+
+    field: str
+    message: str
+    severity: str = "error"  # "error" or "warning"
+
+
+def validate_config(config: BenchConfig) -> list[ValidationError]:
+    """Validate a benchmark configuration.
+
+    Returns a list of validation errors.  Empty list means valid.
+    """
+    errors: list[ValidationError] = []
+
+    # Must have at least one condition.
+    if not config.conditions:
+        errors.append(
+            ValidationError(
+                field="conditions",
+                message=(
+                    "No benchmark conditions defined. "
+                    "Use --profile or --condition to define at least one."
+                ),
+            )
+        )
+
+    # Each condition must have a target Python.
+    for name, cond in config.conditions.items():
+        python_path = cond.target_python or config.default_target_python
+        if not python_path:
+            errors.append(
+                ValidationError(
+                    field=f"conditions.{name}.target_python",
+                    message=(
+                        f"Condition '{name}' has no target Python. "
+                        f"Set --target-python or specify it in the condition."
+                    ),
+                )
+            )
+        else:
+            python = Path(python_path)
+            if not python.exists():
+                errors.append(
+                    ValidationError(
+                        field=f"conditions.{name}.target_python",
+                        message=(
+                            f"Target Python for condition '{name}' does not exist: {python_path}"
+                        ),
+                    )
+                )
+            elif not python.is_file():
+                errors.append(
+                    ValidationError(
+                        field=f"conditions.{name}.target_python",
+                        message=(
+                            f"Target Python for condition '{name}' is not a file: {python_path}"
+                        ),
+                    )
+                )
+
+    # Iterations must be >= 3.
+    if config.iterations < 3:
+        errors.append(
+            ValidationError(
+                field="iterations",
+                message=(
+                    f"Need at least 3 measured iterations for "
+                    f"meaningful statistics (got {config.iterations})."
+                ),
+            )
+        )
+
+    # Warmup must be >= 0.
+    if config.warmup < 0:
+        errors.append(
+            ValidationError(
+                field="warmup",
+                message=f"Warmup iterations cannot be negative (got {config.warmup}).",
+            )
+        )
+
+    # Registry dir must exist if specified.
+    if config.registry_dir and not config.registry_dir.exists():
+        errors.append(
+            ValidationError(
+                field="registry_dir",
+                message=f"Registry directory does not exist: {config.registry_dir}",
+            )
+        )
+
+    # Timeout must be positive.
+    if config.timeout <= 0:
+        errors.append(
+            ValidationError(
+                field="timeout",
+                message=f"Timeout must be positive (got {config.timeout}).",
+            )
+        )
+
+    # Interleave and alternate are mutually exclusive.
+    if config.interleave and config.should_alternate:
+        errors.append(
+            ValidationError(
+                field="interleave",
+                message=(
+                    "--interleave and --alternate are mutually exclusive. "
+                    "Choose one execution strategy."
+                ),
+                severity="warning",
+            )
+        )
+
+    # Condition names must be non-empty.
+    for name in config.conditions:
+        if not name or not name.strip():
+            errors.append(
+                ValidationError(
+                    field="conditions",
+                    message="Condition names must be non-empty.",
+                )
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# YAML profile loading
+# ---------------------------------------------------------------------------
+
+
+def load_profile(profile_path: Path) -> dict[str, Any]:
+    """Load a benchmark profile from a YAML file.
+
+    Profile format::
+
+        name: "benchmark name"
+        description: "optional description"
+        iterations: 5
+        warmup: 1
+        timeout: 600
+
+        conditions:
+          baseline:
+            description: "No coverage"
+            target_python: "/usr/bin/python3.15"
+            env:
+              PYTHON_JIT: "1"
+          coverage:
+            description: "With coverage.py"
+            extra_deps: ["coverage"]
+            test_command_prefix: "coverage run -m"
+
+    Returns:
+        The parsed YAML as a dict.
+    """
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(
+            "PyYAML is required for loading benchmark profiles. "
+            "Install it with: pip install pyyaml"
+        ) from exc
+
+    if not profile_path.exists():
+        raise FileNotFoundError(f"Profile not found: {profile_path}")
+
+    text = profile_path.read_text()
+    data = yaml.safe_load(text)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Profile must be a YAML mapping, got {type(data).__name__}")
+
+    return data
+
+
+def config_from_profile(
+    profile_data: dict[str, Any],
+    *,
+    cli_overrides: dict[str, Any] | None = None,
+) -> BenchConfig:
+    """Build a BenchConfig from a parsed YAML profile.
+
+    CLI overrides take precedence over profile values for:
+    iterations, warmup, timeout, target_python, registry_dir,
+    repos_dir, venvs_dir, results_dir, packages_filter.
+
+    Args:
+        profile_data: Parsed YAML profile dict.
+        cli_overrides: Dict of CLI option values that override
+            profile defaults.  Keys match BenchConfig field names.
+
+    Returns:
+        BenchConfig with conditions and settings populated.
+    """
+    cli = cli_overrides or {}
+
+    config = BenchConfig(
+        name=cli.get("name") or profile_data.get("name", ""),
+        description=profile_data.get("description", ""),
+        iterations=(cli.get("iterations") or profile_data.get("iterations", 5)),
+        warmup=(cli["warmup"] if cli.get("warmup") is not None else profile_data.get("warmup", 1)),
+        timeout=cli.get("timeout") or profile_data.get("timeout", 600),
+        default_target_python=(cli.get("target_python") or profile_data.get("target_python", "")),
+    )
+
+    # Parse conditions.
+    conditions_data = profile_data.get("conditions", {})
+    if not isinstance(conditions_data, dict):
+        raise ValueError("Profile 'conditions' must be a mapping of condition_name -> definition")
+
+    for name, cond_data in conditions_data.items():
+        if cond_data is None:
+            cond_data = {}
+        if not isinstance(cond_data, dict):
+            raise ValueError(
+                f"Condition '{name}' must be a mapping, got {type(cond_data).__name__}"
+            )
+
+        config.conditions[name] = ConditionDef(
+            name=name,
+            description=cond_data.get("description", ""),
+            target_python=cond_data.get("target_python", ""),
+            env=cond_data.get("env", {}),
+            extra_deps=cond_data.get("extra_deps", []),
+            test_command_override=cond_data.get("test_command_override"),
+            test_command_prefix=cond_data.get("test_command_prefix"),
+            test_command_suffix=cond_data.get("test_command_suffix"),
+            install_command=cond_data.get("install_command"),
+        )
+
+    # Apply CLI path overrides.
+    if cli.get("registry_dir"):
+        config.registry_dir = Path(cli["registry_dir"])
+    elif profile_data.get("registry_dir"):
+        config.registry_dir = Path(profile_data["registry_dir"])
+
+    if cli.get("repos_dir"):
+        config.repos_dir = Path(cli["repos_dir"])
+    if cli.get("venvs_dir"):
+        config.venvs_dir = Path(cli["venvs_dir"])
+    if cli.get("results_dir"):
+        config.results_dir = Path(cli["results_dir"])
+
+    if cli.get("packages_filter"):
+        config.packages_filter = cli["packages_filter"]
+    if cli.get("top_n"):
+        config.top_n = cli["top_n"]
+
+    if cli.get("check_stability"):
+        config.check_stability = True
+    if cli.get("wait_for_stability"):
+        config.wait_for_stability = True
+
+    if cli.get("alternate") is not None:
+        config.alternate = cli["alternate"]
+    if cli.get("interleave"):
+        config.interleave = True
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Inline condition parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_inline_condition(spec: str) -> ConditionDef:
+    """Parse an inline condition specification from CLI.
+
+    Format: ``"name:key=value,key=value,..."``
+    or just ``"name:"`` for defaults.
+
+    Supported keys:
+      target_python, env.KEY, extra_deps, test_command_override,
+      test_command_prefix, test_prefix, test_command_suffix,
+      test_suffix, install_command, description
+
+    Examples::
+
+        "baseline:"
+        "coverage:extra_deps=coverage+pytest-cov,test_prefix=coverage run -m"
+        "jit:target_python=/opt/python-jit/bin/python3,env.PYTHON_JIT=1"
+
+    Returns:
+        ConditionDef with parsed values.
+    """
+    if ":" not in spec:
+        raise ValueError(
+            f"Invalid condition spec: '{spec}'. Expected format: 'name:key=value,...'"
+        )
+
+    name, rest = spec.split(":", 1)
+    name = name.strip()
+    if not name:
+        raise ValueError("Condition name cannot be empty.")
+
+    cond = ConditionDef(name=name)
+
+    if not rest.strip():
+        return cond  # Just a name, all defaults.
+
+    pairs = _split_condition_pairs(rest.strip())
+
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"Invalid key=value pair in condition '{name}': '{pair}'")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+
+        if key == "target_python":
+            cond.target_python = value
+        elif key == "extra_deps":
+            cond.extra_deps = [d.strip() for d in value.split("+") if d.strip()]
+        elif key == "test_command_override":
+            cond.test_command_override = value
+        elif key in ("test_prefix", "test_command_prefix"):
+            cond.test_command_prefix = value
+        elif key in ("test_suffix", "test_command_suffix"):
+            cond.test_command_suffix = value
+        elif key == "install_command":
+            cond.install_command = value
+        elif key == "description":
+            cond.description = value
+        elif key.startswith("env."):
+            env_key = key[4:]
+            cond.env[env_key] = value
+        else:
+            raise ValueError(
+                f"Unknown condition key '{key}' in condition '{name}'. "
+                f"Valid keys: target_python, extra_deps, test_command_override, "
+                f"test_prefix, test_suffix, install_command, description, env.KEY"
+            )
+
+    return cond
+
+
+def _split_condition_pairs(text: str) -> list[str]:
+    """Split condition key=value pairs on commas.
+
+    Values may contain spaces.  We split on commas and rejoin segments
+    that don't contain ``=`` with the preceding segment (they are part
+    of a value that contained a comma).
+    """
+    raw_parts = text.split(",")
+    pairs: list[str] = []
+    for part in raw_parts:
+        part = part.strip()
+        if not part:
+            continue
+        if "=" in part and (not pairs or "=" in pairs[-1]):
+            pairs.append(part)
+        elif pairs:
+            # Continuation of the previous value.
+            pairs[-1] += "," + part
+        else:
+            pairs.append(part)
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Test command resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_test_command(
+    registry_command: str | None,
+    condition: ConditionDef,
+    *,
+    default_suffix: str | None = None,
+) -> str:
+    """Resolve the test command for a package under a condition.
+
+    Resolution order (first match wins):
+
+    1. ``condition.test_command_override`` — use as-is
+    2. ``condition.test_command_prefix`` — prefix + registry command
+    3. ``condition.test_command_suffix`` — registry command + suffix
+    4. ``default_suffix`` — registry command + default suffix
+    5. Registry command as-is
+    6. Fallback: ``"python -m pytest"``
+
+    Args:
+        registry_command: The package's test command from the registry.
+        condition: The condition being applied.
+        default_suffix: Global suffix from BenchConfig.
+
+    Returns:
+        The resolved test command string.
+    """
+    base = registry_command or "python -m pytest"
+
+    if condition.test_command_override:
+        return condition.test_command_override
+
+    if condition.test_command_prefix:
+        prefix = condition.test_command_prefix
+        if base.startswith("python -m "):
+            rest = base[len("python -m ") :]
+            return f"{prefix} {rest}"
+        if base.startswith("python "):
+            rest = base[len("python ") :]
+            return f"{prefix} {rest}"
+        return f"{prefix} {base}"
+
+    cmd = base
+    if condition.test_command_suffix:
+        cmd = f"{cmd} {condition.test_command_suffix}"
+    elif default_suffix:
+        cmd = f"{cmd} {default_suffix}"
+
+    return cmd
+
+
+def resolve_target_python(
+    condition: ConditionDef,
+    default: str,
+) -> Path:
+    """Resolve the target Python for a condition.
+
+    Returns:
+        Path to the Python executable.
+
+    Raises:
+        ValueError: If no target Python can be determined.
+    """
+    python_str = condition.target_python or default
+    if not python_str:
+        raise ValueError(
+            f"No target Python for condition '{condition.name}'. "
+            f"Set --target-python or specify target_python in the condition definition."
+        )
+    return Path(python_str)
+
+
+def resolve_env(
+    condition: ConditionDef,
+    default_env: dict[str, str],
+) -> dict[str, str]:
+    """Merge default env with condition-specific env.
+
+    Condition env takes precedence over defaults.
+    """
+    env = dict(default_env)
+    env.update(condition.env)
+    return env
+
+
+def resolve_extra_deps(
+    condition: ConditionDef,
+    default_deps: list[str],
+) -> list[str]:
+    """Merge default extra deps with condition-specific deps.
+
+    Returns a deduplicated list, preserving order.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for dep in default_deps + condition.extra_deps:
+        if dep not in seen:
+            seen.add(dep)
+            result.append(dep)
+    return result

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -1,0 +1,582 @@
+"""Tests for labeille.bench.config — benchmark configuration and condition profiles."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from labeille.bench.config import (
+    BenchConfig,
+    _split_condition_pairs,
+    config_from_profile,
+    load_profile,
+    parse_inline_condition,
+    resolve_env,
+    resolve_extra_deps,
+    resolve_target_python,
+    resolve_test_command,
+    validate_config,
+)
+from labeille.bench.results import ConditionDef
+
+
+# ---------------------------------------------------------------------------
+# BenchConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchConfig(unittest.TestCase):
+    """Tests for BenchConfig dataclass."""
+
+    def test_config_defaults(self) -> None:
+        """Default config values should be sensible."""
+        config = BenchConfig()
+        self.assertEqual(config.iterations, 5)
+        self.assertEqual(config.warmup, 1)
+        self.assertEqual(config.timeout, 600)
+        self.assertFalse(config.interleave)
+        self.assertIsNone(config.alternate)
+
+    def test_config_bench_id_auto(self) -> None:
+        """Auto-generated bench_id should start with 'bench_'."""
+        config = BenchConfig()
+        self.assertTrue(config.bench_id.startswith("bench_"))
+
+    def test_config_bench_id_explicit(self) -> None:
+        """Explicit bench_id should be preserved."""
+        config = BenchConfig(bench_id="my_bench")
+        self.assertEqual(config.bench_id, "my_bench")
+
+    def test_config_total_iterations(self) -> None:
+        """total_iterations = warmup + iterations."""
+        config = BenchConfig(iterations=5, warmup=2)
+        self.assertEqual(config.total_iterations, 7)
+
+    def test_config_should_alternate_auto_single(self) -> None:
+        """Single condition: should_alternate auto-resolves to False."""
+        config = BenchConfig()
+        config.conditions["baseline"] = ConditionDef(name="baseline")
+        self.assertFalse(config.should_alternate)
+
+    def test_config_should_alternate_auto_multi(self) -> None:
+        """Multiple conditions: should_alternate auto-resolves to True."""
+        config = BenchConfig()
+        config.conditions["baseline"] = ConditionDef(name="baseline")
+        config.conditions["jit"] = ConditionDef(name="jit")
+        self.assertTrue(config.should_alternate)
+
+    def test_config_should_alternate_explicit(self) -> None:
+        """Explicit alternate=False overrides auto."""
+        config = BenchConfig(alternate=False)
+        config.conditions["a"] = ConditionDef(name="a")
+        config.conditions["b"] = ConditionDef(name="b")
+        self.assertFalse(config.should_alternate)
+
+    def test_config_output_dir(self) -> None:
+        """output_dir should be results_dir / bench_id."""
+        config = BenchConfig(bench_id="x", results_dir=Path("/tmp"))
+        self.assertEqual(config.output_dir, Path("/tmp/x"))
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfig(unittest.TestCase):
+    """Tests for validate_config()."""
+
+    def _valid_config(self) -> BenchConfig:
+        """Create a minimal valid config using sys.executable."""
+        config = BenchConfig(bench_id="test")
+        config.conditions["baseline"] = ConditionDef(
+            name="baseline",
+            target_python=sys.executable,
+        )
+        return config
+
+    def test_validate_no_conditions(self) -> None:
+        """Empty conditions should produce an error."""
+        config = BenchConfig(bench_id="test")
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "conditions" for e in errors))
+
+    def test_validate_missing_python(self) -> None:
+        """Condition without target_python and no default should error."""
+        config = BenchConfig(bench_id="test")
+        config.conditions["base"] = ConditionDef(name="base")
+        errors = validate_config(config)
+        self.assertTrue(any("target python" in e.message.lower() for e in errors))
+
+    def test_validate_python_not_found(self) -> None:
+        """Nonexistent target Python should error."""
+        config = BenchConfig(bench_id="test")
+        config.conditions["base"] = ConditionDef(
+            name="base",
+            target_python="/nonexistent/python3.99",
+        )
+        errors = validate_config(config)
+        self.assertTrue(any("does not exist" in e.message for e in errors))
+
+    def test_validate_iterations_too_low(self) -> None:
+        """iterations < 3 should produce an error."""
+        config = self._valid_config()
+        config.iterations = 2
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "iterations" for e in errors))
+
+    def test_validate_negative_warmup(self) -> None:
+        """Negative warmup should produce an error."""
+        config = self._valid_config()
+        config.warmup = -1
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "warmup" for e in errors))
+
+    def test_validate_negative_timeout(self) -> None:
+        """Zero timeout should produce an error."""
+        config = self._valid_config()
+        config.timeout = 0
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "timeout" for e in errors))
+
+    def test_validate_valid_config(self) -> None:
+        """Well-formed config should produce no errors."""
+        config = self._valid_config()
+        errors = validate_config(config)
+        self.assertEqual(errors, [])
+
+    def test_validate_registry_dir_missing(self) -> None:
+        """Nonexistent registry dir should error."""
+        config = self._valid_config()
+        config.registry_dir = Path("/nonexistent/registry")
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "registry_dir" for e in errors))
+
+    def test_validate_returns_warnings(self) -> None:
+        """interleave + alternate should produce a warning."""
+        config = self._valid_config()
+        config.conditions["jit"] = ConditionDef(name="jit", target_python=sys.executable)
+        config.interleave = True
+        config.alternate = True
+        errors = validate_config(config)
+        warnings = [e for e in errors if e.severity == "warning"]
+        self.assertTrue(len(warnings) > 0)
+
+
+# ---------------------------------------------------------------------------
+# Profile loading tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadProfile(unittest.TestCase):
+    """Tests for load_profile()."""
+
+    def test_load_profile_valid(self) -> None:
+        """Valid YAML profile should load correctly."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "name: test bench\n"
+                "iterations: 7\n"
+                "conditions:\n"
+                "  baseline:\n"
+                "    description: No JIT\n"
+                "  jit:\n"
+                "    description: With JIT\n"
+                "    env:\n"
+                "      PYTHON_JIT: '1'\n"
+            )
+            path = Path(f.name)
+        try:
+            data = load_profile(path)
+            self.assertEqual(data["name"], "test bench")
+            self.assertEqual(data["iterations"], 7)
+            self.assertIn("baseline", data["conditions"])
+            self.assertIn("jit", data["conditions"])
+        finally:
+            path.unlink()
+
+    def test_load_profile_missing_file(self) -> None:
+        """Nonexistent file should raise FileNotFoundError."""
+        with self.assertRaises(FileNotFoundError):
+            load_profile(Path("/nonexistent/profile.yaml"))
+
+    def test_load_profile_invalid_yaml(self) -> None:
+        """Invalid YAML should raise an error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("invalid: yaml: [unterminated\n")
+            path = Path(f.name)
+        try:
+            with self.assertRaises(Exception):
+                load_profile(path)
+        finally:
+            path.unlink()
+
+    def test_load_profile_not_a_mapping(self) -> None:
+        """YAML list instead of mapping should raise ValueError."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("- item1\n- item2\n")
+            path = Path(f.name)
+        try:
+            with self.assertRaises(ValueError, msg="must be a YAML mapping"):
+                load_profile(path)
+        finally:
+            path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# config_from_profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFromProfile(unittest.TestCase):
+    """Tests for config_from_profile()."""
+
+    def test_config_from_profile_basic(self) -> None:
+        """Profile with name, 2 conditions, iterations=7."""
+        data = {
+            "name": "overhead test",
+            "iterations": 7,
+            "conditions": {
+                "baseline": {"description": "No JIT"},
+                "jit": {"description": "With JIT", "env": {"PYTHON_JIT": "1"}},
+            },
+        }
+        config = config_from_profile(data)
+        self.assertEqual(config.name, "overhead test")
+        self.assertEqual(config.iterations, 7)
+        self.assertEqual(len(config.conditions), 2)
+        self.assertIn("baseline", config.conditions)
+        self.assertIn("jit", config.conditions)
+
+    def test_config_from_profile_condition_fields(self) -> None:
+        """Condition fields should be populated from profile."""
+        data = {
+            "conditions": {
+                "cov": {
+                    "target_python": "/opt/python",
+                    "env": {"COV": "1"},
+                    "extra_deps": ["coverage"],
+                    "test_command_prefix": "coverage run -m",
+                },
+            },
+        }
+        config = config_from_profile(data)
+        cond = config.conditions["cov"]
+        self.assertEqual(cond.target_python, "/opt/python")
+        self.assertEqual(cond.env, {"COV": "1"})
+        self.assertEqual(cond.extra_deps, ["coverage"])
+        self.assertEqual(cond.test_command_prefix, "coverage run -m")
+
+    def test_config_from_profile_cli_overrides_iterations(self) -> None:
+        """CLI iterations should override profile iterations."""
+        data = {"iterations": 5, "conditions": {"a": None}}
+        config = config_from_profile(data, cli_overrides={"iterations": 10})
+        self.assertEqual(config.iterations, 10)
+
+    def test_config_from_profile_cli_overrides_target_python(self) -> None:
+        """CLI target_python should override profile's."""
+        data = {"target_python": "/old/python", "conditions": {"a": None}}
+        config = config_from_profile(data, cli_overrides={"target_python": "/new/python"})
+        self.assertEqual(config.default_target_python, "/new/python")
+
+    def test_config_from_profile_empty_condition(self) -> None:
+        """Condition value of None should be treated as empty dict."""
+        data = {"conditions": {"empty": None}}
+        config = config_from_profile(data)
+        self.assertIn("empty", config.conditions)
+        self.assertEqual(config.conditions["empty"].name, "empty")
+
+    def test_config_from_profile_invalid_conditions_type(self) -> None:
+        """conditions as a list should raise ValueError."""
+        data = {"conditions": ["a", "b"]}
+        with self.assertRaises(ValueError):
+            config_from_profile(data)
+
+    def test_config_from_profile_cli_overrides_paths(self) -> None:
+        """CLI path overrides should be applied."""
+        data = {"conditions": {"a": None}}
+        config = config_from_profile(
+            data,
+            cli_overrides={
+                "registry_dir": "/tmp/reg",
+                "repos_dir": "/tmp/repos",
+                "venvs_dir": "/tmp/venvs",
+                "results_dir": "/tmp/results",
+            },
+        )
+        self.assertEqual(config.registry_dir, Path("/tmp/reg"))
+        self.assertEqual(config.repos_dir, Path("/tmp/repos"))
+        self.assertEqual(config.venvs_dir, Path("/tmp/venvs"))
+        self.assertEqual(config.results_dir, Path("/tmp/results"))
+
+    def test_config_from_profile_warmup_zero(self) -> None:
+        """CLI warmup=0 should override profile's warmup (not be falsy-skipped)."""
+        data = {"warmup": 3, "conditions": {"a": None}}
+        config = config_from_profile(data, cli_overrides={"warmup": 0})
+        self.assertEqual(config.warmup, 0)
+
+
+# ---------------------------------------------------------------------------
+# Inline condition parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseInlineCondition(unittest.TestCase):
+    """Tests for parse_inline_condition()."""
+
+    def test_parse_inline_defaults(self) -> None:
+        """'baseline:' should produce defaults."""
+        cond = parse_inline_condition("baseline:")
+        self.assertEqual(cond.name, "baseline")
+        self.assertEqual(cond.target_python, "")
+        self.assertEqual(cond.env, {})
+        self.assertEqual(cond.extra_deps, [])
+
+    def test_parse_inline_target_python(self) -> None:
+        """target_python key should be parsed."""
+        cond = parse_inline_condition("jit:target_python=/opt/python")
+        self.assertEqual(cond.target_python, "/opt/python")
+
+    def test_parse_inline_extra_deps(self) -> None:
+        """extra_deps should split on '+'."""
+        cond = parse_inline_condition("cov:extra_deps=coverage+pytest-cov")
+        self.assertEqual(cond.extra_deps, ["coverage", "pytest-cov"])
+
+    def test_parse_inline_env(self) -> None:
+        """env.KEY=VALUE should populate env dict."""
+        cond = parse_inline_condition("jit:env.PYTHON_JIT=1,env.FOO=bar")
+        self.assertEqual(cond.env, {"PYTHON_JIT": "1", "FOO": "bar"})
+
+    def test_parse_inline_test_prefix(self) -> None:
+        """test_prefix should set test_command_prefix."""
+        cond = parse_inline_condition("cov:test_prefix=coverage run -m")
+        self.assertEqual(cond.test_command_prefix, "coverage run -m")
+
+    def test_parse_inline_multiple_keys(self) -> None:
+        """Multiple keys should all be parsed."""
+        cond = parse_inline_condition("full:target_python=/opt/py,extra_deps=cov,env.JIT=1")
+        self.assertEqual(cond.name, "full")
+        self.assertEqual(cond.target_python, "/opt/py")
+        self.assertEqual(cond.extra_deps, ["cov"])
+        self.assertEqual(cond.env, {"JIT": "1"})
+
+    def test_parse_inline_no_colon(self) -> None:
+        """Missing colon should raise ValueError."""
+        with self.assertRaises(ValueError):
+            parse_inline_condition("baseline")
+
+    def test_parse_inline_empty_name(self) -> None:
+        """Empty name should raise ValueError."""
+        with self.assertRaises(ValueError):
+            parse_inline_condition(":key=val")
+
+    def test_parse_inline_unknown_key(self) -> None:
+        """Unknown key should raise ValueError."""
+        with self.assertRaises(ValueError):
+            parse_inline_condition("x:badkey=val")
+
+    def test_parse_inline_no_equals(self) -> None:
+        """Missing '=' in pair should raise ValueError."""
+        with self.assertRaises(ValueError):
+            parse_inline_condition("x:badformat")
+
+    def test_parse_inline_test_suffix(self) -> None:
+        """test_suffix should set test_command_suffix."""
+        cond = parse_inline_condition("v:test_suffix=-v --tb=short")
+        self.assertEqual(cond.test_command_suffix, "-v --tb=short")
+
+    def test_parse_inline_description(self) -> None:
+        """description key should be parsed."""
+        cond = parse_inline_condition("base:description=No JIT enabled")
+        self.assertEqual(cond.description, "No JIT enabled")
+
+
+# ---------------------------------------------------------------------------
+# _split_condition_pairs tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitConditionPairs(unittest.TestCase):
+    """Tests for _split_condition_pairs() helper."""
+
+    def test_split_simple(self) -> None:
+        """Simple comma-separated pairs."""
+        self.assertEqual(_split_condition_pairs("a=1,b=2"), ["a=1", "b=2"])
+
+    def test_split_value_with_space(self) -> None:
+        """Values containing spaces should not be split."""
+        result = _split_condition_pairs("cmd=coverage run -m,b=2")
+        self.assertEqual(result, ["cmd=coverage run -m", "b=2"])
+
+    def test_split_empty(self) -> None:
+        """Empty string should produce empty list."""
+        self.assertEqual(_split_condition_pairs(""), [])
+
+    def test_split_trailing_comma(self) -> None:
+        """Trailing comma should be ignored."""
+        self.assertEqual(_split_condition_pairs("a=1,"), ["a=1"])
+
+    def test_split_single_pair(self) -> None:
+        """Single pair without comma."""
+        self.assertEqual(_split_condition_pairs("key=val"), ["key=val"])
+
+
+# ---------------------------------------------------------------------------
+# Test command resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTestCommand(unittest.TestCase):
+    """Tests for resolve_test_command()."""
+
+    def test_resolve_no_overrides(self) -> None:
+        """Registry command returned as-is when no overrides."""
+        cond = ConditionDef(name="base")
+        result = resolve_test_command("python -m pytest tests/", cond)
+        self.assertEqual(result, "python -m pytest tests/")
+
+    def test_resolve_override(self) -> None:
+        """test_command_override wins over everything."""
+        cond = ConditionDef(name="base", test_command_override="custom")
+        result = resolve_test_command("python -m pytest", cond)
+        self.assertEqual(result, "custom")
+
+    def test_resolve_prefix(self) -> None:
+        """Prefix replaces 'python -m' in the command."""
+        cond = ConditionDef(name="cov", test_command_prefix="coverage run -m")
+        result = resolve_test_command("python -m pytest tests/", cond)
+        self.assertEqual(result, "coverage run -m pytest tests/")
+
+    def test_resolve_prefix_no_python_m(self) -> None:
+        """Prefix prepends when base doesn't start with 'python -m'."""
+        cond = ConditionDef(name="cov", test_command_prefix="coverage run -m")
+        result = resolve_test_command("pytest tests/", cond)
+        self.assertEqual(result, "coverage run -m pytest tests/")
+
+    def test_resolve_suffix(self) -> None:
+        """Condition suffix appended to base command."""
+        cond = ConditionDef(name="v", test_command_suffix="-v")
+        result = resolve_test_command("python -m pytest", cond)
+        self.assertEqual(result, "python -m pytest -v")
+
+    def test_resolve_default_suffix(self) -> None:
+        """Default suffix appended when condition has no suffix."""
+        cond = ConditionDef(name="base")
+        result = resolve_test_command("python -m pytest", cond, default_suffix="-v")
+        self.assertEqual(result, "python -m pytest -v")
+
+    def test_resolve_condition_suffix_beats_default(self) -> None:
+        """Condition suffix takes precedence over default suffix."""
+        cond = ConditionDef(name="v", test_command_suffix="--tb=long")
+        result = resolve_test_command("python -m pytest", cond, default_suffix="--tb=short")
+        self.assertEqual(result, "python -m pytest --tb=long")
+
+    def test_resolve_override_beats_all(self) -> None:
+        """Override wins even if prefix and suffix are also set."""
+        cond = ConditionDef(
+            name="all",
+            test_command_override="override cmd",
+            test_command_prefix="prefix",
+            test_command_suffix="suffix",
+        )
+        result = resolve_test_command("python -m pytest", cond, default_suffix="-v")
+        self.assertEqual(result, "override cmd")
+
+    def test_resolve_no_registry_command(self) -> None:
+        """None registry command falls back to 'python -m pytest'."""
+        cond = ConditionDef(name="base")
+        result = resolve_test_command(None, cond)
+        self.assertEqual(result, "python -m pytest")
+
+    def test_resolve_prefix_with_python_space(self) -> None:
+        """Prefix replaces 'python ' when base starts with it."""
+        cond = ConditionDef(name="cov", test_command_prefix="coverage run")
+        result = resolve_test_command("python test_suite.py", cond)
+        self.assertEqual(result, "coverage run test_suite.py")
+
+
+# ---------------------------------------------------------------------------
+# resolve_target_python tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTargetPython(unittest.TestCase):
+    """Tests for resolve_target_python()."""
+
+    def test_resolve_condition_python(self) -> None:
+        """Condition's python takes precedence."""
+        cond = ConditionDef(name="a", target_python="/opt/python")
+        result = resolve_target_python(cond, "/default/python")
+        self.assertEqual(result, Path("/opt/python"))
+
+    def test_resolve_default_python(self) -> None:
+        """Falls back to default when condition has no python."""
+        cond = ConditionDef(name="a")
+        result = resolve_target_python(cond, "/default/python")
+        self.assertEqual(result, Path("/default/python"))
+
+    def test_resolve_no_python(self) -> None:
+        """Neither set raises ValueError."""
+        cond = ConditionDef(name="a")
+        with self.assertRaises(ValueError):
+            resolve_target_python(cond, "")
+
+
+# ---------------------------------------------------------------------------
+# resolve_env tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEnv(unittest.TestCase):
+    """Tests for resolve_env()."""
+
+    def test_resolve_env_merge(self) -> None:
+        """Default and condition env should be merged."""
+        cond = ConditionDef(name="a", env={"B": "2"})
+        result = resolve_env(cond, {"A": "1"})
+        self.assertEqual(result, {"A": "1", "B": "2"})
+
+    def test_resolve_env_override(self) -> None:
+        """Condition env overrides default for same key."""
+        cond = ConditionDef(name="a", env={"A": "2"})
+        result = resolve_env(cond, {"A": "1"})
+        self.assertEqual(result, {"A": "2"})
+
+    def test_resolve_env_empty(self) -> None:
+        """Both empty should produce empty dict."""
+        cond = ConditionDef(name="a")
+        result = resolve_env(cond, {})
+        self.assertEqual(result, {})
+
+
+# ---------------------------------------------------------------------------
+# resolve_extra_deps tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveExtraDeps(unittest.TestCase):
+    """Tests for resolve_extra_deps()."""
+
+    def test_resolve_deps_merge(self) -> None:
+        """Default and condition deps should be merged."""
+        cond = ConditionDef(name="a", extra_deps=["b"])
+        result = resolve_extra_deps(cond, ["a"])
+        self.assertEqual(result, ["a", "b"])
+
+    def test_resolve_deps_dedup(self) -> None:
+        """Duplicates should be removed, preserving order."""
+        cond = ConditionDef(name="a", extra_deps=["b", "c"])
+        result = resolve_extra_deps(cond, ["a", "b"])
+        self.assertEqual(result, ["a", "b", "c"])
+
+    def test_resolve_deps_empty(self) -> None:
+        """Both empty should produce empty list."""
+        cond = ConditionDef(name="a")
+        result = resolve_extra_deps(cond, [])
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `config.py` to `bench` subpackage with `BenchConfig` dataclass (analog of `RunnerConfig` for benchmarking), YAML profile loading via `load_profile()`/`config_from_profile()`, and inline condition parsing via `parse_inline_condition()` (e.g. `"jit:env.PYTHON_JIT=1,target_python=/opt/py"`).
- Test command resolution with priority chain: override > prefix > suffix > default > registry. Environment, extra deps, and target Python merging with condition-level overrides.
- Configuration validation with error/warning severity levels (`validate_config()`): checks conditions exist, target Pythons are valid, iterations >= 3, timeout > 0, and detects conflicting execution strategies.
- 65 new tests in `test_bench_config.py`.

## Test plan
- [x] `ruff format` — clean
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues in 25 source files
- [x] All 1029 tests pass (6 skipped — macOS-only on Linux)

Closes #66

Generated with [Claude Code](https://claude.com/claude-code)