### PR TITLE
feat: add free-threading result dataclasses and categorization (ft/results.py)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `ft/results.py` module with `FailureCategory` enum, `IterationOutcome`, `FTPackageResult`, `FTRunMeta`, and `FTRunSummary` dataclasses for free-threading result storage, categorization, and JSONL/JSON serialization.
+- `categorize_package()` priority-ordered classification (install failure > import failure > deadlock > crash > TSAN > GIL fallback > compatible > incompatible > intermittent).
 - `ft` subpackage with `compat.py` module for extension GIL compatibility detection: runtime probe via `sys._is_gil_enabled()` and source scan for `Py_mod_gil` declarations.
 - `ExtensionInfo`, `SourceScanResult`, `ModGilDeclaration`, and `ExtensionCompat` dataclasses with JSON serialization.
 - `probe_gil_fallback()` runtime probe, `scan_source_for_mod_gil()` source scanner, `assess_extension_compat()` combined assessment, and `format_extension_compat()` display helper.

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -1,0 +1,585 @@
+"""Result dataclasses for free-threading compatibility testing.
+
+Three levels of results:
+- IterationOutcome: a single run of a package's test suite.
+- FTPackageResult: all iterations for one package, with aggregate
+  statistics and a compatibility category.
+- FTRunResult: all packages in a complete test run, with metadata
+  and summary statistics.
+
+Serialization uses JSONL (one line per package) for incremental
+writing during long runs, plus JSON for metadata and summaries.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("labeille")
+
+
+class FailureCategory(enum.Enum):
+    """Classification of a package's free-threading compatibility.
+
+    Ordered roughly by severity, from fully working to untestable.
+    """
+
+    COMPATIBLE = "compatible"
+    COMPATIBLE_GIL_FALLBACK = "compatible_gil_fallback"
+    INTERMITTENT = "intermittent"
+    INCOMPATIBLE = "incompatible"
+    CRASH = "crash"
+    DEADLOCK = "deadlock"
+    TSAN_WARNINGS = "tsan_warnings"
+    INSTALL_FAILURE = "install_failure"
+    IMPORT_FAILURE = "import_failure"
+    UNKNOWN = "unknown"
+
+    @property
+    def is_usable(self) -> bool:
+        """True if the package at least works sometimes."""
+        return self in (
+            FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_GIL_FALLBACK,
+            FailureCategory.INTERMITTENT,
+            FailureCategory.TSAN_WARNINGS,
+        )
+
+    @property
+    def severity(self) -> int:
+        """Numeric severity for sorting (higher = worse)."""
+        order = {
+            FailureCategory.COMPATIBLE: 0,
+            FailureCategory.COMPATIBLE_GIL_FALLBACK: 1,
+            FailureCategory.TSAN_WARNINGS: 2,
+            FailureCategory.INTERMITTENT: 3,
+            FailureCategory.INCOMPATIBLE: 4,
+            FailureCategory.CRASH: 5,
+            FailureCategory.DEADLOCK: 6,
+            FailureCategory.INSTALL_FAILURE: 7,
+            FailureCategory.IMPORT_FAILURE: 8,
+            FailureCategory.UNKNOWN: 9,
+        }
+        return order.get(self, 9)
+
+    @property
+    def symbol(self) -> str:
+        """Single-character symbol for compact display."""
+        symbols = {
+            FailureCategory.COMPATIBLE: "\u2713",
+            FailureCategory.COMPATIBLE_GIL_FALLBACK: "\u26a0",
+            FailureCategory.INTERMITTENT: "~",
+            FailureCategory.INCOMPATIBLE: "\u2717",
+            FailureCategory.CRASH: "\U0001f4a5",
+            FailureCategory.DEADLOCK: "\U0001f512",
+            FailureCategory.TSAN_WARNINGS: "\u26a1",
+            FailureCategory.INSTALL_FAILURE: "\u2699",
+            FailureCategory.IMPORT_FAILURE: "\U0001f4e6",
+            FailureCategory.UNKNOWN: "?",
+        }
+        return symbols.get(self, "?")
+
+
+@dataclass
+class IterationOutcome:
+    """Result of a single test suite execution.
+
+    Captures the status, timing, crash info, deadlock detection,
+    and TSAN warnings for one iteration.
+    """
+
+    index: int
+    status: str  # pass, fail, crash, timeout, deadlock
+    exit_code: int | None = None
+    duration_s: float = 0.0
+    crash_signal: str | None = None
+    crash_signature: str | None = None
+    tsan_warnings: list[str] = field(default_factory=list)
+    output_stalled: bool = False
+    last_output_line: str = ""
+    stderr_tail: str = ""
+    test_results: dict[str, str] = field(default_factory=dict)
+    tests_passed: int | None = None
+    tests_failed: int | None = None
+    tests_errored: int | None = None
+    tests_skipped: int | None = None
+
+    @property
+    def is_pass(self) -> bool:
+        return self.status == "pass"
+
+    @property
+    def is_crash(self) -> bool:
+        return self.status == "crash"
+
+    @property
+    def is_deadlock(self) -> bool:
+        return self.status == "deadlock"
+
+    @property
+    def is_timeout(self) -> bool:
+        return self.status in ("timeout", "deadlock")
+
+    @property
+    def has_tsan_warnings(self) -> bool:
+        return len(self.tsan_warnings) > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if not d["test_results"]:
+            del d["test_results"]
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> IterationOutcome:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+@dataclass
+class FTPackageResult:
+    """Aggregate free-threading test results for one package.
+
+    Contains all iteration outcomes, aggregate statistics, extension
+    compatibility data, and the final category classification.
+    """
+
+    package: str
+    category: FailureCategory = FailureCategory.UNKNOWN
+    iterations: list[IterationOutcome] = field(default_factory=list)
+
+    iterations_completed: int = 0
+    pass_count: int = 0
+    fail_count: int = 0
+    crash_count: int = 0
+    timeout_count: int = 0
+    deadlock_count: int = 0
+    tsan_warning_iterations: int = 0
+
+    pass_rate: float = 0.0
+    mean_duration_s: float = 0.0
+
+    extension_compat: dict[str, Any] | None = None
+
+    failure_signatures: list[str] = field(default_factory=list)
+    tsan_warning_types: list[str] = field(default_factory=list)
+    flaky_tests: dict[str, int] = field(default_factory=dict)
+
+    install_ok: bool = True
+    install_error: str | None = None
+    install_duration_s: float = 0.0
+    import_ok: bool = True
+    import_error: str | None = None
+    commit: str | None = None
+
+    gil_enabled_pass_rate: float | None = None
+    gil_enabled_iterations: list[IterationOutcome] | None = None
+
+    def compute_aggregates(self) -> None:
+        """Recompute aggregate statistics from iterations.
+
+        Call this after all iterations are added.
+        """
+        if not self.iterations:
+            return
+
+        self.iterations_completed = len(self.iterations)
+        self.pass_count = sum(1 for i in self.iterations if i.is_pass)
+        self.crash_count = sum(1 for i in self.iterations if i.is_crash)
+        self.deadlock_count = sum(1 for i in self.iterations if i.is_deadlock)
+        self.timeout_count = sum(1 for i in self.iterations if i.is_timeout)
+        self.fail_count = sum(1 for i in self.iterations if i.status == "fail")
+        self.tsan_warning_iterations = sum(1 for i in self.iterations if i.has_tsan_warnings)
+
+        if self.iterations_completed > 0:
+            self.pass_rate = self.pass_count / self.iterations_completed
+        else:
+            self.pass_rate = 0.0
+
+        durations = [i.duration_s for i in self.iterations if i.duration_s > 0]
+        if durations:
+            self.mean_duration_s = sum(durations) / len(durations)
+
+        sigs: set[str] = set()
+        for i in self.iterations:
+            if i.crash_signature:
+                sigs.add(i.crash_signature)
+        self.failure_signatures = sorted(sigs)
+
+        tsan_types: set[str] = set()
+        for i in self.iterations:
+            for w in i.tsan_warnings:
+                tsan_types.add(w)
+        self.tsan_warning_types = sorted(tsan_types)
+
+        test_failures: dict[str, int] = {}
+        test_total: dict[str, int] = {}
+        for i in self.iterations:
+            for test_name, status in i.test_results.items():
+                test_total[test_name] = test_total.get(test_name, 0) + 1
+                if status in ("FAILED", "ERROR"):
+                    test_failures[test_name] = test_failures.get(test_name, 0) + 1
+        self.flaky_tests = {
+            name: count
+            for name, count in sorted(test_failures.items(), key=lambda x: -x[1])
+            if count < test_total.get(name, 0)
+        }
+
+        if self.gil_enabled_iterations:
+            gil_passes = sum(1 for i in self.gil_enabled_iterations if i.is_pass)
+            self.gil_enabled_pass_rate = gil_passes / len(self.gil_enabled_iterations)
+
+    def categorize(self) -> FailureCategory:
+        """Determine the failure category based on aggregates.
+
+        Call compute_aggregates() first.
+
+        Returns:
+            The FailureCategory, also stored in self.category.
+        """
+        self.category = categorize_package(self)
+        return self.category
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "package": self.package,
+            "category": self.category.value,
+            "iterations_completed": self.iterations_completed,
+            "pass_count": self.pass_count,
+            "fail_count": self.fail_count,
+            "crash_count": self.crash_count,
+            "timeout_count": self.timeout_count,
+            "deadlock_count": self.deadlock_count,
+            "tsan_warning_iterations": self.tsan_warning_iterations,
+            "pass_rate": round(self.pass_rate, 4),
+            "mean_duration_s": round(self.mean_duration_s, 2),
+            "failure_signatures": self.failure_signatures,
+            "tsan_warning_types": self.tsan_warning_types,
+            "flaky_tests": self.flaky_tests,
+            "install_ok": self.install_ok,
+            "install_error": self.install_error,
+            "install_duration_s": round(self.install_duration_s, 2),
+            "import_ok": self.import_ok,
+            "import_error": self.import_error,
+            "commit": self.commit,
+            "iterations": [i.to_dict() for i in self.iterations],
+        }
+        if self.extension_compat is not None:
+            d["extension_compat"] = self.extension_compat
+        if self.gil_enabled_pass_rate is not None:
+            d["gil_enabled_pass_rate"] = round(self.gil_enabled_pass_rate, 4)
+        if self.gil_enabled_iterations is not None:
+            d["gil_enabled_iterations"] = [i.to_dict() for i in self.gil_enabled_iterations]
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FTPackageResult:
+        iterations = [IterationOutcome.from_dict(i) for i in data.get("iterations", [])]
+        gil_iters = None
+        if "gil_enabled_iterations" in data:
+            gil_iters = [IterationOutcome.from_dict(i) for i in data["gil_enabled_iterations"]]
+
+        return cls(
+            package=data["package"],
+            category=FailureCategory(data.get("category", "unknown")),
+            iterations=iterations,
+            iterations_completed=data.get("iterations_completed", 0),
+            pass_count=data.get("pass_count", 0),
+            fail_count=data.get("fail_count", 0),
+            crash_count=data.get("crash_count", 0),
+            timeout_count=data.get("timeout_count", 0),
+            deadlock_count=data.get("deadlock_count", 0),
+            tsan_warning_iterations=data.get("tsan_warning_iterations", 0),
+            pass_rate=data.get("pass_rate", 0.0),
+            mean_duration_s=data.get("mean_duration_s", 0.0),
+            extension_compat=data.get("extension_compat"),
+            failure_signatures=data.get("failure_signatures", []),
+            tsan_warning_types=data.get("tsan_warning_types", []),
+            flaky_tests=data.get("flaky_tests", {}),
+            install_ok=data.get("install_ok", True),
+            install_error=data.get("install_error"),
+            install_duration_s=data.get("install_duration_s", 0.0),
+            import_ok=data.get("import_ok", True),
+            import_error=data.get("import_error"),
+            commit=data.get("commit"),
+            gil_enabled_pass_rate=data.get("gil_enabled_pass_rate"),
+            gil_enabled_iterations=gil_iters,
+        )
+
+
+def categorize_package(result: FTPackageResult) -> FailureCategory:
+    """Classify a package's free-threading compatibility.
+
+    The classification considers installation status, pass rates,
+    crash/deadlock presence, TSAN warnings, and GIL fallback.
+
+    Classification priority (checked in order):
+    1. install_ok=False -> INSTALL_FAILURE
+    2. import_ok=False -> IMPORT_FAILURE
+    3. No iterations completed -> UNKNOWN
+    4. Any deadlocks -> DEADLOCK
+    5. Any crashes -> CRASH
+    6. All pass + TSAN warnings -> TSAN_WARNINGS
+    7. All pass + GIL fallback -> COMPATIBLE_GIL_FALLBACK
+    8. All pass -> COMPATIBLE
+    9. All fail -> INCOMPATIBLE
+    10. Mixed -> INTERMITTENT
+    """
+    if not result.install_ok:
+        return FailureCategory.INSTALL_FAILURE
+
+    if not result.import_ok:
+        return FailureCategory.IMPORT_FAILURE
+
+    if result.iterations_completed == 0:
+        return FailureCategory.UNKNOWN
+
+    if result.deadlock_count > 0:
+        return FailureCategory.DEADLOCK
+
+    if result.crash_count > 0:
+        return FailureCategory.CRASH
+
+    if result.pass_rate == 1.0:
+        if result.tsan_warning_iterations > 0:
+            return FailureCategory.TSAN_WARNINGS
+
+        ext = result.extension_compat
+        if ext and ext.get("gil_fallback_active", False):
+            return FailureCategory.COMPATIBLE_GIL_FALLBACK
+
+        return FailureCategory.COMPATIBLE
+
+    if result.pass_rate == 0.0:
+        return FailureCategory.INCOMPATIBLE
+
+    return FailureCategory.INTERMITTENT
+
+
+# ---------------------------------------------------------------------------
+# Run metadata and summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FTRunMeta:
+    """Metadata for a complete free-threading test run."""
+
+    run_id: str
+    timestamp: str
+    system_profile: dict[str, Any] = field(default_factory=dict)
+    python_profile: dict[str, Any] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
+    cli_args: list[str] = field(default_factory=list)
+    packages_total: int = 0
+    packages_completed: int = 0
+    total_iterations: int = 0
+    total_duration_s: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FTRunMeta:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class FTRunSummary:
+    """Aggregate summary of a free-threading test run."""
+
+    total_packages: int = 0
+    categories: dict[str, int] = field(default_factory=dict)
+    pass_rate_distribution: dict[str, int] = field(default_factory=dict)
+    pure_python_count: int = 0
+    extension_count: int = 0
+    pure_python_compatible_pct: float = 0.0
+    extension_compatible_pct: float = 0.0
+    tsan_warning_count: int = 0
+
+    @classmethod
+    def compute(cls, results: list[FTPackageResult]) -> FTRunSummary:
+        """Compute summary from a list of package results."""
+        summary = cls(total_packages=len(results))
+
+        for r in results:
+            cat = r.category.value
+            summary.categories[cat] = summary.categories.get(cat, 0) + 1
+
+        buckets = {"100%": 0, "90-99%": 0, "50-89%": 0, "1-49%": 0, "0%": 0, "N/A": 0}
+        for r in results:
+            if r.iterations_completed == 0:
+                buckets["N/A"] += 1
+            elif r.pass_rate == 1.0:
+                buckets["100%"] += 1
+            elif r.pass_rate >= 0.9:
+                buckets["90-99%"] += 1
+            elif r.pass_rate >= 0.5:
+                buckets["50-89%"] += 1
+            elif r.pass_rate > 0.0:
+                buckets["1-49%"] += 1
+            else:
+                buckets["0%"] += 1
+        summary.pass_rate_distribution = buckets
+
+        pure_python: list[FTPackageResult] = []
+        extensions: list[FTPackageResult] = []
+        for r in results:
+            ext = r.extension_compat
+            if ext and not ext.get("is_pure_python", True):
+                extensions.append(r)
+            else:
+                pure_python.append(r)
+
+        summary.pure_python_count = len(pure_python)
+        summary.extension_count = len(extensions)
+
+        if pure_python:
+            pp_compat = sum(
+                1
+                for r in pure_python
+                if r.category
+                in (
+                    FailureCategory.COMPATIBLE,
+                    FailureCategory.TSAN_WARNINGS,
+                )
+            )
+            summary.pure_python_compatible_pct = round(pp_compat / len(pure_python) * 100, 1)
+
+        if extensions:
+            ext_compat = sum(
+                1
+                for r in extensions
+                if r.category
+                in (
+                    FailureCategory.COMPATIBLE,
+                    FailureCategory.COMPATIBLE_GIL_FALLBACK,
+                    FailureCategory.TSAN_WARNINGS,
+                )
+            )
+            summary.extension_compatible_pct = round(ext_compat / len(extensions) * 100, 1)
+
+        summary.tsan_warning_count = sum(1 for r in results if r.tsan_warning_iterations > 0)
+
+        return summary
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FTRunSummary:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+# ---------------------------------------------------------------------------
+# Serialization and I/O
+# ---------------------------------------------------------------------------
+
+
+def save_ft_run(
+    results_dir: Path,
+    meta: FTRunMeta,
+    results: list[FTPackageResult],
+) -> None:
+    """Save a complete free-threading test run to disk.
+
+    Creates:
+      {results_dir}/ft_meta.json       -- run metadata
+      {results_dir}/ft_results.jsonl   -- per-package results
+      {results_dir}/ft_summary.json    -- aggregate summary
+
+    Args:
+        results_dir: Directory to write results into (created if
+            it doesn't exist).
+        meta: Run metadata.
+        results: List of package results.
+    """
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    meta.packages_completed = len(results)
+    meta_path = results_dir / "ft_meta.json"
+    meta_path.write_text(
+        json.dumps(meta.to_dict(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    results_path = results_dir / "ft_results.jsonl"
+    with results_path.open("w", encoding="utf-8") as f:
+        for r in results:
+            f.write(json.dumps(r.to_dict()) + "\n")
+
+    summary = FTRunSummary.compute(results)
+    summary_path = results_dir / "ft_summary.json"
+    summary_path.write_text(
+        json.dumps(summary.to_dict(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    log.info(
+        "Saved free-threading results: %d packages \u2192 %s",
+        len(results),
+        results_dir,
+    )
+
+
+def append_ft_result(
+    results_dir: Path,
+    result: FTPackageResult,
+) -> None:
+    """Append a single package result to the JSONL file.
+
+    Used for incremental writing during long runs so results
+    survive interruption.
+    """
+    results_path = results_dir / "ft_results.jsonl"
+    with results_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(result.to_dict()) + "\n")
+
+
+def load_ft_run(
+    results_dir: Path,
+) -> tuple[FTRunMeta, list[FTPackageResult]]:
+    """Load a complete free-threading test run from disk.
+
+    Returns:
+        (meta, results) tuple.
+
+    Raises:
+        FileNotFoundError: if the results directory doesn't exist
+            or is missing required files.
+    """
+    meta_path = results_dir / "ft_meta.json"
+    results_path = results_dir / "ft_results.jsonl"
+
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No ft_meta.json in {results_dir}")
+    if not results_path.exists():
+        raise FileNotFoundError(f"No ft_results.jsonl in {results_dir}")
+
+    meta = FTRunMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
+
+    results: list[FTPackageResult] = []
+    with results_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                results.append(FTPackageResult.from_dict(json.loads(line)))
+
+    return meta, results
+
+
+def load_ft_summary(results_dir: Path) -> FTRunSummary:
+    """Load the summary file, or recompute from results."""
+    summary_path = results_dir / "ft_summary.json"
+    if summary_path.exists():
+        return FTRunSummary.from_dict(json.loads(summary_path.read_text(encoding="utf-8")))
+    _, results = load_ft_run(results_dir)
+    return FTRunSummary.compute(results)

--- a/tests/ft_test_helpers.py
+++ b/tests/ft_test_helpers.py
@@ -1,0 +1,58 @@
+"""Shared test helpers for free-threading test modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from labeille.ft.results import (
+    FTPackageResult,
+    IterationOutcome,
+)
+
+
+def make_iteration(
+    index: int = 1,
+    status: str = "pass",
+    exit_code: int = 0,
+    duration_s: float = 10.0,
+    **kwargs: Any,
+) -> IterationOutcome:
+    """Create an IterationOutcome with sensible defaults."""
+    return IterationOutcome(
+        index=index,
+        status=status,
+        exit_code=exit_code,
+        duration_s=duration_s,
+        **kwargs,
+    )
+
+
+def make_package_result(
+    package: str = "test-pkg",
+    statuses: list[str] | None = None,
+    **kwargs: Any,
+) -> FTPackageResult:
+    """Create an FTPackageResult with specified iteration statuses.
+
+    Example: make_package_result("foo", ["pass", "pass", "crash"])
+    """
+    if statuses is None:
+        statuses = ["pass"] * 5
+
+    iterations = [
+        make_iteration(
+            index=i + 1,
+            status=s,
+            exit_code=0 if s == "pass" else 1,
+        )
+        for i, s in enumerate(statuses)
+    ]
+
+    result = FTPackageResult(
+        package=package,
+        iterations=iterations,
+        **kwargs,
+    )
+    result.compute_aggregates()
+    result.categorize()
+    return result

--- a/tests/test_ft_results.py
+++ b/tests/test_ft_results.py
@@ -1,0 +1,572 @@
+"""Tests for labeille.ft.results — free-threading result dataclasses."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ft_test_helpers import make_iteration, make_package_result
+
+from labeille.ft.results import (
+    FailureCategory,
+    FTPackageResult,
+    FTRunMeta,
+    FTRunSummary,
+    IterationOutcome,
+    append_ft_result,
+    categorize_package,
+    load_ft_run,
+    load_ft_summary,
+    save_ft_run,
+)
+
+
+# ---------------------------------------------------------------------------
+# FailureCategory tests
+# ---------------------------------------------------------------------------
+
+
+class TestFailureCategory(unittest.TestCase):
+    def test_category_values(self) -> None:
+        values = [c.value for c in FailureCategory]
+        self.assertEqual(len(values), len(set(values)))
+
+    def test_category_is_usable(self) -> None:
+        usable = {
+            FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_GIL_FALLBACK,
+            FailureCategory.INTERMITTENT,
+            FailureCategory.TSAN_WARNINGS,
+        }
+        for cat in FailureCategory:
+            if cat in usable:
+                self.assertTrue(cat.is_usable, f"{cat} should be usable")
+            else:
+                self.assertFalse(cat.is_usable, f"{cat} should not be usable")
+
+    def test_category_severity_order(self) -> None:
+        self.assertLess(
+            FailureCategory.COMPATIBLE.severity,
+            FailureCategory.INTERMITTENT.severity,
+        )
+        self.assertLess(
+            FailureCategory.INTERMITTENT.severity,
+            FailureCategory.CRASH.severity,
+        )
+        self.assertLess(
+            FailureCategory.CRASH.severity,
+            FailureCategory.DEADLOCK.severity,
+        )
+        self.assertLess(
+            FailureCategory.DEADLOCK.severity,
+            FailureCategory.INSTALL_FAILURE.severity,
+        )
+
+    def test_category_symbols(self) -> None:
+        for cat in FailureCategory:
+            self.assertTrue(len(cat.symbol) > 0, f"{cat} has empty symbol")
+
+    def test_category_from_string(self) -> None:
+        self.assertEqual(FailureCategory("compatible"), FailureCategory.COMPATIBLE)
+
+    def test_category_invalid_string(self) -> None:
+        with self.assertRaises(ValueError):
+            FailureCategory("not_a_category")
+
+
+# ---------------------------------------------------------------------------
+# IterationOutcome tests
+# ---------------------------------------------------------------------------
+
+
+class TestIterationOutcome(unittest.TestCase):
+    def test_iteration_pass(self) -> None:
+        it = IterationOutcome(index=1, status="pass", exit_code=0)
+        self.assertTrue(it.is_pass)
+        self.assertFalse(it.is_crash)
+        self.assertFalse(it.is_deadlock)
+        self.assertFalse(it.is_timeout)
+
+    def test_iteration_crash(self) -> None:
+        it = IterationOutcome(index=1, status="crash", exit_code=-11)
+        self.assertTrue(it.is_crash)
+        self.assertFalse(it.is_pass)
+
+    def test_iteration_deadlock(self) -> None:
+        it = IterationOutcome(index=1, status="deadlock")
+        self.assertTrue(it.is_deadlock)
+        self.assertTrue(it.is_timeout)
+
+    def test_iteration_timeout(self) -> None:
+        it = IterationOutcome(index=1, status="timeout")
+        self.assertTrue(it.is_timeout)
+        self.assertFalse(it.is_deadlock)
+
+    def test_iteration_tsan(self) -> None:
+        it = IterationOutcome(index=1, status="pass", tsan_warnings=["data race"])
+        self.assertTrue(it.has_tsan_warnings)
+
+    def test_iteration_serialization_roundtrip(self) -> None:
+        it = IterationOutcome(
+            index=3,
+            status="crash",
+            exit_code=-11,
+            duration_s=5.5,
+            crash_signal="SIGSEGV",
+            crash_signature="_PyEval_EvalFrame+0x1234",
+            tsan_warnings=["data race in foo"],
+            output_stalled=True,
+            last_output_line="FAILED test_bar",
+            stderr_tail="segfault at 0x0",
+            test_results={"test_bar": "FAILED"},
+            tests_passed=10,
+            tests_failed=1,
+            tests_errored=0,
+            tests_skipped=2,
+        )
+        d = it.to_dict()
+        restored = IterationOutcome.from_dict(d)
+        self.assertEqual(restored.index, 3)
+        self.assertEqual(restored.status, "crash")
+        self.assertEqual(restored.crash_signal, "SIGSEGV")
+        self.assertEqual(restored.tsan_warnings, ["data race in foo"])
+        self.assertEqual(restored.test_results, {"test_bar": "FAILED"})
+        self.assertEqual(restored.tests_passed, 10)
+
+    def test_iteration_serialization_omits_empty_test_results(self) -> None:
+        it = IterationOutcome(index=1, status="pass")
+        d = it.to_dict()
+        self.assertNotIn("test_results", d)
+
+    def test_iteration_from_dict_missing_fields(self) -> None:
+        d = {"index": 1, "status": "pass"}
+        it = IterationOutcome.from_dict(d)
+        self.assertEqual(it.index, 1)
+        self.assertIsNone(it.exit_code)
+        self.assertEqual(it.duration_s, 0.0)
+        self.assertEqual(it.tsan_warnings, [])
+
+
+# ---------------------------------------------------------------------------
+# FTPackageResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTPackageResult(unittest.TestCase):
+    def test_compute_aggregates_all_pass(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass") for i in range(5)],
+        )
+        result.compute_aggregates()
+        self.assertEqual(result.pass_count, 5)
+        self.assertEqual(result.pass_rate, 1.0)
+        self.assertEqual(result.crash_count, 0)
+        self.assertEqual(result.iterations_completed, 5)
+
+    def test_compute_aggregates_mixed(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass"),
+                make_iteration(1, "pass"),
+                make_iteration(2, "pass"),
+                make_iteration(3, "crash", exit_code=-11),
+                make_iteration(4, "fail", exit_code=1),
+            ],
+        )
+        result.compute_aggregates()
+        self.assertAlmostEqual(result.pass_rate, 0.6)
+        self.assertEqual(result.crash_count, 1)
+        self.assertEqual(result.fail_count, 1)
+
+    def test_compute_aggregates_empty(self) -> None:
+        result = FTPackageResult(package="pkg")
+        result.compute_aggregates()
+        self.assertEqual(result.iterations_completed, 0)
+        self.assertEqual(result.pass_rate, 0.0)
+
+    def test_compute_aggregates_mean_duration(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=10.0),
+                make_iteration(1, "pass", duration_s=12.0),
+                make_iteration(2, "pass", duration_s=11.0),
+            ],
+        )
+        result.compute_aggregates()
+        self.assertAlmostEqual(result.mean_duration_s, 11.0)
+
+    def test_compute_aggregates_failure_signatures(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "crash", crash_signature="sig_a"),
+                make_iteration(1, "crash", crash_signature="sig_a"),
+                make_iteration(2, "crash", crash_signature="sig_b"),
+            ],
+        )
+        result.compute_aggregates()
+        self.assertEqual(result.failure_signatures, ["sig_a", "sig_b"])
+
+    def test_compute_aggregates_tsan_types(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", tsan_warnings=["data race", "data race"]),
+                make_iteration(1, "pass", tsan_warnings=["thread leak"]),
+            ],
+        )
+        result.compute_aggregates()
+        self.assertEqual(result.tsan_warning_types, ["data race", "thread leak"])
+        self.assertEqual(result.tsan_warning_iterations, 2)
+
+    def test_compute_aggregates_flaky_tests(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", test_results={"test_foo": "PASSED"}),
+                make_iteration(1, "fail", test_results={"test_foo": "FAILED"}),
+                make_iteration(2, "pass", test_results={"test_foo": "PASSED"}),
+                make_iteration(3, "fail", test_results={"test_foo": "FAILED"}),
+                make_iteration(4, "pass", test_results={"test_foo": "PASSED"}),
+            ],
+        )
+        result.compute_aggregates()
+        self.assertIn("test_foo", result.flaky_tests)
+        self.assertEqual(result.flaky_tests["test_foo"], 2)
+
+    def test_compute_aggregates_no_flaky_if_always_fails(self) -> None:
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(i, "fail", test_results={"test_bar": "FAILED"}) for i in range(5)
+            ],
+        )
+        result.compute_aggregates()
+        self.assertNotIn("test_bar", result.flaky_tests)
+
+    def test_compute_aggregates_gil_comparison(self) -> None:
+        gil_iters = [make_iteration(i, "pass" if i < 4 else "fail") for i in range(5)]
+        result = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass") for i in range(5)],
+            gil_enabled_iterations=gil_iters,
+        )
+        result.compute_aggregates()
+        self.assertIsNotNone(result.gil_enabled_pass_rate)
+        self.assertAlmostEqual(result.gil_enabled_pass_rate, 0.8)  # type: ignore[arg-type]
+
+    def test_serialization_roundtrip(self) -> None:
+        result = FTPackageResult(
+            package="mypkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=10.0),
+                make_iteration(1, "crash", exit_code=-11, crash_signal="SIGSEGV"),
+            ],
+            extension_compat={"is_pure_python": False, "gil_fallback_active": True},
+            install_duration_s=5.5,
+            commit="abc123",
+            gil_enabled_iterations=[make_iteration(0, "pass")],
+        )
+        result.compute_aggregates()
+        result.categorize()
+
+        d = result.to_dict()
+        restored = FTPackageResult.from_dict(d)
+        self.assertEqual(restored.package, "mypkg")
+        self.assertEqual(restored.category, result.category)
+        self.assertEqual(len(restored.iterations), 2)
+        self.assertIsNotNone(restored.extension_compat)
+        self.assertEqual(restored.commit, "abc123")
+        self.assertIsNotNone(restored.gil_enabled_iterations)
+        assert restored.gil_enabled_iterations is not None
+        self.assertEqual(len(restored.gil_enabled_iterations), 1)
+
+    def test_serialization_without_optional_fields(self) -> None:
+        result = FTPackageResult(package="minimal")
+        result.compute_aggregates()
+        result.categorize()
+        d = result.to_dict()
+        self.assertNotIn("extension_compat", d)
+        self.assertNotIn("gil_enabled_pass_rate", d)
+        self.assertNotIn("gil_enabled_iterations", d)
+
+
+# ---------------------------------------------------------------------------
+# Categorization tests
+# ---------------------------------------------------------------------------
+
+
+class TestCategorizePackage(unittest.TestCase):
+    def test_categorize_install_failure(self) -> None:
+        result = FTPackageResult(package="pkg", install_ok=False)
+        self.assertEqual(categorize_package(result), FailureCategory.INSTALL_FAILURE)
+
+    def test_categorize_import_failure(self) -> None:
+        result = FTPackageResult(package="pkg", import_ok=False)
+        self.assertEqual(categorize_package(result), FailureCategory.IMPORT_FAILURE)
+
+    def test_categorize_no_iterations(self) -> None:
+        result = FTPackageResult(package="pkg", iterations_completed=0)
+        self.assertEqual(categorize_package(result), FailureCategory.UNKNOWN)
+
+    def test_categorize_compatible(self) -> None:
+        r = make_package_result("pkg", ["pass"] * 5)
+        self.assertEqual(r.category, FailureCategory.COMPATIBLE)
+
+    def test_categorize_compatible_gil_fallback(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass") for i in range(5)],
+            extension_compat={"gil_fallback_active": True},
+        )
+        r.compute_aggregates()
+        cat = r.categorize()
+        self.assertEqual(cat, FailureCategory.COMPATIBLE_GIL_FALLBACK)
+
+    def test_categorize_tsan_warnings(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass", tsan_warnings=["data race"]) for i in range(5)],
+        )
+        r.compute_aggregates()
+        cat = r.categorize()
+        self.assertEqual(cat, FailureCategory.TSAN_WARNINGS)
+
+    def test_categorize_tsan_takes_priority_over_gil_fallback(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass", tsan_warnings=["data race"]) for i in range(5)],
+            extension_compat={"gil_fallback_active": True},
+        )
+        r.compute_aggregates()
+        cat = r.categorize()
+        self.assertEqual(cat, FailureCategory.TSAN_WARNINGS)
+
+    def test_categorize_crash(self) -> None:
+        r = make_package_result("pkg", ["pass", "pass", "crash"])
+        self.assertEqual(r.category, FailureCategory.CRASH)
+
+    def test_categorize_deadlock(self) -> None:
+        r = make_package_result("pkg", ["pass", "deadlock", "pass"])
+        self.assertEqual(r.category, FailureCategory.DEADLOCK)
+
+    def test_categorize_deadlock_takes_priority_over_crash(self) -> None:
+        r = make_package_result("pkg", ["deadlock", "crash", "pass"])
+        self.assertEqual(r.category, FailureCategory.DEADLOCK)
+
+    def test_categorize_incompatible(self) -> None:
+        r = make_package_result("pkg", ["fail"] * 5)
+        self.assertEqual(r.category, FailureCategory.INCOMPATIBLE)
+
+    def test_categorize_intermittent(self) -> None:
+        r = make_package_result("pkg", ["pass", "pass", "fail"])
+        self.assertEqual(r.category, FailureCategory.INTERMITTENT)
+
+    def test_categorize_crash_with_some_passes(self) -> None:
+        r = make_package_result("pkg", ["pass"] * 7 + ["crash"] * 3)
+        self.assertEqual(r.category, FailureCategory.CRASH)
+
+
+# ---------------------------------------------------------------------------
+# FTRunSummary tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTRunSummary(unittest.TestCase):
+    def test_summary_category_counts(self) -> None:
+        results = [
+            make_package_result("a", ["pass"] * 5),
+            make_package_result("b", ["pass"] * 5),
+            make_package_result("c", ["pass"] * 5),
+            make_package_result("d", ["pass", "fail", "pass"]),
+            make_package_result("e", ["pass", "fail", "pass"]),
+            make_package_result("f", ["pass", "crash", "pass"]),
+        ]
+        summary = FTRunSummary.compute(results)
+        self.assertEqual(summary.categories.get("compatible"), 3)
+        self.assertEqual(summary.categories.get("intermittent"), 2)
+        self.assertEqual(summary.categories.get("crash"), 1)
+
+    def test_summary_pass_rate_distribution(self) -> None:
+        results = [
+            make_package_result("a", ["pass"] * 5),  # 100%
+            make_package_result("b", ["pass"] * 9 + ["fail"]),  # 90%
+            make_package_result("c", ["pass"] * 5 + ["fail"] * 5),  # 50%
+            make_package_result("d", ["pass"] + ["fail"] * 9),  # 10%
+            make_package_result("e", ["fail"] * 5),  # 0%
+        ]
+        summary = FTRunSummary.compute(results)
+        self.assertEqual(summary.pass_rate_distribution["100%"], 1)
+        self.assertEqual(summary.pass_rate_distribution["90-99%"], 1)
+        self.assertEqual(summary.pass_rate_distribution["50-89%"], 1)
+        self.assertEqual(summary.pass_rate_distribution["1-49%"], 1)
+        self.assertEqual(summary.pass_rate_distribution["0%"], 1)
+
+    def test_summary_pure_python_vs_extension(self) -> None:
+        results = [
+            make_package_result("pure1", ["pass"] * 5),
+            make_package_result(
+                "ext1",
+                ["pass"] * 5,
+                extension_compat={"is_pure_python": False},
+            ),
+            make_package_result(
+                "ext2",
+                ["fail"] * 5,
+                extension_compat={"is_pure_python": False},
+            ),
+        ]
+        summary = FTRunSummary.compute(results)
+        self.assertEqual(summary.pure_python_count, 1)
+        self.assertEqual(summary.extension_count, 2)
+        self.assertEqual(summary.pure_python_compatible_pct, 100.0)
+        self.assertEqual(summary.extension_compatible_pct, 50.0)
+
+    def test_summary_serialization_roundtrip(self) -> None:
+        results = [
+            make_package_result("a", ["pass"] * 5),
+            make_package_result("b", ["crash", "pass"]),
+        ]
+        summary = FTRunSummary.compute(results)
+        d = summary.to_dict()
+        restored = FTRunSummary.from_dict(d)
+        self.assertEqual(restored.total_packages, 2)
+        self.assertEqual(restored.categories, summary.categories)
+        self.assertEqual(restored.pass_rate_distribution, summary.pass_rate_distribution)
+
+
+# ---------------------------------------------------------------------------
+# I/O tests
+# ---------------------------------------------------------------------------
+
+
+class TestIO(unittest.TestCase):
+    def test_save_and_load_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            meta = FTRunMeta(run_id="test-1", timestamp="2026-03-01T00:00:00")
+            results = [
+                make_package_result("a", ["pass"] * 3),
+                make_package_result("b", ["pass", "crash"]),
+                make_package_result("c", ["fail"] * 3),
+            ]
+            save_ft_run(d, meta, results)
+
+            loaded_meta, loaded_results = load_ft_run(d)
+            self.assertEqual(loaded_meta.run_id, "test-1")
+            self.assertEqual(loaded_meta.packages_completed, 3)
+            self.assertEqual(len(loaded_results), 3)
+            self.assertEqual(loaded_results[0].package, "a")
+            self.assertEqual(loaded_results[1].package, "b")
+
+    def test_append_ft_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            # Create empty JSONL.
+            (d / "ft_results.jsonl").write_text("")
+            (d / "ft_meta.json").write_text(
+                json.dumps(FTRunMeta(run_id="x", timestamp="t").to_dict())
+            )
+
+            for i in range(3):
+                r = make_package_result(f"pkg{i}", ["pass"])
+                append_ft_result(d, r)
+
+            _, loaded = load_ft_run(d)
+            self.assertEqual(len(loaded), 3)
+
+    def test_append_then_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "ft_results.jsonl").write_text("")
+            (d / "ft_meta.json").write_text(
+                json.dumps(FTRunMeta(run_id="x", timestamp="t").to_dict())
+            )
+
+            append_ft_result(d, make_package_result("alpha", ["pass", "pass"]))
+            append_ft_result(d, make_package_result("beta", ["fail"]))
+
+            _, loaded = load_ft_run(d)
+            self.assertEqual(len(loaded), 2)
+            self.assertEqual(loaded[0].package, "alpha")
+            self.assertEqual(loaded[1].package, "beta")
+
+    def test_load_nonexistent_dir(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            load_ft_run(Path("/nonexistent/dir"))
+
+    def test_load_empty_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "ft_meta.json").write_text(
+                json.dumps(FTRunMeta(run_id="x", timestamp="t").to_dict())
+            )
+            (d / "ft_results.jsonl").write_text("")
+            _, loaded = load_ft_run(d)
+            self.assertEqual(loaded, [])
+
+    def test_load_ft_summary_from_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            results = [make_package_result("a", ["pass"] * 5)]
+            meta = FTRunMeta(run_id="test", timestamp="t")
+            save_ft_run(d, meta, results)
+
+            summary = load_ft_summary(d)
+            self.assertEqual(summary.total_packages, 1)
+            self.assertEqual(summary.categories.get("compatible"), 1)
+
+    def test_load_ft_summary_recomputes_if_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            results = [
+                make_package_result("a", ["pass"] * 5),
+                make_package_result("b", ["crash", "pass"]),
+            ]
+            meta = FTRunMeta(run_id="test", timestamp="t")
+            save_ft_run(d, meta, results)
+
+            # Delete summary file.
+            (d / "ft_summary.json").unlink()
+
+            summary = load_ft_summary(d)
+            self.assertEqual(summary.total_packages, 2)
+
+
+# ---------------------------------------------------------------------------
+# FTRunMeta tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTRunMeta(unittest.TestCase):
+    def test_meta_serialization_roundtrip(self) -> None:
+        meta = FTRunMeta(
+            run_id="run-42",
+            timestamp="2026-03-01T12:00:00",
+            packages_total=10,
+            packages_completed=8,
+            total_iterations=40,
+            total_duration_s=1234.5,
+            cli_args=["--packages", "foo", "--iterations", "5"],
+        )
+        d = meta.to_dict()
+        restored = FTRunMeta.from_dict(d)
+        self.assertEqual(restored.run_id, "run-42")
+        self.assertEqual(restored.packages_total, 10)
+        self.assertEqual(restored.cli_args, ["--packages", "foo", "--iterations", "5"])
+
+    def test_meta_from_dict_missing_fields(self) -> None:
+        d = {"run_id": "x", "timestamp": "t"}
+        meta = FTRunMeta.from_dict(d)
+        self.assertEqual(meta.run_id, "x")
+        self.assertEqual(meta.packages_total, 0)
+        self.assertEqual(meta.cli_args, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `FailureCategory` enum with 10 categories, severity ordering, symbols, and `is_usable` property
- Add `IterationOutcome`, `FTPackageResult`, `FTRunMeta`, `FTRunSummary` dataclasses with full serialization
- Add `categorize_package()` priority-ordered classification and `compute_aggregates()` for flaky test detection, TSAN warning tracking, and crash signature collection
- Add JSONL/JSON I/O functions (`save_ft_run`, `append_ft_result`, `load_ft_run`, `load_ft_summary`) for incremental result writing
- Add shared test helpers in `tests/ft_test_helpers.py`

## Test plan
- [x] 51 new tests in `tests/test_ft_results.py` covering all dataclasses, categorization logic, serialization, and I/O
- [x] ruff format — clean
- [x] ruff check — clean
- [x] mypy strict — clean
- [x] All 1259 tests pass

Closes #78

Generated with [Claude Code](https://claude.com/claude-code)