### PR TITLE
fix: bench runner install_package now receives complete environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Renamed `Issues` URL key to `Bug Tracker` in project metadata for PyPI display consistency.
 
 ### Fixed
+- Bench runner `install_package` now receives a complete environment (starting from `os.environ`) instead of bare condition env vars, fixing install failures when build backends need `PATH` to find tools like `git`.
 - `run_meta.json` now stores actual CLI argument strings (`sys.argv[1:]`) instead of parameter names, making runs reproducible from metadata.
 - `build_reproduce_command` uses `export PATH` for venv activation instead of fragile `.venv/bin/` prefix string replacement.
 - Deduplicated `_signal_name` (3 copies → `format_signal_name` in `formatting.py`).


### PR DESCRIPTION
## Summary
- `_setup_package` was passing the bare output of `resolve_env()` (only condition-specific vars) to `install_package`, which passes it to `Popen(env=...)`. With an explicit env dict, Popen replaces the entire inherited environment — so the install subprocess had no `PATH`, `HOME`, etc. Build backends like hatch-vcs couldn't find `git`, causing `pip install -e .` to fail.
- Add `_build_install_env()` that starts from `os.environ`, strips `PYTHONHOME`/`PYTHONPATH`, prepends the venv `bin/` to `PATH`, and layers condition vars on top — matching what `run_timed_in_venv` already does for test execution.
- 7 new tests for `_build_install_env` covering env inheritance, venv PATH prepending, Python pollution stripping, condition overrides, and empty condition env.

## Test plan
- [x] 1155 tests pass (7 new)
- [x] ruff format/check clean
- [x] mypy strict clean

Closes #74

Generated with [Claude Code](https://claude.com/claude-code)