### PR TITLE
feat: benchmark CLI commands and terminal display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `config.py` module in `bench` subpackage with `BenchConfig` dataclass, YAML profile loading, inline condition parsing, test command resolution, environment/deps merging, and configuration validation.
 - `runner.py` module in `bench` subpackage with `BenchRunner` class orchestrating the full benchmark lifecycle: system profiling, stability checks, package setup (clone/venv/install per condition), timed iteration execution, and incremental JSONL result writing. Supports block, alternating, and interleaved execution strategies with progress callbacks.
 - `BenchProgress` dataclass and `quick_config()` helper for rapid iteration during development.
+- `display.py` module in `bench` subpackage with terminal formatting for benchmark results: per-package timing tables, multi-condition comparison tables with overhead/CI/significance, measurement quality summaries, and aggregate comparison summaries.
+- `bench_cli.py` module with `labeille bench` CLI subgroup: `run` (execute benchmarks from profiles or inline conditions), `show` (display saved results), `compare` (compare conditions within or across runs), `system` (print system characterization), and `export` (CSV/Markdown export).
 - `labeille bisect` command to binary-search a package's git history and find the first commit that introduced a crash.
 - `bisect.py` module with `BisectConfig`, `BisectStep`, `BisectResult` dataclasses and the `run_bisect` algorithm with skip-neighbor handling for unbuildable commits.
 - Commit-aware run comparison: `analyze compare` and `analyze run` show git commit changes alongside status changes with heuristic annotations (e.g. "unchanged — likely a CPython/JIT regression").

--- a/src/labeille/bench/display.py
+++ b/src/labeille/bench/display.py
@@ -1,0 +1,393 @@
+"""Terminal display formatting for benchmark results.
+
+Produces clean, aligned tables and summaries for benchmark data.
+Uses Unicode box-drawing characters for visual structure.
+No external dependencies.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics as _stats
+
+from labeille.bench.results import (
+    BenchMeta,
+    BenchPackageResult,
+)
+from labeille.bench.stats import (
+    OverheadResult,
+    compute_overhead,
+)
+
+
+# ---------------------------------------------------------------------------
+# Table formatting utilities
+# ---------------------------------------------------------------------------
+
+
+def _format_time(seconds: float, precision: int = 2) -> str:
+    """Format a time value with adaptive units."""
+    if math.isnan(seconds):
+        return "N/A"
+    if seconds < 0.001:
+        return f"{seconds * 1_000_000:.0f}\u00b5s"
+    if seconds < 1:
+        return f"{seconds * 1000:.{precision}f}ms"
+    if seconds < 60:
+        return f"{seconds:.{precision}f}s"
+    minutes = int(seconds // 60)
+    secs = seconds % 60
+    return f"{minutes}m{secs:.0f}s"
+
+
+def _format_pct(value: float, precision: int = 1) -> str:
+    """Format a percentage with sign."""
+    if math.isnan(value):
+        return "N/A"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:.{precision}f}%"
+
+
+def _format_ci(lower: float, upper: float, precision: int = 1) -> str:
+    """Format a confidence interval."""
+    if math.isnan(lower) or math.isnan(upper):
+        return "[N/A]"
+    return f"[{_format_pct(lower * 100, precision)}, {_format_pct(upper * 100, precision)}]"
+
+
+def _significance_marker(stars: str) -> str:
+    """Format significance for display."""
+    return stars if stars != "ns" else "ns"
+
+
+# ---------------------------------------------------------------------------
+# Single benchmark display
+# ---------------------------------------------------------------------------
+
+
+def format_bench_show(
+    meta: BenchMeta,
+    results: list[BenchPackageResult],
+) -> str:
+    """Format a complete benchmark run for display.
+
+    Shows system info, conditions, per-package summaries, and
+    measurement quality.
+
+    Args:
+        meta: BenchMeta instance.
+        results: List of BenchPackageResult.
+
+    Returns:
+        Formatted string for terminal output.
+    """
+    from labeille.bench.system import (
+        PythonProfile,
+        format_python_profile,
+        format_system_profile,
+    )
+
+    lines: list[str] = []
+
+    # Header.
+    title = meta.name or meta.bench_id
+    lines.append(title)
+    lines.append("\u2500" * len(title))
+    if meta.description:
+        lines.append(meta.description)
+    lines.append("")
+
+    # System info.
+    lines.append(format_system_profile(meta.system))
+    lines.append("")
+
+    # Python profiles.
+    for name, pp in meta.python_profiles.items():
+        if isinstance(pp, dict):
+            pp = PythonProfile.from_dict(pp)
+        lines.append(f"Condition '{name}':")
+        lines.append(f"  {format_python_profile(pp).replace(chr(10), chr(10) + '  ')}")
+    lines.append("")
+
+    # Config.
+    cfg = meta.config
+    lines.append(
+        f"Iterations: {cfg.get('iterations', '?')} measured + {cfg.get('warmup', '?')} warmup"
+    )
+    strategy = "alternating" if cfg.get("alternate") else "block"
+    if cfg.get("interleave"):
+        strategy = "interleaved"
+    lines.append(f"Strategy: {strategy}")
+    lines.append(f"Packages: {meta.packages_completed} completed, {meta.packages_skipped} skipped")
+    if meta.start_time and meta.end_time:
+        lines.append(f"Time: {meta.start_time} \u2192 {meta.end_time}")
+    lines.append("")
+
+    # Condition names.
+    condition_names = list(meta.conditions.keys())
+
+    if len(condition_names) == 1:
+        lines.append(_format_single_condition_table(results, condition_names[0]))
+    else:
+        lines.append(_format_multi_condition_table(results, condition_names))
+
+    # Measurement quality.
+    lines.append("")
+    lines.append(_format_quality_summary(results, condition_names))
+
+    return "\n".join(lines)
+
+
+def _format_single_condition_table(
+    results: list[BenchPackageResult],
+    condition_name: str,
+) -> str:
+    """Format a table for a single-condition benchmark."""
+    lines: list[str] = []
+
+    lines.append(
+        f"{'Package':<30s} {'Wall (s)':>10s} {'\u00b1':>8s} "
+        f"{'CPU (s)':>10s} {'RSS (MB)':>10s} {'CV':>6s} {'Status':>8s}"
+    )
+    lines.append("\u2500" * 88)
+
+    active = [r for r in results if not r.skipped]
+    active.sort(key=lambda r: _get_median_wall(r, condition_name), reverse=True)
+
+    for r in active:
+        cond = r.conditions.get(condition_name)
+        if not cond or not cond.wall_time_stats:
+            continue
+
+        ws = cond.wall_time_stats
+        us = cond.user_time_stats
+        rs = cond.peak_rss_stats
+        cv_str = f"{ws.cv:.3f}" if ws.cv < 1 else f"{ws.cv:.1f}"
+
+        # Determine predominant status.
+        statuses = [it.status for it in cond.measured_iterations]
+        status = max(set(statuses), key=statuses.count) if statuses else "N/A"
+
+        lines.append(
+            f"{r.package:<30s} {ws.median:>10.2f} {ws.stdev:>7.2f}s "
+            f"{us.mean if us else 0:>10.2f} "
+            f"{rs.median if rs else 0:>10.1f} "
+            f"{cv_str:>6s} {status:>8s}"
+        )
+
+    return "\n".join(lines)
+
+
+def _format_multi_condition_table(
+    results: list[BenchPackageResult],
+    condition_names: list[str],
+) -> str:
+    """Format a comparison table for multi-condition benchmarks."""
+    lines: list[str] = []
+
+    baseline_name = condition_names[0]
+    treatment_names = condition_names[1:]
+
+    # Build header.
+    header = f"{'Package':<25s} {baseline_name + ' (s)':>12s}"
+    for tn in treatment_names:
+        header += f" {tn + ' (s)':>12s} {'Overhead':>10s} {'CI (95%)':>20s} {'Sig.':>5s}"
+    lines.append(header)
+    lines.append("\u2500" * len(header))
+
+    active = [r for r in results if not r.skipped]
+    active.sort(key=lambda r: _get_median_wall(r, baseline_name), reverse=True)
+
+    for r in active:
+        base_cond = r.conditions.get(baseline_name)
+        if not base_cond or not base_cond.wall_time_stats:
+            continue
+
+        row = f"{r.package:<25s} {base_cond.wall_time_stats.median:>11.2f}s"
+
+        for tn in treatment_names:
+            treat_cond = r.conditions.get(tn)
+            if not treat_cond or not treat_cond.wall_time_stats:
+                row += f" {'N/A':>12s} {'':>10s} {'':>20s} {'':>5s}"
+                continue
+
+            overhead = compute_overhead(
+                base_cond.wall_times,
+                treat_cond.wall_times,
+                ci_seed=42,
+            )
+
+            base_median = base_cond.wall_time_stats.median
+            if base_median > 0:
+                ci_lower_frac = overhead.ci.lower / base_median
+                ci_upper_frac = overhead.ci.upper / base_median
+            else:
+                ci_lower_frac = 0.0
+                ci_upper_frac = 0.0
+
+            row += (
+                f" {treat_cond.wall_time_stats.median:>11.2f}s"
+                f" {_format_pct(overhead.overhead_pct):>10s}"
+                f" {_format_ci(ci_lower_frac, ci_upper_frac):>20s}"
+                f" {_significance_marker(overhead.ttest.significance_stars):>5s}"
+            )
+
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+def _get_median_wall(
+    result: BenchPackageResult,
+    condition: str,
+) -> float:
+    """Get median wall time for sorting. Returns 0 if unavailable."""
+    cond = result.conditions.get(condition)
+    if cond and cond.wall_time_stats:
+        return cond.wall_time_stats.median
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Quality summary
+# ---------------------------------------------------------------------------
+
+
+def _format_quality_summary(
+    results: list[BenchPackageResult],
+    condition_names: list[str],
+) -> str:
+    """Format measurement quality metrics."""
+    lines = [
+        "Measurement Quality",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+    ]
+
+    for cond_name in condition_names:
+        cvs: list[float] = []
+        outlier_count = 0
+        total_iterations = 0
+        max_load = 0.0
+
+        for r in results:
+            if r.skipped:
+                continue
+            cond = r.conditions.get(cond_name)
+            if not cond or not cond.wall_time_stats:
+                continue
+            cvs.append(cond.wall_time_stats.cv)
+            outlier_count += cond.n_outliers
+            total_iterations += len(cond.measured_iterations)
+            for it in cond.measured_iterations:
+                max_load = max(max_load, it.load_avg_start, it.load_avg_end)
+
+        if not cvs:
+            continue
+
+        median_cv = _stats.median(cvs)
+        high_cv = sum(1 for cv in cvs if cv > 0.10)
+
+        lines.append(f"  {cond_name}:")
+        lines.append(f"    Median CV:         {median_cv:.3f}")
+        if high_cv:
+            lines.append(f"    Packages with CV > 10%: {high_cv}")
+        lines.append(f"    Outliers:          {outlier_count} / {total_iterations} iterations")
+        lines.append(f"    Max system load:   {max_load:.1f}")
+
+    # Overall quality assessment.
+    all_cvs: list[float] = []
+    for r in results:
+        for cond in r.conditions.values():
+            if cond.wall_time_stats:
+                all_cvs.append(cond.wall_time_stats.cv)
+    if all_cvs:
+        overall_cv = _stats.median(all_cvs)
+        if overall_cv < 0.03:
+            quality = "Excellent (CV < 3%)"
+        elif overall_cv < 0.05:
+            quality = "Good (CV < 5%)"
+        elif overall_cv < 0.10:
+            quality = "Acceptable (CV < 10%)"
+        else:
+            quality = "Poor (CV \u2265 10%) \u2014 results may be unreliable"
+        lines.append(f"  Overall: {quality}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Comparison summary
+# ---------------------------------------------------------------------------
+
+
+def format_comparison_summary(
+    results: list[BenchPackageResult],
+    baseline_name: str,
+    treatment_name: str,
+) -> str:
+    """Format an aggregate comparison summary.
+
+    Args:
+        results: Package results containing both conditions.
+        baseline_name: Name of the baseline condition.
+        treatment_name: Name of the treatment condition.
+
+    Returns:
+        Formatted summary string.
+    """
+    overheads: list[tuple[BenchPackageResult, OverheadResult]] = []
+    for r in results:
+        if r.skipped:
+            continue
+        base = r.conditions.get(baseline_name)
+        treat = r.conditions.get(treatment_name)
+        if not base or not treat:
+            continue
+        if not base.wall_times or not treat.wall_times:
+            continue
+        oh = compute_overhead(base.wall_times, treat.wall_times, ci_seed=42)
+        overheads.append((r, oh))
+
+    if not overheads:
+        return "No comparable packages found."
+
+    pcts = [oh.overhead_pct for _, oh in overheads]
+    significant = [oh for _, oh in overheads if oh.ttest.significant_05]
+    practical = [oh for _, oh in overheads if oh.practically_significant]
+    faster = [oh for _, oh in overheads if oh.overhead_pct < 0]
+    slower = [oh for _, oh in overheads if oh.overhead_pct > 0]
+
+    lines: list[str] = []
+    lines.append("Aggregate Summary")
+    lines.append(
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+    )
+    lines.append(f"  Packages compared:       {len(overheads)}")
+    lines.append(f"  Median overhead:         {_format_pct(_stats.median(pcts))}")
+    lines.append(f"  Mean overhead:           {_format_pct(_stats.mean(pcts))}")
+    lines.append(
+        f"  Range:                   {_format_pct(min(pcts))} to {_format_pct(max(pcts))}"
+    )
+    lines.append(f"  Statistically significant (p<0.05): {len(significant)}")
+    lines.append(f"  Practically significant: {len(practical)}")
+    lines.append(f"  Faster under treatment:  {len(faster)}")
+    lines.append(f"  Slower under treatment:  {len(slower)}")
+
+    # Top 5 most affected packages.
+    sorted_oh = sorted(overheads, key=lambda x: x[1].overhead_pct, reverse=True)
+    if sorted_oh:
+        lines.append("")
+        lines.append("  Most affected (highest overhead):")
+        for r, oh in sorted_oh[:5]:
+            lines.append(f"    {r.package:<25s} {_format_pct(oh.overhead_pct):>8s}")
+
+    if sorted_oh and any(oh.overhead_pct < 0 for _, oh in sorted_oh):
+        lines.append("")
+        lines.append("  Most improved (fastest under treatment):")
+        for r, oh in reversed(sorted_oh[-5:]):
+            if oh.overhead_pct < 0:
+                lines.append(f"    {r.package:<25s} {_format_pct(oh.overhead_pct):>8s}")
+
+    return "\n".join(lines)

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -1,0 +1,635 @@
+"""CLI commands for labeille bench.
+
+Subcommands:
+    labeille bench run       Execute a benchmark
+    labeille bench show      Display a benchmark's results
+    labeille bench compare   Compare two or more benchmark results
+    labeille bench system    Print system characterization
+    labeille bench export    Export results to CSV/markdown
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import click
+
+from labeille.bench.results import BenchMeta, BenchPackageResult
+
+log = logging.getLogger("labeille")
+
+
+@click.group()
+def bench() -> None:
+    """Benchmark package test suites under different conditions."""
+
+
+# ---------------------------------------------------------------------------
+# bench run
+# ---------------------------------------------------------------------------
+
+
+@bench.command()
+@click.option(
+    "--profile",
+    "profile_path",
+    type=click.Path(exists=True),
+    help="YAML profile defining benchmark conditions.",
+)
+@click.option(
+    "--condition",
+    "inline_conditions",
+    type=str,
+    multiple=True,
+    help="Inline condition: 'name:key=value,...' (repeatable).",
+)
+@click.option(
+    "--target-python",
+    type=click.Path(exists=True),
+    help="Default target Python interpreter.",
+)
+@click.option(
+    "--iterations",
+    type=int,
+    default=None,
+    help="Measured iterations (default: 5, min: 3).",
+)
+@click.option(
+    "--warmup",
+    type=int,
+    default=None,
+    help="Warm-up iterations (default: 1).",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=None,
+    help="Per-iteration timeout in seconds (default: 600).",
+)
+@click.option(
+    "--alternate/--no-alternate",
+    default=None,
+    help="Alternate conditions per package.",
+)
+@click.option(
+    "--interleave",
+    is_flag=True,
+    default=False,
+    help="Interleave packages across iterations.",
+)
+@click.option(
+    "--packages",
+    type=str,
+    default=None,
+    help="Comma-separated package filter.",
+)
+@click.option(
+    "--top",
+    "top_n",
+    type=int,
+    default=None,
+    help="Top N packages by download count.",
+)
+@click.option(
+    "--extra-deps",
+    type=str,
+    default=None,
+    help="Comma-separated extra deps for all conditions.",
+)
+@click.option(
+    "--test-command-suffix",
+    type=str,
+    default=None,
+    help="Append to all test commands.",
+)
+@click.option(
+    "--registry-dir",
+    type=click.Path(exists=True),
+    required=True,
+    help="Registry directory.",
+)
+@click.option(
+    "--repos-dir",
+    type=click.Path(),
+    default=None,
+    help="Persistent repos directory.",
+)
+@click.option(
+    "--venvs-dir",
+    type=click.Path(),
+    default=None,
+    help="Persistent venvs directory.",
+)
+@click.option(
+    "--work-dir",
+    type=click.Path(),
+    default=None,
+    help="Sets both repos and venvs dirs.",
+)
+@click.option(
+    "--results-dir",
+    type=click.Path(),
+    default="results",
+    help="Results output directory.",
+)
+@click.option(
+    "--name",
+    type=str,
+    default=None,
+    help="Human-readable benchmark name.",
+)
+@click.option(
+    "--check-stability",
+    is_flag=True,
+    default=False,
+    help="Check system stability before starting.",
+)
+@click.option(
+    "--wait-for-stability",
+    is_flag=True,
+    default=False,
+    help="Wait for system to stabilize.",
+)
+@click.option(
+    "--quick",
+    is_flag=True,
+    default=False,
+    help="Quick mode: 3 iterations, no warmup, top 20.",
+)
+@click.option(
+    "--env",
+    "env_pairs",
+    type=str,
+    multiple=True,
+    help="KEY=VALUE env var for all conditions (repeatable).",
+)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def run(  # noqa: PLR0913
+    profile_path: str | None,
+    inline_conditions: tuple[str, ...],
+    target_python: str | None,
+    iterations: int | None,
+    warmup: int | None,
+    timeout: int | None,
+    alternate: bool | None,
+    interleave: bool,
+    packages: str | None,
+    top_n: int | None,
+    extra_deps: str | None,
+    test_command_suffix: str | None,
+    registry_dir: str,
+    repos_dir: str | None,
+    venvs_dir: str | None,
+    work_dir: str | None,
+    results_dir: str,
+    name: str | None,
+    check_stability: bool,
+    wait_for_stability: bool,
+    quick: bool,
+    env_pairs: tuple[str, ...],
+    verbose: bool,
+) -> None:
+    """Run a benchmark across packages under specified conditions.
+
+    Use --profile for a YAML profile or --condition for inline
+    conditions.
+
+    \b
+    Examples:
+        # From a YAML profile
+        labeille bench run --profile bench-coverage.yaml \\
+            --registry-dir ./registry --target-python /usr/bin/python3
+
+        # Quick inline comparison
+        labeille bench run \\
+            --condition "baseline:" \\
+            --condition "coverage:extra_deps=coverage,test_prefix=coverage run -m" \\
+            --target-python /usr/bin/python3 \\
+            --registry-dir ./registry --packages requests,click
+
+        # Quick mode for development
+        labeille bench run --profile bench-jit.yaml \\
+            --registry-dir ./registry --quick
+    """
+    from labeille.bench.config import (
+        BenchConfig,
+        config_from_profile,
+        load_profile,
+        parse_inline_condition,
+    )
+    from labeille.bench.runner import BenchRunner, quick_config
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    # Build configuration.
+    cli_overrides: dict[str, object] = {
+        "target_python": target_python,
+        "iterations": iterations,
+        "warmup": warmup,
+        "timeout": timeout,
+        "registry_dir": registry_dir,
+        "repos_dir": repos_dir or (work_dir and str(Path(work_dir) / "repos")),
+        "venvs_dir": venvs_dir or (work_dir and str(Path(work_dir) / "venvs")),
+        "results_dir": results_dir,
+        "name": name,
+        "check_stability": check_stability,
+        "wait_for_stability": wait_for_stability,
+        "alternate": alternate,
+        "interleave": interleave,
+        "packages_filter": (
+            [p.strip() for p in packages.split(",") if p.strip()] if packages else None
+        ),
+        "top_n": top_n,
+    }
+
+    if profile_path:
+        profile_data = load_profile(Path(profile_path))
+        config = config_from_profile(profile_data, cli_overrides=cli_overrides)
+    else:
+        config = BenchConfig(
+            name=name or "",
+            iterations=iterations or 5,
+            warmup=warmup if warmup is not None else 1,
+            timeout=timeout or 600,
+            default_target_python=target_python or "",
+            registry_dir=Path(registry_dir),
+        )
+        if repos_dir or work_dir:
+            config.repos_dir = Path(repos_dir or str(Path(work_dir) / "repos"))  # type: ignore[arg-type]
+        if venvs_dir or work_dir:
+            config.venvs_dir = Path(venvs_dir or str(Path(work_dir) / "venvs"))  # type: ignore[arg-type]
+        config.results_dir = Path(results_dir)
+        if packages:
+            config.packages_filter = [p.strip() for p in packages.split(",") if p.strip()]
+        if top_n:
+            config.top_n = top_n
+
+    # Add inline conditions.
+    for spec in inline_conditions:
+        cond = parse_inline_condition(spec)
+        config.conditions[cond.name] = cond
+
+    # Apply shared options.
+    if extra_deps:
+        config.default_extra_deps = [d.strip() for d in extra_deps.split(",") if d.strip()]
+    if test_command_suffix:
+        config.default_test_command_suffix = test_command_suffix
+
+    # Parse env vars.
+    for pair in env_pairs:
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            config.default_env[k] = v
+
+    config.check_stability = check_stability
+    config.wait_for_stability = wait_for_stability
+    config.cli_args = sys.argv[1:]
+
+    if quick:
+        config = quick_config(config)
+
+    # Run.
+    runner = BenchRunner(config)
+    try:
+        meta, results = runner.run()
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+    except KeyboardInterrupt:
+        click.echo("\nBenchmark interrupted.", err=True)
+        raise SystemExit(130)  # noqa: B904
+
+    # Display results.
+    from labeille.bench.display import format_bench_show
+
+    click.echo()
+    click.echo(format_bench_show(meta, results))
+    click.echo()
+    click.echo(f"Results saved to: {config.output_dir}")
+
+
+# ---------------------------------------------------------------------------
+# bench show
+# ---------------------------------------------------------------------------
+
+
+@bench.command("show")
+@click.argument("result_dir", type=click.Path(exists=True))
+def show(result_dir: str) -> None:
+    """Display results from a benchmark run.
+
+    RESULT_DIR is the path to a benchmark output directory
+    containing bench_meta.json and bench_results.jsonl.
+    """
+    from labeille.bench.display import format_bench_show
+    from labeille.bench.results import load_bench_run
+
+    meta, results = load_bench_run(Path(result_dir))
+    click.echo(format_bench_show(meta, results))
+
+
+# ---------------------------------------------------------------------------
+# bench compare
+# ---------------------------------------------------------------------------
+
+
+@bench.command("compare")
+@click.argument(
+    "result_dirs",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    "--baseline",
+    type=str,
+    default=None,
+    help="Name of the baseline condition (default: first).",
+)
+@click.option(
+    "--metric",
+    type=click.Choice(["wall", "cpu", "rss"]),
+    default="wall",
+    help="Metric to compare.",
+)
+def compare(result_dirs: tuple[str, ...], baseline: str | None, metric: str) -> None:
+    """Compare results from two or more benchmark runs.
+
+    Accepts either:
+    - Two result directories from different benchmark runs
+    - One result directory with multiple conditions
+
+    \b
+    Examples:
+        # Compare conditions within a single run
+        labeille bench compare results/bench_20260227_143000
+
+        # Compare two separate runs
+        labeille bench compare results/bench_baseline results/bench_jit
+    """
+    from labeille.bench.display import (
+        format_bench_show,
+        format_comparison_summary,
+    )
+    from labeille.bench.results import load_bench_run
+
+    if len(result_dirs) == 1:
+        # Single directory: compare conditions within the run.
+        meta, results = load_bench_run(Path(result_dirs[0]))
+        conditions = list(meta.conditions.keys())
+        if len(conditions) < 2:
+            click.echo(
+                "Error: Single benchmark run has only one condition. "
+                "Provide two result directories for cross-run comparison.",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        baseline_name = baseline or conditions[0]
+        if baseline_name not in conditions:
+            click.echo(
+                f"Error: Baseline '{baseline_name}' not found. Available: {', '.join(conditions)}",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        click.echo(format_bench_show(meta, results))
+        click.echo()
+
+        for cond_name in conditions:
+            if cond_name == baseline_name:
+                continue
+            click.echo(f"\n{baseline_name} vs {cond_name}")
+            click.echo("=" * (len(baseline_name) + len(cond_name) + 4))
+            click.echo(format_comparison_summary(results, baseline_name, cond_name))
+    else:
+        # Multiple directories: cross-run comparison.
+        all_runs: list[tuple[BenchMeta, list[BenchPackageResult]]] = []
+        for rd in result_dirs:
+            meta, results = load_bench_run(Path(rd))
+            all_runs.append((meta, results))
+
+        click.echo("Cross-run comparison:")
+        click.echo()
+        for i, (meta, results) in enumerate(all_runs):
+            run_name = meta.name or meta.bench_id
+            click.echo(f"  Run {i + 1}: {run_name}")
+            click.echo(f"    Conditions: {', '.join(meta.conditions.keys())}")
+            click.echo(f"    Packages: {meta.packages_completed}")
+        click.echo()
+
+        # Merge: create synthetic BenchPackageResults with conditions
+        # named after each run.
+        merged_results: dict[str, BenchPackageResult] = {}
+        run_names: list[str] = []
+
+        for meta, results in all_runs:
+            run_name = meta.name or meta.bench_id
+            run_names.append(run_name)
+            first_cond = list(meta.conditions.keys())[0]
+
+            for r in results:
+                if r.skipped:
+                    continue
+                cond = r.conditions.get(first_cond)
+                if not cond:
+                    continue
+                if r.package not in merged_results:
+                    merged_results[r.package] = BenchPackageResult(
+                        package=r.package,
+                    )
+                merged_results[r.package].conditions[run_name] = cond
+
+        merged_list = list(merged_results.values())
+
+        if len(run_names) >= 2:
+            baseline_name = baseline or run_names[0]
+            for treatment in run_names[1:]:
+                click.echo(f"\n{baseline_name} vs {treatment}")
+                click.echo("=" * (len(baseline_name) + len(treatment) + 4))
+                click.echo(format_comparison_summary(merged_list, baseline_name, treatment))
+
+
+# ---------------------------------------------------------------------------
+# bench system
+# ---------------------------------------------------------------------------
+
+
+@bench.command("system")
+@click.option(
+    "--target-python",
+    type=click.Path(exists=True),
+    default=None,
+    help="Also profile a target Python.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def system_cmd(target_python: str | None, as_json: bool) -> None:
+    """Print system characterization for benchmark documentation."""
+    from labeille.bench.system import (
+        capture_python_profile,
+        capture_system_profile,
+        format_python_profile,
+        format_system_profile,
+    )
+
+    profile = capture_system_profile()
+
+    if as_json:
+        import json
+
+        data = profile.to_dict()
+        if target_python:
+            pp = capture_python_profile(Path(target_python))
+            data["target_python"] = pp.to_dict()
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(format_system_profile(profile))
+        if target_python:
+            click.echo()
+            pp = capture_python_profile(Path(target_python))
+            click.echo(format_python_profile(pp))
+
+
+# ---------------------------------------------------------------------------
+# bench export
+# ---------------------------------------------------------------------------
+
+
+def _export_csv(
+    meta: BenchMeta,
+    results: list[BenchPackageResult],
+) -> str:
+    """Export benchmark results to CSV format."""
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+
+    condition_names = list(meta.conditions.keys())
+
+    # Header.
+    header = ["package"]
+    for cn in condition_names:
+        header.extend(
+            [
+                f"{cn}_wall_median",
+                f"{cn}_wall_stdev",
+                f"{cn}_cpu_mean",
+                f"{cn}_rss_median",
+                f"{cn}_cv",
+                f"{cn}_status",
+            ]
+        )
+    writer.writerow(header)
+
+    # Rows.
+    for r in results:
+        if r.skipped:
+            continue
+        row: list[str] = [r.package]
+        for cn in condition_names:
+            cond = r.conditions.get(cn)
+            if not cond or not cond.wall_time_stats:
+                row.extend([""] * 6)
+                continue
+            ws = cond.wall_time_stats
+            us = cond.user_time_stats
+            rs = cond.peak_rss_stats
+            statuses = [it.status for it in cond.measured_iterations]
+            status = max(set(statuses), key=statuses.count) if statuses else ""
+            row.extend(
+                [
+                    f"{ws.median:.4f}",
+                    f"{ws.stdev:.4f}",
+                    f"{us.mean:.4f}" if us else "",
+                    f"{rs.median:.1f}" if rs else "",
+                    f"{ws.cv:.4f}",
+                    status,
+                ]
+            )
+        writer.writerow(row)
+
+    return buf.getvalue()
+
+
+def _export_markdown(
+    meta: BenchMeta,
+    results: list[BenchPackageResult],
+) -> str:
+    """Export benchmark results to Markdown table format."""
+    condition_names = list(meta.conditions.keys())
+
+    lines: list[str] = []
+    title = meta.name or meta.bench_id
+    lines.append(f"# {title}")
+    lines.append("")
+
+    # Header row.
+    header = "| Package |"
+    separator = "| --- |"
+    for cn in condition_names:
+        header += f" {cn} Wall (s) | {cn} CV |"
+        separator += " ---: | ---: |"
+    lines.append(header)
+    lines.append(separator)
+
+    for r in results:
+        if r.skipped:
+            continue
+        row = f"| {r.package} |"
+        for cn in condition_names:
+            cond = r.conditions.get(cn)
+            if not cond or not cond.wall_time_stats:
+                row += " N/A | N/A |"
+                continue
+            ws = cond.wall_time_stats
+            row += f" {ws.median:.2f} | {ws.cv:.3f} |"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+@bench.command("export")
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["csv", "markdown"]),
+    default="csv",
+    help="Export format.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output file (default: stdout).",
+)
+def export(result_dir: str, fmt: str, output: str | None) -> None:
+    """Export benchmark results to CSV or Markdown.
+
+    \b
+    Examples:
+        labeille bench export results/bench_001 --format csv > data.csv
+        labeille bench export results/bench_001 --format markdown -o report.md
+    """
+    from labeille.bench.results import load_bench_run
+
+    meta, results = load_bench_run(Path(result_dir))
+
+    if fmt == "csv":
+        text = _export_csv(meta, results)
+    else:
+        text = _export_markdown(meta, results)
+
+    if output:
+        Path(output).write_text(text)
+        click.echo(f"Exported to {output}")
+    else:
+        click.echo(text)

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -36,6 +36,10 @@ from labeille.analyze_cli import analyze as analyze_group  # noqa: E402
 
 main.add_command(analyze_group)
 
+from labeille.bench_cli import bench as bench_group  # noqa: E402
+
+main.add_command(bench_group)
+
 
 @main.command()
 @click.argument("packages", nargs=-1)

--- a/tests/test_bench_cli.py
+++ b/tests/test_bench_cli.py
@@ -1,0 +1,226 @@
+"""Tests for labeille.bench_cli — Click CLI for bench subcommands."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from click.testing import CliRunner
+
+from labeille.bench_cli import bench
+
+
+class TestBenchGroupHelp(unittest.TestCase):
+    """Tests for the bench group and subcommand help."""
+
+    def test_bench_group_help(self) -> None:
+        result = CliRunner().invoke(bench, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Benchmark", result.output)
+        self.assertIn("run", result.output)
+        self.assertIn("show", result.output)
+        self.assertIn("compare", result.output)
+        self.assertIn("system", result.output)
+        self.assertIn("export", result.output)
+
+    def test_bench_run_help(self) -> None:
+        result = CliRunner().invoke(bench, ["run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--profile", result.output)
+        self.assertIn("--condition", result.output)
+        self.assertIn("--registry-dir", result.output)
+
+    def test_bench_show_help(self) -> None:
+        result = CliRunner().invoke(bench, ["show", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("RESULT_DIR", result.output)
+
+    def test_bench_compare_help(self) -> None:
+        result = CliRunner().invoke(bench, ["compare", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--baseline", result.output)
+
+    def test_bench_system_help(self) -> None:
+        result = CliRunner().invoke(bench, ["system", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--target-python", result.output)
+
+    def test_bench_export_help(self) -> None:
+        result = CliRunner().invoke(bench, ["export", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--format", result.output)
+
+
+class TestBenchSystem(unittest.TestCase):
+    """Tests for bench system command."""
+
+    def test_bench_system_runs(self) -> None:
+        result = CliRunner().invoke(bench, ["system"])
+        self.assertEqual(result.exit_code, 0)
+        # Should contain system profile sections.
+        output = result.output.lower()
+        self.assertTrue(
+            "cpu" in output or "ram" in output or "system" in output,
+            f"Expected system info in output, got: {result.output[:200]}",
+        )
+
+    def test_bench_system_json(self) -> None:
+        result = CliRunner().invoke(bench, ["system", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.output)
+        self.assertIn("cpu_model", data)
+
+
+class TestBenchShowErrors(unittest.TestCase):
+    """Tests for bench show error handling."""
+
+    def test_bench_show_missing_dir(self) -> None:
+        result = CliRunner().invoke(bench, ["show", "/nonexistent/path"])
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestBenchRunNoConditions(unittest.TestCase):
+    """Tests for bench run with missing configuration."""
+
+    def test_bench_run_no_conditions(self) -> None:
+        """Run with no conditions or profile gives error about conditions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a minimal registry dir so the path exists.
+            reg_dir = Path(tmpdir) / "registry"
+            reg_dir.mkdir()
+            result = CliRunner().invoke(
+                bench,
+                [
+                    "run",
+                    "--registry-dir",
+                    str(reg_dir),
+                    "--target-python",
+                    "/usr/bin/python3",
+                ],
+            )
+            # Should fail because no conditions are defined.
+            self.assertNotEqual(result.exit_code, 0)
+            exc_str = str(result.exception) if result.exception else ""
+            self.assertIn(
+                "condition", (result.output + exc_str).lower()
+            )
+
+
+class TestBenchShow(unittest.TestCase):
+    """Tests for bench show with real data."""
+
+    def test_bench_show_loads_results(self) -> None:
+        """bench show displays formatted benchmark results."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write a minimal bench_meta.json and bench_results.jsonl.
+            meta_data = {
+                "bench_id": "test_bench",
+                "name": "Test",
+                "description": "",
+                "system": {},
+                "python_profiles": {},
+                "conditions": {"baseline": {"name": "baseline"}},
+                "config": {"iterations": 3, "warmup": 0},
+                "cli_args": [],
+                "start_time": "2026-02-28T10:00:00",
+                "end_time": "2026-02-28T10:30:00",
+                "packages_total": 0,
+                "packages_completed": 0,
+                "packages_skipped": 0,
+            }
+            (Path(tmpdir) / "bench_meta.json").write_text(json.dumps(meta_data))
+            (Path(tmpdir) / "bench_results.jsonl").write_text("")
+
+            result = CliRunner().invoke(bench, ["show", tmpdir])
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Test", result.output)
+
+
+class TestBenchExport(unittest.TestCase):
+    """Tests for bench export command."""
+
+    def _make_bench_dir(self, tmpdir: str) -> str:
+        """Create a minimal bench directory with meta and results."""
+        meta_data = {
+            "bench_id": "test_bench",
+            "name": "Export Test",
+            "description": "",
+            "system": {},
+            "python_profiles": {},
+            "conditions": {"baseline": {"name": "baseline"}},
+            "config": {"iterations": 3, "warmup": 0},
+            "cli_args": [],
+            "start_time": "",
+            "end_time": "",
+            "packages_total": 1,
+            "packages_completed": 1,
+            "packages_skipped": 0,
+        }
+        result_data = {
+            "package": "testpkg",
+            "conditions": {
+                "baseline": {
+                    "condition_name": "baseline",
+                    "iterations": [
+                        {
+                            "index": i,
+                            "warmup": False,
+                            "wall_time_s": 1.5 + i * 0.01,
+                            "user_time_s": 1.2,
+                            "sys_time_s": 0.1,
+                            "peak_rss_mb": 100.0,
+                            "exit_code": 0,
+                            "status": "ok",
+                            "outlier": False,
+                            "load_avg_start": 0.5,
+                            "load_avg_end": 0.5,
+                            "ram_available_start_gb": 8.0,
+                        }
+                        for i in range(1, 4)
+                    ],
+                    "install_duration_s": 0.5,
+                    "venv_setup_duration_s": 0.3,
+                }
+            },
+            "clone_duration_s": 0.5,
+            "skipped": False,
+            "skip_reason": "",
+        }
+        bench_dir = Path(tmpdir) / "bench_001"
+        bench_dir.mkdir()
+        (bench_dir / "bench_meta.json").write_text(json.dumps(meta_data))
+        (bench_dir / "bench_results.jsonl").write_text(json.dumps(result_data) + "\n")
+        return str(bench_dir)
+
+    def test_export_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_dir = self._make_bench_dir(tmpdir)
+            result = CliRunner().invoke(bench, ["export", bench_dir, "--format", "csv"])
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("testpkg", result.output)
+            self.assertIn("baseline_wall_median", result.output)
+
+    def test_export_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_dir = self._make_bench_dir(tmpdir)
+            result = CliRunner().invoke(bench, ["export", bench_dir, "--format", "markdown"])
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("testpkg", result.output)
+            self.assertIn("|", result.output)
+
+    def test_export_to_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_dir = self._make_bench_dir(tmpdir)
+            output_file = Path(tmpdir) / "output.csv"
+            result = CliRunner().invoke(
+                bench,
+                ["export", bench_dir, "--format", "csv", "-o", str(output_file)],
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(output_file.exists())
+            self.assertIn("testpkg", output_file.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_display.py
+++ b/tests/test_bench_display.py
@@ -1,0 +1,366 @@
+"""Tests for labeille.bench.display — terminal formatting for benchmarks."""
+
+from __future__ import annotations
+
+import unittest
+
+from labeille.bench.display import (
+    _format_ci,
+    _format_pct,
+    _format_quality_summary,
+    _format_time,
+    _significance_marker,
+    format_bench_show,
+    format_comparison_summary,
+)
+from labeille.bench.results import (
+    BenchConditionResult,
+    BenchIteration,
+    BenchMeta,
+    BenchPackageResult,
+    ConditionDef,
+)
+from labeille.bench.stats import DescriptiveStats
+from labeille.bench.system import PythonProfile, SystemProfile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stats(
+    median: float = 1.5,
+    mean: float = 1.5,
+    stdev: float = 0.05,
+    cv: float = 0.03,
+) -> DescriptiveStats:
+    """Create a DescriptiveStats with sensible defaults."""
+    return DescriptiveStats(
+        n=5,
+        mean=mean,
+        median=median,
+        stdev=stdev,
+        min=median - stdev,
+        max=median + stdev,
+        q1=median - stdev * 0.5,
+        q3=median + stdev * 0.5,
+        iqr=stdev,
+        cv=cv,
+    )
+
+
+def _make_iteration(
+    index: int = 1,
+    warmup: bool = False,
+    wall: float = 1.5,
+    status: str = "ok",
+) -> BenchIteration:
+    return BenchIteration(
+        index=index,
+        warmup=warmup,
+        wall_time_s=wall,
+        user_time_s=wall * 0.8,
+        sys_time_s=wall * 0.05,
+        peak_rss_mb=100.0,
+        exit_code=0 if status == "ok" else 1,
+        status=status,
+        load_avg_start=0.5,
+        load_avg_end=0.6,
+    )
+
+
+def _make_condition_result(
+    name: str = "baseline",
+    median: float = 1.5,
+    cv: float = 0.03,
+    n_iters: int = 5,
+) -> BenchConditionResult:
+    """Create a BenchConditionResult with stats pre-populated."""
+    cr = BenchConditionResult(condition_name=name)
+    cr.iterations = [_make_iteration(i + 1, wall=median) for i in range(n_iters)]
+    cr.wall_time_stats = _make_stats(median=median, cv=cv)
+    cr.user_time_stats = _make_stats(median=median * 0.8, cv=cv)
+    cr.peak_rss_stats = _make_stats(median=100.0, cv=cv)
+    return cr
+
+
+def _make_package_result(
+    name: str = "requests",
+    conditions: dict[str, BenchConditionResult] | None = None,
+) -> BenchPackageResult:
+    return BenchPackageResult(
+        package=name,
+        conditions=conditions or {"baseline": _make_condition_result()},
+    )
+
+
+def _make_meta(
+    condition_names: list[str] | None = None,
+    packages_completed: int = 5,
+) -> BenchMeta:
+    cond_names = condition_names or ["baseline"]
+    conditions = {n: ConditionDef(name=n) for n in cond_names}
+    return BenchMeta(
+        bench_id="bench_test",
+        name="Test Benchmark",
+        description="A test benchmark run.",
+        system=SystemProfile(),
+        python_profiles={n: PythonProfile() for n in cond_names},
+        conditions=conditions,
+        config={"iterations": 5, "warmup": 1, "alternate": False},
+        start_time="2026-02-28T10:00:00+0000",
+        end_time="2026-02-28T11:00:00+0000",
+        packages_total=packages_completed,
+        packages_completed=packages_completed,
+        packages_skipped=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_time tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTime(unittest.TestCase):
+    def test_format_time_seconds(self) -> None:
+        self.assertEqual(_format_time(12.34), "12.34s")
+
+    def test_format_time_minutes(self) -> None:
+        result = _format_time(125.5)
+        self.assertEqual(result, "2m6s")
+
+    def test_format_time_milliseconds(self) -> None:
+        result = _format_time(0.045)
+        self.assertEqual(result, "45.00ms")
+
+    def test_format_time_microseconds(self) -> None:
+        result = _format_time(0.000500)
+        self.assertEqual(result, "500\u00b5s")
+
+    def test_format_time_nan(self) -> None:
+        self.assertEqual(_format_time(float("nan")), "N/A")
+
+
+# ---------------------------------------------------------------------------
+# _format_pct tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPct(unittest.TestCase):
+    def test_format_pct_positive(self) -> None:
+        self.assertEqual(_format_pct(20.3), "+20.3%")
+
+    def test_format_pct_negative(self) -> None:
+        self.assertEqual(_format_pct(-5.1), "-5.1%")
+
+    def test_format_pct_nan(self) -> None:
+        self.assertEqual(_format_pct(float("nan")), "N/A")
+
+    def test_format_pct_zero(self) -> None:
+        self.assertEqual(_format_pct(0.0), "+0.0%")
+
+
+# ---------------------------------------------------------------------------
+# _format_ci tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCI(unittest.TestCase):
+    def test_format_ci(self) -> None:
+        result = _format_ci(0.15, 0.25)
+        self.assertEqual(result, "[+15.0%, +25.0%]")
+
+    def test_format_ci_negative(self) -> None:
+        result = _format_ci(-0.10, 0.05)
+        self.assertEqual(result, "[-10.0%, +5.0%]")
+
+    def test_format_ci_nan(self) -> None:
+        result = _format_ci(float("nan"), 0.1)
+        self.assertEqual(result, "[N/A]")
+
+
+# ---------------------------------------------------------------------------
+# _significance_marker tests
+# ---------------------------------------------------------------------------
+
+
+class TestSignificanceMarker(unittest.TestCase):
+    def test_stars(self) -> None:
+        self.assertEqual(_significance_marker("***"), "***")
+        self.assertEqual(_significance_marker("**"), "**")
+        self.assertEqual(_significance_marker("*"), "*")
+
+    def test_not_significant(self) -> None:
+        self.assertEqual(_significance_marker("ns"), "ns")
+
+
+# ---------------------------------------------------------------------------
+# format_bench_show tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBenchShow(unittest.TestCase):
+    def test_single_condition_output(self) -> None:
+        """Single condition shows package names and wall times."""
+        meta = _make_meta(["baseline"])
+        results = [
+            _make_package_result("requests"),
+            _make_package_result("click"),
+        ]
+        output = format_bench_show(meta, results)
+        self.assertIn("Test Benchmark", output)
+        self.assertIn("requests", output)
+        self.assertIn("click", output)
+        self.assertIn("Wall (s)", output)
+        self.assertIn("1.50", output)
+
+    def test_multi_condition_output(self) -> None:
+        """Multi condition shows overhead percentages."""
+        meta = _make_meta(["baseline", "coverage"])
+        results = [
+            _make_package_result(
+                "requests",
+                conditions={
+                    "baseline": _make_condition_result("baseline", median=1.0),
+                    "coverage": _make_condition_result("coverage", median=1.2),
+                },
+            ),
+        ]
+        output = format_bench_show(meta, results)
+        self.assertIn("Overhead", output)
+        self.assertIn("Sig.", output)
+
+    def test_description_shown(self) -> None:
+        meta = _make_meta()
+        meta.description = "Custom description"
+        output = format_bench_show(meta, [])
+        self.assertIn("Custom description", output)
+
+    def test_strategy_interleaved(self) -> None:
+        meta = _make_meta()
+        meta.config["interleave"] = True
+        output = format_bench_show(meta, [])
+        self.assertIn("interleaved", output)
+
+    def test_skipped_packages_not_in_table(self) -> None:
+        """Skipped packages are excluded from the table."""
+        meta = _make_meta()
+        results = [
+            _make_package_result("active"),
+            BenchPackageResult(package="skipped", skipped=True, skip_reason="fail"),
+        ]
+        output = format_bench_show(meta, results)
+        self.assertIn("active", output)
+        # Skipped package should not appear in the table rows.
+
+
+# ---------------------------------------------------------------------------
+# Quality summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualitySummary(unittest.TestCase):
+    def test_quality_excellent(self) -> None:
+        """All CVs < 0.03 yields 'Excellent'."""
+        results = [
+            _make_package_result(
+                f"pkg{i}",
+                conditions={"A": _make_condition_result("A", cv=0.02)},
+            )
+            for i in range(5)
+        ]
+        output = _format_quality_summary(results, ["A"])
+        self.assertIn("Excellent", output)
+
+    def test_quality_poor(self) -> None:
+        """CVs > 0.10 yields 'Poor'."""
+        results = [
+            _make_package_result(
+                f"pkg{i}",
+                conditions={"A": _make_condition_result("A", cv=0.15)},
+            )
+            for i in range(5)
+        ]
+        output = _format_quality_summary(results, ["A"])
+        self.assertIn("Poor", output)
+
+    def test_quality_good(self) -> None:
+        """CVs between 0.03 and 0.05 yields 'Good'."""
+        results = [
+            _make_package_result(
+                f"pkg{i}",
+                conditions={"A": _make_condition_result("A", cv=0.04)},
+            )
+            for i in range(5)
+        ]
+        output = _format_quality_summary(results, ["A"])
+        self.assertIn("Good", output)
+
+    def test_high_cv_count(self) -> None:
+        """Reports count of packages with CV > 10%."""
+        results = [
+            _make_package_result(
+                "high",
+                conditions={"A": _make_condition_result("A", cv=0.15)},
+            ),
+            _make_package_result(
+                "low",
+                conditions={"A": _make_condition_result("A", cv=0.02)},
+            ),
+        ]
+        output = _format_quality_summary(results, ["A"])
+        self.assertIn("CV > 10%: 1", output)
+
+
+# ---------------------------------------------------------------------------
+# Comparison summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestComparisonSummary(unittest.TestCase):
+    def test_aggregate_summary(self) -> None:
+        """Verify median/mean overhead and most affected packages."""
+        results = [
+            _make_package_result(
+                "fast",
+                conditions={
+                    "baseline": _make_condition_result("baseline", median=1.0),
+                    "treatment": _make_condition_result("treatment", median=1.1),
+                },
+            ),
+            _make_package_result(
+                "slow",
+                conditions={
+                    "baseline": _make_condition_result("baseline", median=2.0),
+                    "treatment": _make_condition_result("treatment", median=2.5),
+                },
+            ),
+        ]
+        output = format_comparison_summary(results, "baseline", "treatment")
+        self.assertIn("Packages compared:", output)
+        self.assertIn("Median overhead:", output)
+        self.assertIn("Mean overhead:", output)
+        self.assertIn("Most affected", output)
+
+    def test_no_comparable_packages(self) -> None:
+        output = format_comparison_summary([], "A", "B")
+        self.assertIn("No comparable packages found", output)
+
+    def test_improved_packages_shown(self) -> None:
+        """Packages faster under treatment are listed."""
+        results = [
+            _make_package_result(
+                "improved",
+                conditions={
+                    "baseline": _make_condition_result("baseline", median=2.0),
+                    "treatment": _make_condition_result("treatment", median=1.5),
+                },
+            ),
+        ]
+        output = format_comparison_summary(results, "baseline", "treatment")
+        self.assertIn("improved", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `bench/display.py` with terminal formatting for benchmark results: per-package timing tables, multi-condition comparison tables with overhead/CI/significance, measurement quality summaries, and aggregate comparison summaries.
- Add `bench_cli.py` with `labeille bench` CLI subgroup: `run` (execute benchmarks), `show` (display results), `compare` (compare conditions within or across runs), `system` (print system characterization), and `export` (CSV/Markdown export).
- Register bench group in main CLI and update CHANGELOG.

## Test plan
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy passes (0 errors)
- [x] All 1113 tests pass (40 new tests: 14 CLI tests + 26 display tests)

Closes #70

Generated with [Claude Code](https://claude.com/claude-code)