### PR TITLE
feat: add extension GIL compatibility detection (ft/compat.py)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `ft` subpackage with `compat.py` module for extension GIL compatibility detection: runtime probe via `sys._is_gil_enabled()` and source scan for `Py_mod_gil` declarations.
+- `ExtensionInfo`, `SourceScanResult`, `ModGilDeclaration`, and `ExtensionCompat` dataclasses with JSON serialization.
+- `probe_gil_fallback()` runtime probe, `scan_source_for_mod_gil()` source scanner, `assess_extension_compat()` combined assessment, and `format_extension_compat()` display helper.
+- `guess_import_name()` with `_IMPORT_NAME_OVERRIDES` table for PyPI-to-import name resolution.
 - `bench` subpackage with `system.py` module for capturing system profiles (CPU, RAM, OS, disk) and Python interpreter profiles (version, JIT/GIL state, build flags) for benchmark reproducibility.
 - `SystemProfile`, `PythonProfile`, `StabilityCheck`, and `SystemSnapshot` dataclasses with JSON serialization and terminal display formatting.
 - `check_stability()` pre-benchmark validation (load average, available RAM).

--- a/src/labeille/ft/__init__.py
+++ b/src/labeille/ft/__init__.py
@@ -1,0 +1,6 @@
+"""Free-threading compatibility testing for labeille.
+
+Tests real-world PyPI packages against free-threaded CPython builds,
+detecting crashes, deadlocks, race conditions, and GIL fallback
+behavior across multiple runs.
+"""

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -1,0 +1,608 @@
+"""Extension module GIL compatibility detection.
+
+Provides two complementary approaches to determining whether a
+package's C extensions support free-threaded CPython:
+
+1. Runtime probe: imports the package in a free-threaded interpreter
+   and detects GIL fallback via sys._is_gil_enabled().
+2. Source scan: searches C/C++ files for Py_mod_gil declarations.
+
+The runtime probe tells you what actually happens. The source scan
+tells you what the developer intended.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+log = logging.getLogger("labeille")
+
+
+@dataclass
+class ExtensionInfo:
+    """Information about a single extension module's GIL compatibility."""
+
+    module_name: str
+    is_extension: bool = False
+    import_ok: bool = True
+    import_error: str | None = None
+    triggered_gil_fallback: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExtensionInfo:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class ModGilDeclaration:
+    """A Py_mod_gil declaration found in source code."""
+
+    file: str
+    line_number: int
+    line_text: str
+    is_not_used: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModGilDeclaration:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class SourceScanResult:
+    """Result of scanning source code for Py_mod_gil declarations."""
+
+    files_scanned: int = 0
+    files_with_mod_gil: int = 0
+    declarations: list[ModGilDeclaration] = field(default_factory=list)
+
+    @property
+    def has_any_declaration(self) -> bool:
+        return len(self.declarations) > 0
+
+    @property
+    def all_not_used(self) -> bool:
+        """True if every declaration is Py_MOD_GIL_NOT_USED."""
+        return len(self.declarations) > 0 and all(d.is_not_used for d in self.declarations)
+
+    @property
+    def has_required(self) -> bool:
+        """True if any declaration is Py_MOD_GIL_USED."""
+        return any(not d.is_not_used for d in self.declarations)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "files_scanned": self.files_scanned,
+            "files_with_mod_gil": self.files_with_mod_gil,
+            "declarations": [d.to_dict() for d in self.declarations],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SourceScanResult:
+        decls = [ModGilDeclaration.from_dict(d) for d in data.get("declarations", [])]
+        return cls(
+            files_scanned=data.get("files_scanned", 0),
+            files_with_mod_gil=data.get("files_with_mod_gil", 0),
+            declarations=decls,
+        )
+
+
+@dataclass
+class ExtensionCompat:
+    """Complete GIL compatibility assessment for a package."""
+
+    package: str
+    is_pure_python: bool = True
+    extensions: list[ExtensionInfo] = field(default_factory=list)
+    gil_fallback_active: bool = False
+    all_extensions_compatible: bool = True
+    import_ok: bool = True
+    import_error: str | None = None
+    source_scan: SourceScanResult | None = None
+    probe_error: str | None = None
+
+    @property
+    def fully_compatible(self) -> bool:
+        """True if the package is fully free-threading compatible.
+
+        This means: importable, no GIL fallback, and either pure
+        Python or all extensions declare Py_MOD_GIL_NOT_USED.
+        """
+        return self.import_ok and not self.gil_fallback_active and self.all_extensions_compatible
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "package": self.package,
+            "is_pure_python": self.is_pure_python,
+            "extensions": [e.to_dict() for e in self.extensions],
+            "gil_fallback_active": self.gil_fallback_active,
+            "all_extensions_compatible": self.all_extensions_compatible,
+            "import_ok": self.import_ok,
+            "import_error": self.import_error,
+            "probe_error": self.probe_error,
+        }
+        if self.source_scan is not None:
+            d["source_scan"] = self.source_scan.to_dict()
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExtensionCompat:
+        exts = [ExtensionInfo.from_dict(e) for e in data.get("extensions", [])]
+        scan_data = data.get("source_scan")
+        scan = SourceScanResult.from_dict(scan_data) if scan_data else None
+        return cls(
+            package=data["package"],
+            is_pure_python=data.get("is_pure_python", True),
+            extensions=exts,
+            gil_fallback_active=data.get("gil_fallback_active", False),
+            all_extensions_compatible=data.get("all_extensions_compatible", True),
+            import_ok=data.get("import_ok", True),
+            import_error=data.get("import_error"),
+            source_scan=scan,
+            probe_error=data.get("probe_error"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runtime GIL fallback probe
+# ---------------------------------------------------------------------------
+
+# The probe script runs inside the target free-threaded Python.
+# It must be self-contained (no labeille imports).
+_GIL_PROBE_SCRIPT = r'''
+import importlib
+import json
+import sys
+
+def probe_package(package_name):
+    """Import a package and detect GIL fallback."""
+    result = {
+        "package": package_name,
+        "import_ok": False,
+        "import_error": None,
+        "gil_enabled_before": None,
+        "gil_enabled_after": None,
+        "gil_fallback": False,
+        "is_pure_python": True,
+        "extensions_found": [],
+    }
+
+    # Check GIL state before import.
+    try:
+        result["gil_enabled_before"] = sys._is_gil_enabled()
+    except AttributeError:
+        # Not a free-threaded build.
+        result["import_error"] = "Not a free-threaded Python build"
+        print(json.dumps(result))
+        return
+
+    # Import the package.
+    try:
+        pkg = importlib.import_module(package_name)
+        result["import_ok"] = True
+    except ImportError as e:
+        result["import_error"] = str(e)
+        print(json.dumps(result))
+        return
+    except Exception as e:
+        result["import_error"] = f"{type(e).__name__}: {e}"
+        print(json.dumps(result))
+        return
+
+    # Check GIL state after import.
+    result["gil_enabled_after"] = sys._is_gil_enabled()
+    result["gil_fallback"] = (
+        not result["gil_enabled_before"]
+        and result["gil_enabled_after"]
+    )
+
+    # Check if the package has extension modules.
+    # Walk through the package's submodules if it has __path__.
+    checked = set()
+    to_check = [package_name]
+    if hasattr(pkg, "__path__"):
+        try:
+            import pkgutil
+            for importer, modname, ispkg in pkgutil.walk_packages(
+                pkg.__path__, prefix=package_name + ".",
+                onerror=lambda x: None,
+            ):
+                to_check.append(modname)
+                if len(to_check) > 200:  # Safety limit.
+                    break
+        except Exception:
+            pass
+
+    for modname in to_check:
+        if modname in checked:
+            continue
+        checked.add(modname)
+        try:
+            mod = importlib.import_module(modname)
+            filepath = getattr(mod, "__file__", "") or ""
+            if filepath.endswith((".so", ".pyd", ".dylib")):
+                result["is_pure_python"] = False
+                result["extensions_found"].append({
+                    "module_name": modname,
+                    "is_extension": True,
+                    "file": filepath,
+                })
+        except Exception:
+            pass  # Some submodules may not be importable.
+
+    print(json.dumps(result))
+
+probe_package(sys.argv[1])
+'''
+
+
+def probe_gil_fallback(
+    package_name: str,
+    venv_python: Path,
+    *,
+    env: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> ExtensionCompat:
+    """Probe a package's GIL fallback behavior in a venv.
+
+    Imports the package in the target Python and checks whether
+    the GIL was re-enabled after import.
+
+    Args:
+        package_name: The top-level import name of the package.
+            This may differ from the PyPI name (e.g., "PIL" for
+            "Pillow", "yaml" for "PyYAML").
+        venv_python: Path to the Python executable in the venv
+            where the package is installed.
+        env: Environment variables for the subprocess. Should
+            include PYTHON_GIL=0 to ensure free-threading is active.
+        timeout: Timeout in seconds for the probe.
+
+    Returns:
+        ExtensionCompat with runtime probe results.
+    """
+    compat = ExtensionCompat(package=package_name)
+
+    run_env = dict(os.environ)
+    run_env["PYTHON_GIL"] = "0"
+    run_env.pop("PYTHONHOME", None)
+    run_env.pop("PYTHONPATH", None)
+    run_env["ASAN_OPTIONS"] = "detect_leaks=0"
+    if env:
+        run_env.update(env)
+
+    try:
+        proc = subprocess.run(
+            [str(venv_python), "-c", _GIL_PROBE_SCRIPT, package_name],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=run_env,
+        )
+
+        if proc.returncode != 0:
+            compat.import_ok = False
+            compat.probe_error = (
+                f"Probe exited with code {proc.returncode}: {proc.stderr.strip()[:500]}"
+            )
+            return compat
+
+        if not proc.stdout.strip():
+            compat.probe_error = "Probe produced no output"
+            return compat
+
+        data = json.loads(proc.stdout.strip())
+
+        compat.import_ok = data.get("import_ok", False)
+        compat.import_error = data.get("import_error")
+        compat.gil_fallback_active = data.get("gil_fallback", False)
+        compat.is_pure_python = data.get("is_pure_python", True)
+
+        if not compat.is_pure_python:
+            compat.all_extensions_compatible = not compat.gil_fallback_active
+
+        for ext_data in data.get("extensions_found", []):
+            compat.extensions.append(
+                ExtensionInfo(
+                    module_name=ext_data["module_name"],
+                    is_extension=True,
+                    import_ok=True,
+                )
+            )
+
+    except subprocess.TimeoutExpired:
+        compat.probe_error = f"Probe timed out after {timeout}s"
+        compat.import_ok = False
+    except json.JSONDecodeError as exc:
+        compat.probe_error = f"Probe output not valid JSON: {exc}"
+    except (FileNotFoundError, OSError) as exc:
+        compat.probe_error = f"Could not run probe: {exc}"
+
+    return compat
+
+
+# ---------------------------------------------------------------------------
+# Import name resolution
+# ---------------------------------------------------------------------------
+
+_IMPORT_NAME_OVERRIDES: dict[str, str] = {
+    "pillow": "PIL",
+    "pyyaml": "yaml",
+    "beautifulsoup4": "bs4",
+    "scikit-learn": "sklearn",
+    "python-dateutil": "dateutil",
+    "python-dotenv": "dotenv",
+    "msgpack-python": "msgpack",
+    "attrs": "attr",
+    "protobuf": "google.protobuf",
+    "opencv-python": "cv2",
+    "ruamel.yaml": "ruamel.yaml",
+    "pymongo": "pymongo",
+    "ujson": "ujson",
+}
+
+
+def guess_import_name(pypi_name: str) -> str:
+    """Guess the import name from a PyPI package name.
+
+    Checks a known override table first, then falls back to
+    replacing hyphens with underscores (covers most cases).
+
+    Args:
+        pypi_name: The PyPI package name (e.g., "scikit-learn").
+
+    Returns:
+        The guessed import name (e.g., "sklearn").
+    """
+    lower = pypi_name.lower()
+    if lower in _IMPORT_NAME_OVERRIDES:
+        return _IMPORT_NAME_OVERRIDES[lower]
+    return lower.replace("-", "_")
+
+
+# ---------------------------------------------------------------------------
+# Source code scanning for Py_mod_gil
+# ---------------------------------------------------------------------------
+
+_SOURCE_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".pyx",
+    ".pxd",
+}
+
+_SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    "node_modules",
+    ".tox",
+    ".eggs",
+    ".mypy_cache",
+    "build",
+    "dist",
+    ".venv",
+    "venv",
+    "env",
+}
+
+_MOD_GIL_PATTERN = re.compile(
+    r"""
+    Py_mod_gil              # The slot identifier
+    \s*[,\s]\s*             # Separator (comma or whitespace)
+    (Py_MOD_GIL_NOT_USED    # The value we're looking for
+    |Py_MOD_GIL_USED)       # Or the explicit GIL-required value
+    """,
+    re.VERBOSE,
+)
+
+_MOD_GIL_MENTION_PATTERN = re.compile(r"Py_MOD_GIL_NOT_USED|Py_MOD_GIL_USED|Py_mod_gil")
+
+
+def scan_source_for_mod_gil(
+    repo_dir: Path,
+    *,
+    max_files: int = 5000,
+    max_file_size: int = 1_000_000,
+) -> SourceScanResult:
+    """Scan a repository's source files for Py_mod_gil declarations.
+
+    Walks the repository looking for C/C++/Cython files and searches
+    for Py_mod_gil slot declarations. This detects whether the
+    developer has opted into free-threading support at the source
+    level.
+
+    Args:
+        repo_dir: Path to the cloned repository root.
+        max_files: Maximum number of source files to scan (safety
+            limit for huge repos).
+        max_file_size: Maximum size of a single file to scan in
+            bytes.
+
+    Returns:
+        SourceScanResult with all declarations found.
+    """
+    result = SourceScanResult()
+    files_checked = 0
+
+    for source_file in _walk_source_files(repo_dir):
+        if files_checked >= max_files:
+            log.debug(
+                "Source scan hit file limit (%d) in %s",
+                max_files,
+                repo_dir,
+            )
+            break
+
+        files_checked += 1
+
+        try:
+            size = source_file.stat().st_size
+            if size > max_file_size:
+                continue
+            content = source_file.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        result.files_scanned += 1
+        file_has_declaration = False
+
+        for line_num, line in enumerate(content.splitlines(), 1):
+            match = _MOD_GIL_PATTERN.search(line)
+            if match:
+                value = match.group(1)
+                result.declarations.append(
+                    ModGilDeclaration(
+                        file=str(source_file.relative_to(repo_dir)),
+                        line_number=line_num,
+                        line_text=line.strip()[:200],
+                        is_not_used=(value == "Py_MOD_GIL_NOT_USED"),
+                    )
+                )
+                file_has_declaration = True
+
+        if file_has_declaration:
+            result.files_with_mod_gil += 1
+
+    return result
+
+
+def _walk_source_files(repo_dir: Path) -> Iterator[Path]:
+    """Yield C/C++/Cython source files in a repo, skipping junk dirs."""
+    for root, dirs, files in os.walk(repo_dir):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS and not d.startswith(".")]
+
+        for filename in files:
+            ext = Path(filename).suffix.lower()
+            if ext in _SOURCE_EXTENSIONS:
+                yield Path(root) / filename
+
+
+# ---------------------------------------------------------------------------
+# Combined assessment
+# ---------------------------------------------------------------------------
+
+
+def assess_extension_compat(
+    package_name: str,
+    *,
+    venv_python: Path | None = None,
+    repo_dir: Path | None = None,
+    import_name: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> ExtensionCompat:
+    """Run both runtime probe and source scan for a package.
+
+    Either or both of venv_python (for runtime probe) and repo_dir
+    (for source scan) can be provided. If both are given, results
+    are combined.
+
+    Args:
+        package_name: PyPI package name.
+        venv_python: Path to Python in the package's venv (for probe).
+        repo_dir: Path to the cloned repo (for source scan).
+        import_name: Override for the import name. If None, guessed
+            from package_name.
+        env: Environment variables for the probe subprocess.
+        timeout: Timeout for the runtime probe.
+
+    Returns:
+        ExtensionCompat with combined results.
+    """
+    actual_import_name = import_name or guess_import_name(package_name)
+
+    if venv_python is not None:
+        compat = probe_gil_fallback(
+            actual_import_name,
+            venv_python,
+            env=env,
+            timeout=timeout,
+        )
+    else:
+        compat = ExtensionCompat(package=package_name)
+
+    if repo_dir is not None:
+        try:
+            scan = scan_source_for_mod_gil(repo_dir)
+            compat.source_scan = scan
+
+            if venv_python is None:
+                compat.is_pure_python = not scan.has_any_declaration
+                if scan.has_any_declaration:
+                    compat.all_extensions_compatible = scan.all_not_used
+        except Exception as exc:
+            log.warning("Source scan failed for %s: %s", package_name, exc)
+
+    return compat
+
+
+# ---------------------------------------------------------------------------
+# Display helper
+# ---------------------------------------------------------------------------
+
+
+def format_extension_compat(compat: ExtensionCompat) -> str:
+    """Format extension compatibility for terminal display."""
+    lines = [f"Extension compatibility: {compat.package}"]
+
+    if not compat.import_ok:
+        lines.append(f"  Import failed: {compat.import_error}")
+        return "\n".join(lines)
+
+    if compat.is_pure_python:
+        lines.append("  Pure Python (no C extensions)")
+    else:
+        n_ext = len(compat.extensions)
+        lines.append(f"  C extensions found: {n_ext}")
+        if compat.gil_fallback_active:
+            lines.append("  GIL fallback: ACTIVE (not free-threading safe)")
+        else:
+            lines.append("  GIL fallback: not triggered")
+
+        for ext in compat.extensions:
+            status = "ok" if ext.import_ok else f"FAILED: {ext.import_error}"
+            lines.append(f"    {ext.module_name}: {status}")
+
+    if compat.source_scan is not None:
+        scan = compat.source_scan
+        lines.append(
+            f"  Source scan: {scan.files_scanned} files, "
+            f"{len(scan.declarations)} Py_mod_gil declarations"
+        )
+        for decl in scan.declarations:
+            kind = "NOT_USED" if decl.is_not_used else "USED"
+            lines.append(f"    {decl.file}:{decl.line_number} \u2192 {kind}")
+
+        if scan.has_any_declaration and scan.all_not_used:
+            lines.append("  Source declares full free-threading support")
+        elif scan.has_required:
+            lines.append("  Source declares GIL requirement in some modules")
+        elif not scan.has_any_declaration and not compat.is_pure_python:
+            lines.append(
+                "  No Py_mod_gil declarations found \u2014 extension may "
+                "not have been updated for free-threading"
+            )
+
+    return "\n".join(lines)

--- a/tests/test_ft_compat.py
+++ b/tests/test_ft_compat.py
@@ -1,0 +1,616 @@
+"""Tests for labeille.ft.compat — extension GIL compatibility detection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from labeille.ft.compat import (
+    ExtensionCompat,
+    ExtensionInfo,
+    ModGilDeclaration,
+    SourceScanResult,
+    assess_extension_compat,
+    format_extension_compat,
+    guess_import_name,
+    probe_gil_fallback,
+    scan_source_for_mod_gil,
+)
+
+
+# ---------------------------------------------------------------------------
+# ExtensionCompat dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionCompat(unittest.TestCase):
+    def test_extension_compat_pure_python(self) -> None:
+        compat = ExtensionCompat(
+            package="mypackage",
+            is_pure_python=True,
+            import_ok=True,
+            gil_fallback_active=False,
+        )
+        self.assertTrue(compat.fully_compatible)
+
+    def test_extension_compat_with_fallback(self) -> None:
+        compat = ExtensionCompat(
+            package="mypackage",
+            gil_fallback_active=True,
+        )
+        self.assertFalse(compat.fully_compatible)
+
+    def test_extension_compat_import_failure(self) -> None:
+        compat = ExtensionCompat(
+            package="mypackage",
+            import_ok=False,
+        )
+        self.assertFalse(compat.fully_compatible)
+
+    def test_extension_compat_incompatible_extensions(self) -> None:
+        compat = ExtensionCompat(
+            package="mypackage",
+            all_extensions_compatible=False,
+        )
+        self.assertFalse(compat.fully_compatible)
+
+    def test_extension_compat_serialization_roundtrip(self) -> None:
+        compat = ExtensionCompat(
+            package="mypackage",
+            is_pure_python=False,
+            extensions=[
+                ExtensionInfo(
+                    module_name="mypackage._accel",
+                    is_extension=True,
+                    import_ok=True,
+                ),
+            ],
+            gil_fallback_active=True,
+            all_extensions_compatible=False,
+            import_ok=True,
+            source_scan=SourceScanResult(
+                files_scanned=10,
+                files_with_mod_gil=1,
+                declarations=[
+                    ModGilDeclaration(
+                        file="src/_accel.c",
+                        line_number=42,
+                        line_text="{Py_mod_gil, Py_MOD_GIL_NOT_USED}",
+                        is_not_used=True,
+                    ),
+                ],
+            ),
+            probe_error=None,
+        )
+        d = compat.to_dict()
+        restored = ExtensionCompat.from_dict(d)
+        self.assertEqual(restored.package, "mypackage")
+        self.assertFalse(restored.is_pure_python)
+        self.assertTrue(restored.gil_fallback_active)
+        self.assertFalse(restored.all_extensions_compatible)
+        self.assertTrue(restored.import_ok)
+        self.assertEqual(len(restored.extensions), 1)
+        self.assertEqual(restored.extensions[0].module_name, "mypackage._accel")
+        self.assertIsNotNone(restored.source_scan)
+        assert restored.source_scan is not None
+        self.assertEqual(restored.source_scan.files_scanned, 10)
+        self.assertEqual(len(restored.source_scan.declarations), 1)
+        self.assertTrue(restored.source_scan.declarations[0].is_not_used)
+
+    def test_extension_compat_from_dict_missing_fields(self) -> None:
+        d = {"package": "minimal"}
+        restored = ExtensionCompat.from_dict(d)
+        self.assertEqual(restored.package, "minimal")
+        self.assertTrue(restored.is_pure_python)
+        self.assertTrue(restored.import_ok)
+        self.assertFalse(restored.gil_fallback_active)
+        self.assertIsNone(restored.source_scan)
+        self.assertIsNone(restored.probe_error)
+
+
+# ---------------------------------------------------------------------------
+# SourceScanResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceScanResult(unittest.TestCase):
+    def test_source_scan_all_not_used(self) -> None:
+        result = SourceScanResult(
+            declarations=[
+                ModGilDeclaration("a.c", 1, "...", is_not_used=True),
+                ModGilDeclaration("b.c", 2, "...", is_not_used=True),
+            ],
+        )
+        self.assertTrue(result.all_not_used)
+        self.assertFalse(result.has_required)
+        self.assertTrue(result.has_any_declaration)
+
+    def test_source_scan_mixed(self) -> None:
+        result = SourceScanResult(
+            declarations=[
+                ModGilDeclaration("a.c", 1, "...", is_not_used=True),
+                ModGilDeclaration("b.c", 2, "...", is_not_used=False),
+            ],
+        )
+        self.assertFalse(result.all_not_used)
+        self.assertTrue(result.has_required)
+
+    def test_source_scan_empty(self) -> None:
+        result = SourceScanResult()
+        self.assertFalse(result.has_any_declaration)
+        self.assertFalse(result.all_not_used)
+        self.assertFalse(result.has_required)
+
+    def test_source_scan_serialization_roundtrip(self) -> None:
+        result = SourceScanResult(
+            files_scanned=5,
+            files_with_mod_gil=2,
+            declarations=[
+                ModGilDeclaration("x.c", 10, "line text", is_not_used=True),
+            ],
+        )
+        d = result.to_dict()
+        restored = SourceScanResult.from_dict(d)
+        self.assertEqual(restored.files_scanned, 5)
+        self.assertEqual(restored.files_with_mod_gil, 2)
+        self.assertEqual(len(restored.declarations), 1)
+        self.assertTrue(restored.declarations[0].is_not_used)
+
+
+# ---------------------------------------------------------------------------
+# Import name guessing tests
+# ---------------------------------------------------------------------------
+
+
+class TestGuessImportName(unittest.TestCase):
+    def test_guess_import_name_override(self) -> None:
+        self.assertEqual(guess_import_name("pillow"), "PIL")
+
+    def test_guess_import_name_override_case_insensitive(self) -> None:
+        self.assertEqual(guess_import_name("PyYAML"), "yaml")
+
+    def test_guess_import_name_hyphen(self) -> None:
+        self.assertEqual(guess_import_name("my-package"), "my_package")
+
+    def test_guess_import_name_simple(self) -> None:
+        self.assertEqual(guess_import_name("requests"), "requests")
+
+    def test_guess_import_name_scikit_learn(self) -> None:
+        self.assertEqual(guess_import_name("scikit-learn"), "sklearn")
+
+    def test_guess_import_name_attrs(self) -> None:
+        self.assertEqual(guess_import_name("attrs"), "attr")
+
+    def test_guess_import_name_beautifulsoup4(self) -> None:
+        self.assertEqual(guess_import_name("beautifulsoup4"), "bs4")
+
+
+# ---------------------------------------------------------------------------
+# Source scanning tests
+# ---------------------------------------------------------------------------
+
+
+class TestScanSourceForModGil(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo = Path(self.tmpdir)
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, relpath: str, content: str) -> Path:
+        p = self.repo / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return p
+
+    def test_scan_finds_not_used(self) -> None:
+        self._write_file("src/mod.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 1)
+        self.assertTrue(result.declarations[0].is_not_used)
+        self.assertEqual(result.files_with_mod_gil, 1)
+
+    def test_scan_finds_used(self) -> None:
+        self._write_file("src/mod.c", "{Py_mod_gil, Py_MOD_GIL_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 1)
+        self.assertFalse(result.declarations[0].is_not_used)
+
+    def test_scan_multiple_files(self) -> None:
+        self._write_file("a.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        self._write_file("b.c", "{Py_mod_gil, Py_MOD_GIL_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(result.files_with_mod_gil, 2)
+        self.assertEqual(len(result.declarations), 2)
+
+    def test_scan_skips_git_dir(self) -> None:
+        self._write_file(".git/hooks/mod.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 0)
+
+    def test_scan_skips_build_dir(self) -> None:
+        self._write_file("build/mod.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 0)
+
+    def test_scan_respects_max_files(self) -> None:
+        for i in range(5):
+            self._write_file(f"mod{i}.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo, max_files=1)
+        self.assertLessEqual(result.files_scanned, 1)
+
+    def test_scan_ignores_non_source(self) -> None:
+        self._write_file("mod.py", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        self._write_file("mod.txt", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(result.files_scanned, 0)
+        self.assertEqual(len(result.declarations), 0)
+
+    def test_scan_empty_repo(self) -> None:
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(result.files_scanned, 0)
+        self.assertEqual(len(result.declarations), 0)
+
+    def test_scan_handles_binary_files(self) -> None:
+        p = self.repo / "mod.c"
+        p.write_bytes(b"\x80\x81\x82 {Py_mod_gil, Py_MOD_GIL_NOT_USED} \xff\xfe")
+        result = scan_source_for_mod_gil(self.repo)
+        # Should not crash; file is read with errors="replace".
+        self.assertEqual(result.files_scanned, 1)
+        self.assertEqual(len(result.declarations), 1)
+
+    def test_scan_pyx_files(self) -> None:
+        self._write_file("ext.pyx", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 1)
+
+    def test_scan_realistic_c_source(self) -> None:
+        source = """\
+#include <Python.h>
+
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_exec, module_exec},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+"""
+        self._write_file("src/_accel.c", source)
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 1)
+        decl = result.declarations[0]
+        self.assertTrue(decl.is_not_used)
+        self.assertEqual(decl.line_number, 5)
+        self.assertIn("Py_MOD_GIL_NOT_USED", decl.line_text)
+
+    def test_scan_multiline_declaration(self) -> None:
+        # One-line variant: should be found.
+        self._write_file("oneline.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        # Two-line variant: line-based regex won't match — this is acceptable.
+        self._write_file("twoline.c", "{Py_mod_gil,\n    Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        # Only the one-line version should be found.
+        self.assertEqual(len(result.declarations), 1)
+        self.assertEqual(result.declarations[0].file, "oneline.c")
+
+    def test_scan_commented_out(self) -> None:
+        # Commented-out declarations are still found — intentionally.
+        # They indicate developer awareness of free-threading.
+        self._write_file("mod.c", "// {Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo)
+        self.assertEqual(len(result.declarations), 1)
+
+    def test_scan_large_file_skipped(self) -> None:
+        # Create a file larger than max_file_size.
+        self._write_file("big.c", "x" * 100 + "\n{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = scan_source_for_mod_gil(self.repo, max_file_size=50)
+        self.assertEqual(len(result.declarations), 0)
+
+
+# ---------------------------------------------------------------------------
+# Runtime probe tests (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeGilFallback(unittest.TestCase):
+    def _make_probe_result(self, **overrides: object) -> str:
+        data: dict[str, object] = {
+            "package": "mypkg",
+            "import_ok": True,
+            "import_error": None,
+            "gil_enabled_before": False,
+            "gil_enabled_after": False,
+            "gil_fallback": False,
+            "is_pure_python": True,
+            "extensions_found": [],
+        }
+        data.update(overrides)
+        return json.dumps(data)
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_successful_pure_python(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_probe_result(),
+            stderr="",
+        )
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertTrue(result.import_ok)
+        self.assertTrue(result.is_pure_python)
+        self.assertTrue(result.fully_compatible)
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_successful_with_fallback(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_probe_result(
+                gil_fallback=True,
+                is_pure_python=False,
+                extensions_found=[
+                    {"module_name": "mypkg._accel", "is_extension": True, "file": "/x.so"},
+                ],
+            ),
+            stderr="",
+        )
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertTrue(result.gil_fallback_active)
+        self.assertFalse(result.is_pure_python)
+        self.assertFalse(result.fully_compatible)
+        self.assertEqual(len(result.extensions), 1)
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_import_failure(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_probe_result(
+                import_ok=False,
+                import_error="No module named 'foo'",
+            ),
+            stderr="",
+        )
+        result = probe_gil_fallback("foo", Path("/fake/bin/python"))
+        self.assertFalse(result.import_ok)
+        self.assertEqual(result.import_error, "No module named 'foo'")
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_subprocess_timeout(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="python", timeout=60)
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertIn("timed out", result.probe_error or "")
+        self.assertFalse(result.import_ok)
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_subprocess_crash(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=-11,
+            stdout="",
+            stderr="Segmentation fault",
+        )
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertFalse(result.import_ok)
+        self.assertIn("-11", result.probe_error or "")
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_invalid_json(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="not json at all",
+            stderr="",
+        )
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertIn("JSON", result.probe_error or "")
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_nonexistent_python(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("No such file")
+        result = probe_gil_fallback("mypkg", Path("/nonexistent/python"))
+        self.assertIn("Could not run probe", result.probe_error or "")
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_sets_python_gil_0(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_probe_result(),
+            stderr="",
+        )
+        probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        call_kwargs = mock_run.call_args[1]
+        self.assertEqual(call_kwargs["env"]["PYTHON_GIL"], "0")
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_strips_pythonhome(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_probe_result(),
+            stderr="",
+        )
+        with patch.dict(os.environ, {"PYTHONHOME": "/bad"}):
+            probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        call_kwargs = mock_run.call_args[1]
+        self.assertNotIn("PYTHONHOME", call_kwargs["env"])
+
+    @patch("labeille.ft.compat.subprocess.run")
+    def test_probe_no_output(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        result = probe_gil_fallback("mypkg", Path("/fake/bin/python"))
+        self.assertIn("no output", result.probe_error or "")
+
+
+# ---------------------------------------------------------------------------
+# Combined assessment tests (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestAssessExtensionCompat(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo = Path(self.tmpdir)
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, relpath: str, content: str) -> None:
+        p = self.repo / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+    @patch("labeille.ft.compat.probe_gil_fallback")
+    def test_assess_both_probe_and_scan(self, mock_probe: MagicMock) -> None:
+        mock_probe.return_value = ExtensionCompat(
+            package="mypkg",
+            import_ok=True,
+            is_pure_python=False,
+            gil_fallback_active=False,
+        )
+        self._write_file("src/mod.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+
+        result = assess_extension_compat(
+            "mypkg",
+            venv_python=Path("/fake/bin/python"),
+            repo_dir=self.repo,
+        )
+        self.assertTrue(result.import_ok)
+        self.assertIsNotNone(result.source_scan)
+        assert result.source_scan is not None
+        self.assertEqual(len(result.source_scan.declarations), 1)
+
+    def test_assess_scan_only(self) -> None:
+        self._write_file("src/mod.c", "{Py_mod_gil, Py_MOD_GIL_NOT_USED}")
+        result = assess_extension_compat("mypkg", repo_dir=self.repo)
+        self.assertIsNotNone(result.source_scan)
+        # Without runtime probe, infer from source.
+        self.assertFalse(result.is_pure_python)
+        self.assertTrue(result.all_extensions_compatible)
+
+    @patch("labeille.ft.compat.probe_gil_fallback")
+    def test_assess_probe_only(self, mock_probe: MagicMock) -> None:
+        mock_probe.return_value = ExtensionCompat(
+            package="mypkg",
+            import_ok=True,
+            is_pure_python=True,
+        )
+        result = assess_extension_compat(
+            "mypkg",
+            venv_python=Path("/fake/bin/python"),
+        )
+        self.assertIsNone(result.source_scan)
+        self.assertTrue(result.is_pure_python)
+
+    @patch("labeille.ft.compat.probe_gil_fallback")
+    def test_assess_uses_custom_import_name(self, mock_probe: MagicMock) -> None:
+        mock_probe.return_value = ExtensionCompat(package="PIL")
+        assess_extension_compat(
+            "pillow",
+            venv_python=Path("/fake/bin/python"),
+            import_name="PIL",
+        )
+        mock_probe.assert_called_once()
+        self.assertEqual(mock_probe.call_args[0][0], "PIL")
+
+    def test_assess_scan_with_used_declaration(self) -> None:
+        self._write_file("src/mod.c", "{Py_mod_gil, Py_MOD_GIL_USED}")
+        result = assess_extension_compat("mypkg", repo_dir=self.repo)
+        self.assertFalse(result.is_pure_python)
+        self.assertFalse(result.all_extensions_compatible)
+
+    def test_assess_no_source_no_probe(self) -> None:
+        result = assess_extension_compat("mypkg")
+        self.assertEqual(result.package, "mypkg")
+        self.assertTrue(result.is_pure_python)
+        self.assertIsNone(result.source_scan)
+
+
+# ---------------------------------------------------------------------------
+# Display tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatExtensionCompat(unittest.TestCase):
+    def test_format_pure_python(self) -> None:
+        compat = ExtensionCompat(package="mypkg", is_pure_python=True, import_ok=True)
+        output = format_extension_compat(compat)
+        self.assertIn("Pure Python", output)
+
+    def test_format_with_fallback(self) -> None:
+        compat = ExtensionCompat(
+            package="mypkg",
+            is_pure_python=False,
+            import_ok=True,
+            gil_fallback_active=True,
+            extensions=[
+                ExtensionInfo(module_name="mypkg._ext", is_extension=True),
+            ],
+        )
+        output = format_extension_compat(compat)
+        self.assertIn("ACTIVE", output)
+        self.assertIn("mypkg._ext", output)
+
+    def test_format_with_source_scan(self) -> None:
+        compat = ExtensionCompat(
+            package="mypkg",
+            import_ok=True,
+            is_pure_python=False,
+            source_scan=SourceScanResult(
+                files_scanned=10,
+                files_with_mod_gil=1,
+                declarations=[
+                    ModGilDeclaration("mod.c", 42, "...", is_not_used=True),
+                ],
+            ),
+        )
+        output = format_extension_compat(compat)
+        self.assertIn("Py_mod_gil declarations", output)
+        self.assertIn("mod.c:42", output)
+        self.assertIn("free-threading support", output)
+
+    def test_format_import_failure(self) -> None:
+        compat = ExtensionCompat(
+            package="mypkg",
+            import_ok=False,
+            import_error="No module named 'mypkg'",
+        )
+        output = format_extension_compat(compat)
+        self.assertIn("Import failed", output)
+        self.assertIn("No module named", output)
+
+    def test_format_source_scan_with_used(self) -> None:
+        compat = ExtensionCompat(
+            package="mypkg",
+            import_ok=True,
+            is_pure_python=False,
+            source_scan=SourceScanResult(
+                files_scanned=5,
+                declarations=[
+                    ModGilDeclaration("mod.c", 10, "...", is_not_used=False),
+                ],
+            ),
+        )
+        output = format_extension_compat(compat)
+        self.assertIn("GIL requirement", output)
+
+    def test_format_no_declarations_extension(self) -> None:
+        compat = ExtensionCompat(
+            package="mypkg",
+            import_ok=True,
+            is_pure_python=False,
+            source_scan=SourceScanResult(files_scanned=5),
+        )
+        output = format_extension_compat(compat)
+        self.assertIn("No Py_mod_gil declarations found", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Create `ft` subpackage with `compat.py` module for detecting C extension GIL compatibility
- Runtime probe via `sys._is_gil_enabled()` detects GIL fallback after package import
- Source scan searches C/C++/Cython files for `Py_mod_gil` declarations
- Import name resolution with `guess_import_name()` and override table

## Test plan
- [x] 53 new tests in `tests/test_ft_compat.py` covering all dataclasses, serialization, source scanning, runtime probe (mocked), combined assessment, and display formatting
- [x] ruff format — clean
- [x] ruff check — clean
- [x] mypy strict — clean
- [x] All 1208 tests pass

Closes #76

Generated with [Claude Code](https://claude.com/claude-code)