### PR TITLE
feat: add free-threading analysis module (ft/analysis.py)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `ft/analysis.py` module with `FlakyTest`, `FlakinessProfile`, `GILComparisonResult`, `TriageEntry`, `DurationAnomaly`, and `FTAnalysisReport` dataclasses for free-threading result analysis.
+- `analyze_flakiness()` for detailed flakiness profiling with failure pattern classification and consecutive streak detection.
+- `compare_gil_modes()` for GIL-enabled vs free-threaded result comparison.
+- `prioritize_triage()` severity-scored triage with extension and TSAN bonuses.
+- `detect_duration_anomalies()` using statistical outlier detection from bench/stats.py.
+- `analyze_ft_run()` full analysis pipeline producing `FTAnalysisReport`.
 - `ft/runner.py` module with `FTRunConfig`, `OutputMonitor`, `run_single_iteration()`, `run_package_ft()`, and `run_ft()` for free-threading test execution with crash/deadlock/TSAN detection and pytest output parsing.
 - `ft/results.py` module with `FailureCategory` enum, `IterationOutcome`, `FTPackageResult`, `FTRunMeta`, and `FTRunSummary` dataclasses for free-threading result storage, categorization, and JSONL/JSON serialization.
 - `categorize_package()` priority-ordered classification (install failure > import failure > deadlock > crash > TSAN > GIL fallback > compatible > incompatible > intermittent).

--- a/src/labeille/ft/analysis.py
+++ b/src/labeille/ft/analysis.py
@@ -1,0 +1,568 @@
+"""Deep analysis of free-threading test results.
+
+Provides:
+- Flakiness profiling: which tests fail intermittently and how often.
+- Failure pattern detection: same test every time vs random failures.
+- GIL comparison: isolate free-threading-specific failures.
+- Triage prioritization: rank packages by investigation urgency.
+- Duration analysis: detect timing anomalies suggesting contention.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from labeille.ft.results import (
+    FailureCategory,
+    FTPackageResult,
+    FTRunSummary,
+    IterationOutcome,
+)
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# Flakiness profiling
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FlakyTest:
+    """A single test that fails intermittently."""
+
+    test_id: str
+    fail_count: int
+    total_seen: int
+    fail_rate: float
+    statuses: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "test_id": self.test_id,
+            "fail_count": self.fail_count,
+            "total_seen": self.total_seen,
+            "fail_rate": round(self.fail_rate, 4),
+        }
+
+
+@dataclass
+class FlakinessProfile:
+    """Detailed analysis of an intermittent package.
+
+    Goes deeper than the basic pass_rate in FTPackageResult to
+    identify specific flaky tests, failure patterns, and likely
+    root causes.
+    """
+
+    package: str
+    pass_rate: float
+    total_iterations: int
+
+    failure_modes: dict[str, int] = field(default_factory=dict)
+    flaky_tests: list[FlakyTest] = field(default_factory=list)
+    max_consecutive_passes: int = 0
+    max_consecutive_failures: int = 0
+    pattern: str = "unknown"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package": self.package,
+            "pass_rate": round(self.pass_rate, 4),
+            "total_iterations": self.total_iterations,
+            "failure_modes": self.failure_modes,
+            "flaky_tests": [t.to_dict() for t in self.flaky_tests],
+            "max_consecutive_passes": self.max_consecutive_passes,
+            "max_consecutive_failures": self.max_consecutive_failures,
+            "pattern": self.pattern,
+        }
+
+
+def analyze_flakiness(result: FTPackageResult) -> FlakinessProfile:
+    """Produce a detailed flakiness profile for a package.
+
+    Analyzes iteration outcomes to determine failure patterns,
+    identify specific flaky tests, and classify the type of
+    non-determinism.
+
+    Args:
+        result: A package result with multiple iterations.
+
+    Returns:
+        FlakinessProfile with detailed analysis.
+    """
+    profile = FlakinessProfile(
+        package=result.package,
+        pass_rate=result.pass_rate,
+        total_iterations=result.iterations_completed,
+    )
+
+    if not result.iterations:
+        return profile
+
+    modes: dict[str, int] = {}
+    for it in result.iterations:
+        if it.status != "pass":
+            modes[it.status] = modes.get(it.status, 0) + 1
+    profile.failure_modes = modes
+
+    profile.max_consecutive_passes = _max_streak(result.iterations, lambda it: it.is_pass)
+    profile.max_consecutive_failures = _max_streak(result.iterations, lambda it: not it.is_pass)
+
+    test_outcomes: dict[str, list[str]] = {}
+    for it in result.iterations:
+        for test_id, status in it.test_results.items():
+            test_outcomes.setdefault(test_id, []).append(status)
+
+    for test_id, statuses in sorted(test_outcomes.items()):
+        fail_count = sum(1 for s in statuses if s in ("FAILED", "ERROR"))
+        total = len(statuses)
+        if 0 < fail_count < total:
+            profile.flaky_tests.append(
+                FlakyTest(
+                    test_id=test_id,
+                    fail_count=fail_count,
+                    total_seen=total,
+                    fail_rate=fail_count / total,
+                    statuses=statuses,
+                )
+            )
+
+    profile.flaky_tests.sort(key=lambda t: -t.fail_rate)
+
+    profile.pattern = _classify_failure_pattern(result, profile)
+
+    return profile
+
+
+def _max_streak(
+    iterations: list[IterationOutcome],
+    predicate: Callable[[IterationOutcome], bool],
+) -> int:
+    """Find the longest consecutive streak matching predicate."""
+    max_streak = 0
+    current = 0
+    for it in iterations:
+        if predicate(it):
+            current += 1
+            max_streak = max(max_streak, current)
+        else:
+            current = 0
+    return max_streak
+
+
+def _classify_failure_pattern(
+    result: FTPackageResult,
+    profile: FlakinessProfile,
+) -> str:
+    """Classify the type of failure pattern.
+
+    Heuristics:
+    - If the same specific tests fail every time they fail ->
+      "consistent_test" (likely a deterministic bug triggered by
+      specific code paths).
+    - If different tests fail each time -> "random_test" (likely a
+      race condition in shared state).
+    - If crashes have the same signature -> "consistent_crash".
+    - If crashes have different signatures -> "varied_crash".
+    """
+    if result.crash_count > 0 and result.fail_count == 0:
+        if len(result.failure_signatures) == 1:
+            return "consistent_crash"
+        elif len(result.failure_signatures) > 1:
+            return "varied_crash"
+
+    if profile.flaky_tests:
+        failing_test_sets: list[frozenset[str]] = []
+        for it in result.iterations:
+            if not it.is_pass and it.test_results:
+                failed_in_this = frozenset(
+                    tid for tid, status in it.test_results.items() if status in ("FAILED", "ERROR")
+                )
+                if failed_in_this:
+                    failing_test_sets.append(failed_in_this)
+
+        if len(failing_test_sets) >= 2:
+            if len(set(failing_test_sets)) == 1:
+                return "consistent_test"
+            return "random_test"
+
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# GIL comparison analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GILComparisonResult:
+    """Comparison of one package under GIL-enabled vs GIL-disabled."""
+
+    package: str
+    gil_disabled_pass_rate: float
+    gil_enabled_pass_rate: float
+    classification: str
+    ft_specific_failing_tests: list[str] = field(default_factory=list)
+    shared_failing_tests: list[str] = field(default_factory=list)
+
+    @property
+    def free_threading_specific(self) -> bool:
+        """True if failures only appear with GIL disabled."""
+        return self.gil_enabled_pass_rate == 1.0 and self.gil_disabled_pass_rate < 1.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package": self.package,
+            "gil_disabled_pass_rate": round(self.gil_disabled_pass_rate, 4),
+            "gil_enabled_pass_rate": round(self.gil_enabled_pass_rate, 4),
+            "classification": self.classification,
+            "ft_specific_failing_tests": self.ft_specific_failing_tests,
+            "shared_failing_tests": self.shared_failing_tests,
+        }
+
+
+def compare_gil_modes(
+    result: FTPackageResult,
+) -> GILComparisonResult | None:
+    """Compare GIL-disabled vs GIL-enabled results for one package.
+
+    Returns None if the package doesn't have GIL comparison data.
+
+    Classification:
+    - "ft_compatible": both modes pass 100%
+    - "ft_intermittent": GIL-enabled passes 100%, GIL-disabled < 100%
+    - "ft_incompatible": GIL-enabled passes 100%, GIL-disabled 0%
+    - "pre_existing": both modes have failures
+    - "ft_exacerbated": both have failures but GIL-disabled is worse
+    - "gil_helps": GIL-disabled passes more than GIL-enabled (rare)
+    """
+    if result.gil_enabled_iterations is None:
+        return None
+    if result.gil_enabled_pass_rate is None:
+        return None
+
+    ft_rate = result.pass_rate
+    gil_rate = result.gil_enabled_pass_rate
+
+    if ft_rate == 1.0 and gil_rate == 1.0:
+        classification = "ft_compatible"
+    elif gil_rate == 1.0 and ft_rate == 0.0:
+        classification = "ft_incompatible"
+    elif gil_rate == 1.0 and ft_rate < 1.0:
+        classification = "ft_intermittent"
+    elif ft_rate > gil_rate:
+        classification = "gil_helps"
+    elif gil_rate < 1.0 and ft_rate < gil_rate:
+        classification = "ft_exacerbated"
+    elif gil_rate < 1.0:
+        classification = "pre_existing"
+    else:
+        classification = "ft_compatible"
+
+    ft_failures: Counter[str] = Counter()
+    for it in result.iterations:
+        for tid, status in it.test_results.items():
+            if status in ("FAILED", "ERROR"):
+                ft_failures[tid] += 1
+
+    gil_failures: Counter[str] = Counter()
+    for it in result.gil_enabled_iterations:
+        for tid, status in it.test_results.items():
+            if status in ("FAILED", "ERROR"):
+                gil_failures[tid] += 1
+
+    ft_only = sorted(set(ft_failures) - set(gil_failures))
+    shared = sorted(set(ft_failures) & set(gil_failures))
+
+    return GILComparisonResult(
+        package=result.package,
+        gil_disabled_pass_rate=ft_rate,
+        gil_enabled_pass_rate=gil_rate,
+        classification=classification,
+        ft_specific_failing_tests=ft_only,
+        shared_failing_tests=shared,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Triage prioritization
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TriageEntry:
+    """A package ranked by investigation priority."""
+
+    package: str
+    priority_score: float
+    category: str
+    reason: str
+    pass_rate: float
+    crash_count: int = 0
+    deadlock_count: int = 0
+    flaky_test_count: int = 0
+    is_pure_python: bool = True
+    has_tsan_warnings: bool = False
+    monthly_downloads: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package": self.package,
+            "priority_score": round(self.priority_score, 2),
+            "category": self.category,
+            "reason": self.reason,
+            "pass_rate": round(self.pass_rate, 4),
+        }
+
+
+def prioritize_triage(
+    results: list[FTPackageResult],
+    *,
+    include_compatible: bool = False,
+) -> list[TriageEntry]:
+    """Rank packages by investigation urgency.
+
+    Priority is based on:
+    - Severity: crashes > deadlocks > intermittent > incompatible
+    - Popularity: higher-download packages matter more
+    - Fixability: intermittent with identifiable flaky tests is
+      more actionable than random failures
+    - Extension status: C extension bugs are harder to fix but
+      more impactful
+
+    Args:
+        results: List of package results.
+        include_compatible: If True, include compatible packages
+            (usually excluded from triage).
+
+    Returns:
+        List of TriageEntry sorted by priority (highest first).
+    """
+    entries: list[TriageEntry] = []
+
+    for r in results:
+        if not include_compatible and r.category in (
+            FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_GIL_FALLBACK,
+        ):
+            continue
+
+        score = 0.0
+        reasons: list[str] = []
+
+        severity_scores = {
+            FailureCategory.CRASH: 50,
+            FailureCategory.DEADLOCK: 45,
+            FailureCategory.INTERMITTENT: 30,
+            FailureCategory.INCOMPATIBLE: 25,
+            FailureCategory.TSAN_WARNINGS: 20,
+            FailureCategory.INSTALL_FAILURE: 10,
+            FailureCategory.IMPORT_FAILURE: 10,
+            FailureCategory.UNKNOWN: 5,
+        }
+        sev = severity_scores.get(r.category, 0)
+        score += sev
+        if sev > 0:
+            reasons.append(f"severity:{r.category.value}")
+
+        if r.crash_count > 0:
+            score += min(r.crash_count * 5, 20)
+            reasons.append(f"{r.crash_count} crashes")
+        if r.deadlock_count > 0:
+            score += min(r.deadlock_count * 5, 15)
+            reasons.append(f"{r.deadlock_count} deadlocks")
+
+        ext = r.extension_compat or {}
+        is_pure = ext.get("is_pure_python", True)
+        if not is_pure and r.category in (
+            FailureCategory.CRASH,
+            FailureCategory.INTERMITTENT,
+            FailureCategory.TSAN_WARNINGS,
+        ):
+            score += 15
+            reasons.append("C extension")
+
+        if r.tsan_warning_iterations > 0:
+            score += 10
+            reasons.append(f"TSAN:{','.join(r.tsan_warning_types[:3])}")
+
+        entries.append(
+            TriageEntry(
+                package=r.package,
+                priority_score=score,
+                category=r.category.value,
+                reason="; ".join(reasons),
+                pass_rate=r.pass_rate,
+                crash_count=r.crash_count,
+                deadlock_count=r.deadlock_count,
+                flaky_test_count=len(r.flaky_tests),
+                is_pure_python=is_pure,
+                has_tsan_warnings=r.tsan_warning_iterations > 0,
+            )
+        )
+
+    entries.sort(key=lambda e: -e.priority_score)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Duration anomaly detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DurationAnomaly:
+    """A package whose timing suggests thread contention."""
+
+    package: str
+    mean_duration_s: float
+    stdev_duration_s: float
+    cv: float
+    slowest_iteration: int
+    slowest_duration_s: float
+    anomaly_type: str
+
+
+def detect_duration_anomalies(
+    results: list[FTPackageResult],
+    *,
+    cv_threshold: float = 0.3,
+) -> list[DurationAnomaly]:
+    """Find packages with abnormal timing patterns.
+
+    High variance in test duration across iterations can indicate
+    thread contention -- the test suite runs fine when threads don't
+    overlap but slows dramatically when they do.
+
+    Progressive slowdown (each iteration slower than the last)
+    suggests a resource leak or accumulating lock contention.
+
+    Args:
+        results: List of package results.
+        cv_threshold: Coefficient of variation above which timing
+            is flagged as anomalous (default 0.3 = 30%).
+
+    Returns:
+        List of DurationAnomaly for flagged packages.
+    """
+    from labeille.bench.stats import describe
+
+    anomalies: list[DurationAnomaly] = []
+
+    for r in results:
+        durations = [it.duration_s for it in r.iterations if it.duration_s > 0]
+        if len(durations) < 3:
+            continue
+
+        stats = describe(durations)
+        if stats.cv < cv_threshold:
+            continue
+
+        slowest_idx = max(
+            range(len(r.iterations)),
+            key=lambda i: r.iterations[i].duration_s,
+        )
+
+        anomaly_type = "high_variance"
+        if len(durations) >= 4:
+            mid = len(durations) // 2
+            first_half_mean = sum(durations[:mid]) / mid
+            second_half_mean = sum(durations[mid:]) / (len(durations) - mid)
+            if second_half_mean > first_half_mean * 1.2:
+                anomaly_type = "progressive_slowdown"
+
+        anomalies.append(
+            DurationAnomaly(
+                package=r.package,
+                mean_duration_s=stats.mean,
+                stdev_duration_s=stats.stdev,
+                cv=stats.cv,
+                slowest_iteration=slowest_idx + 1,
+                slowest_duration_s=r.iterations[slowest_idx].duration_s,
+                anomaly_type=anomaly_type,
+            )
+        )
+
+    anomalies.sort(key=lambda a: -a.cv)
+    return anomalies
+
+
+# ---------------------------------------------------------------------------
+# Aggregate analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FTAnalysisReport:
+    """Complete analysis of a free-threading test run.
+
+    Aggregates flakiness profiles, GIL comparisons, triage priority,
+    and duration anomalies into one report.
+    """
+
+    total_packages: int = 0
+    summary: dict[str, Any] = field(default_factory=dict)
+    triage: list[TriageEntry] = field(default_factory=list)
+    flaky_profiles: list[FlakinessProfile] = field(default_factory=list)
+    gil_comparisons: list[GILComparisonResult] = field(default_factory=list)
+    duration_anomalies: list[DurationAnomaly] = field(default_factory=list)
+
+    ft_specific_failures: int = 0
+    pre_existing_failures: int = 0
+    most_common_crash_sigs: list[tuple[str, int]] = field(default_factory=list)
+    most_common_tsan_types: list[tuple[str, int]] = field(default_factory=list)
+
+
+def analyze_ft_run(
+    results: list[FTPackageResult],
+) -> FTAnalysisReport:
+    """Run the full analysis pipeline on a set of results.
+
+    Args:
+        results: List of package results from an ft run.
+
+    Returns:
+        FTAnalysisReport with all analyses populated.
+    """
+    report = FTAnalysisReport(total_packages=len(results))
+
+    report.summary = FTRunSummary.compute(results).to_dict()
+
+    report.triage = prioritize_triage(results)
+
+    for r in results:
+        if r.category == FailureCategory.INTERMITTENT:
+            report.flaky_profiles.append(analyze_flakiness(r))
+
+    for r in results:
+        if r.category == FailureCategory.CRASH and r.pass_count > 0:
+            report.flaky_profiles.append(analyze_flakiness(r))
+
+    for r in results:
+        comp = compare_gil_modes(r)
+        if comp is not None:
+            report.gil_comparisons.append(comp)
+            if comp.free_threading_specific:
+                report.ft_specific_failures += 1
+            elif comp.classification == "pre_existing":
+                report.pre_existing_failures += 1
+
+    report.duration_anomalies = detect_duration_anomalies(results)
+
+    crash_sigs: Counter[str] = Counter()
+    for r in results:
+        for sig in r.failure_signatures:
+            crash_sigs[sig] += 1
+    report.most_common_crash_sigs = crash_sigs.most_common(10)
+
+    tsan_types: Counter[str] = Counter()
+    for r in results:
+        for t in r.tsan_warning_types:
+            tsan_types[t] += 1
+    report.most_common_tsan_types = tsan_types.most_common(10)
+
+    return report

--- a/tests/test_ft_analysis.py
+++ b/tests/test_ft_analysis.py
@@ -1,0 +1,499 @@
+"""Tests for labeille.ft.analysis — deep free-threading analysis."""
+
+from __future__ import annotations
+
+import unittest
+
+from ft_test_helpers import make_iteration, make_package_result
+
+from labeille.ft.analysis import (
+    analyze_flakiness,
+    analyze_ft_run,
+    compare_gil_modes,
+    detect_duration_anomalies,
+    prioritize_triage,
+)
+from labeille.ft.results import (
+    FTPackageResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Flakiness profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFlakiness(unittest.TestCase):
+    def test_flakiness_all_pass(self) -> None:
+        r = make_package_result("pkg", ["pass"] * 5)
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pass_rate, 1.0)
+        self.assertEqual(profile.failure_modes, {})
+
+    def test_flakiness_mixed(self) -> None:
+        r = make_package_result("pkg", ["pass", "pass", "pass", "fail", "fail"])
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.failure_modes, {"fail": 2})
+        self.assertAlmostEqual(profile.pass_rate, 0.6)
+
+    def test_flakiness_with_crashes(self) -> None:
+        r = make_package_result("pkg", ["pass", "pass", "pass", "crash", "fail"])
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.failure_modes.get("crash"), 1)
+        self.assertEqual(profile.failure_modes.get("fail"), 1)
+
+    def test_flakiness_consecutive_streaks(self) -> None:
+        r = make_package_result("pkg", ["pass", "pass", "pass", "fail", "fail"])
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.max_consecutive_passes, 3)
+        self.assertEqual(profile.max_consecutive_failures, 2)
+
+    def test_flakiness_per_test_detection(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(
+                    0, "pass", test_results={"test_foo": "PASSED", "test_bar": "PASSED"}
+                ),
+                make_iteration(
+                    1, "fail", test_results={"test_foo": "FAILED", "test_bar": "PASSED"}
+                ),
+                make_iteration(
+                    2, "pass", test_results={"test_foo": "PASSED", "test_bar": "PASSED"}
+                ),
+                make_iteration(
+                    3, "fail", test_results={"test_foo": "FAILED", "test_bar": "FAILED"}
+                ),
+                make_iteration(
+                    4, "pass", test_results={"test_foo": "PASSED", "test_bar": "PASSED"}
+                ),
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        self.assertEqual(len(profile.flaky_tests), 2)
+        # test_foo has higher fail rate (2/5) than test_bar (1/5).
+        self.assertEqual(profile.flaky_tests[0].test_id, "test_foo")
+        self.assertEqual(profile.flaky_tests[0].fail_count, 2)
+
+    def test_flakiness_consistent_failure_not_flaky(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(i, "fail", test_results={"test_baz": "FAILED"}) for i in range(5)
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        # test_baz fails in ALL iterations, so it's not flaky.
+        self.assertEqual(len(profile.flaky_tests), 0)
+
+    def test_pattern_consistent_test(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", test_results={"test_a": "PASSED"}),
+                make_iteration(1, "fail", test_results={"test_a": "FAILED"}),
+                make_iteration(2, "pass", test_results={"test_a": "PASSED"}),
+                make_iteration(3, "fail", test_results={"test_a": "FAILED"}),
+                make_iteration(4, "pass", test_results={"test_a": "PASSED"}),
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pattern, "consistent_test")
+
+    def test_pattern_random_test(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", test_results={"test_a": "PASSED", "test_b": "PASSED"}),
+                make_iteration(1, "fail", test_results={"test_a": "FAILED", "test_b": "PASSED"}),
+                make_iteration(2, "pass", test_results={"test_a": "PASSED", "test_b": "PASSED"}),
+                make_iteration(3, "fail", test_results={"test_a": "PASSED", "test_b": "FAILED"}),
+                make_iteration(4, "pass", test_results={"test_a": "PASSED", "test_b": "PASSED"}),
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pattern, "random_test")
+
+    def test_pattern_consistent_crash(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass"),
+                make_iteration(1, "crash", crash_signature="sig_a"),
+                make_iteration(2, "pass"),
+                make_iteration(3, "crash", crash_signature="sig_a"),
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pattern, "consistent_crash")
+
+    def test_pattern_varied_crash(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass"),
+                make_iteration(1, "crash", crash_signature="sig_a"),
+                make_iteration(2, "crash", crash_signature="sig_b"),
+            ],
+        )
+        r.compute_aggregates()
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pattern, "varied_crash")
+
+    def test_pattern_unknown_no_test_data(self) -> None:
+        r = make_package_result("pkg", ["pass", "fail", "pass"])
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.pattern, "unknown")
+
+    def test_flakiness_empty_iterations(self) -> None:
+        r = FTPackageResult(package="pkg")
+        profile = analyze_flakiness(r)
+        self.assertEqual(profile.total_iterations, 0)
+        self.assertEqual(profile.failure_modes, {})
+
+
+# ---------------------------------------------------------------------------
+# GIL comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareGilModes(unittest.TestCase):
+    def _make_result_with_gil(
+        self,
+        ft_statuses: list[str],
+        gil_statuses: list[str],
+        ft_test_results: list[dict[str, str]] | None = None,
+        gil_test_results: list[dict[str, str]] | None = None,
+    ) -> FTPackageResult:
+        ft_iters = [
+            make_iteration(
+                i,
+                s,
+                test_results=ft_test_results[i] if ft_test_results else {},
+            )
+            for i, s in enumerate(ft_statuses)
+        ]
+        gil_iters = [
+            make_iteration(
+                i,
+                s,
+                test_results=gil_test_results[i] if gil_test_results else {},
+            )
+            for i, s in enumerate(gil_statuses)
+        ]
+        r = FTPackageResult(
+            package="pkg",
+            iterations=ft_iters,
+            gil_enabled_iterations=gil_iters,
+        )
+        r.compute_aggregates()
+        return r
+
+    def test_compare_ft_compatible(self) -> None:
+        r = self._make_result_with_gil(["pass"] * 5, ["pass"] * 5)
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertEqual(comp.classification, "ft_compatible")
+
+    def test_compare_ft_intermittent(self) -> None:
+        r = self._make_result_with_gil(
+            ["pass", "pass", "fail", "pass", "pass"],
+            ["pass"] * 5,
+        )
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertEqual(comp.classification, "ft_intermittent")
+        self.assertTrue(comp.free_threading_specific)
+
+    def test_compare_ft_incompatible(self) -> None:
+        r = self._make_result_with_gil(["fail"] * 5, ["pass"] * 5)
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertEqual(comp.classification, "ft_incompatible")
+
+    def test_compare_pre_existing(self) -> None:
+        r = self._make_result_with_gil(
+            ["pass", "pass", "fail", "pass", "pass"],
+            ["pass", "fail", "pass", "pass", "pass"],
+        )
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertEqual(comp.classification, "pre_existing")
+
+    def test_compare_ft_exacerbated(self) -> None:
+        r = self._make_result_with_gil(
+            ["pass", "fail", "fail", "fail", "pass"],
+            ["pass", "pass", "pass", "fail", "pass"],
+        )
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertEqual(comp.classification, "ft_exacerbated")
+
+    def test_compare_no_data(self) -> None:
+        r = make_package_result("pkg", ["pass"] * 5)
+        comp = compare_gil_modes(r)
+        self.assertIsNone(comp)
+
+    def test_compare_ft_specific_tests(self) -> None:
+        ft_results = [{"test_x": "FAILED"}] * 5
+        gil_results = [{"test_x": "PASSED"}] * 5
+        r = self._make_result_with_gil(
+            ["fail"] * 5,
+            ["pass"] * 5,
+            ft_test_results=ft_results,
+            gil_test_results=gil_results,
+        )
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertIn("test_x", comp.ft_specific_failing_tests)
+
+    def test_compare_shared_tests(self) -> None:
+        ft_results = [{"test_y": "FAILED"}] * 5
+        gil_results = [{"test_y": "FAILED"}] * 5
+        r = self._make_result_with_gil(
+            ["fail"] * 5,
+            ["fail"] * 5,
+            ft_test_results=ft_results,
+            gil_test_results=gil_results,
+        )
+        comp = compare_gil_modes(r)
+        assert comp is not None
+        self.assertIn("test_y", comp.shared_failing_tests)
+
+
+# ---------------------------------------------------------------------------
+# Triage prioritization tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrioritizeTriage(unittest.TestCase):
+    def test_triage_crashes_highest(self) -> None:
+        results = [
+            make_package_result("crash_pkg", ["pass", "pass", "crash"]),
+            make_package_result("inter_pkg", ["pass", "fail", "pass"]),
+        ]
+        triage = prioritize_triage(results)
+        self.assertEqual(triage[0].package, "crash_pkg")
+        self.assertGreater(triage[0].priority_score, triage[1].priority_score)
+
+    def test_triage_deadlock_high(self) -> None:
+        results = [
+            make_package_result("dead_pkg", ["pass", "deadlock"]),
+            make_package_result("inter_pkg", ["pass", "fail", "pass"]),
+        ]
+        triage = prioritize_triage(results)
+        self.assertEqual(triage[0].package, "dead_pkg")
+
+    def test_triage_compatible_excluded(self) -> None:
+        results = [
+            make_package_result("ok_pkg", ["pass"] * 5),
+            make_package_result("crash_pkg", ["pass", "crash"]),
+        ]
+        triage = prioritize_triage(results)
+        packages = [e.package for e in triage]
+        self.assertNotIn("ok_pkg", packages)
+        self.assertIn("crash_pkg", packages)
+
+    def test_triage_extension_bonus(self) -> None:
+        results = [
+            make_package_result(
+                "ext_crash",
+                ["pass", "crash"],
+                extension_compat={"is_pure_python": False},
+            ),
+            make_package_result("py_crash", ["pass", "crash"]),
+        ]
+        triage = prioritize_triage(results)
+        self.assertEqual(triage[0].package, "ext_crash")
+        self.assertGreater(triage[0].priority_score, triage[1].priority_score)
+
+    def test_triage_tsan_bonus(self) -> None:
+        r = FTPackageResult(
+            package="tsan_pkg",
+            iterations=[make_iteration(i, "pass", tsan_warnings=["data race"]) for i in range(5)],
+        )
+        r.compute_aggregates()
+        r.categorize()
+        triage = prioritize_triage([r])
+        self.assertEqual(len(triage), 1)
+        self.assertTrue(triage[0].has_tsan_warnings)
+
+    def test_triage_sorted_by_score(self) -> None:
+        results = [
+            make_package_result("low", ["pass", "fail"]),
+            make_package_result("high", ["pass", "crash", "crash"]),
+            make_package_result("mid", ["fail"] * 5),
+        ]
+        triage = prioritize_triage(results)
+        scores = [e.priority_score for e in triage]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_triage_includes_compatible_when_requested(self) -> None:
+        results = [make_package_result("ok_pkg", ["pass"] * 5)]
+        triage = prioritize_triage(results, include_compatible=True)
+        packages = [e.package for e in triage]
+        self.assertIn("ok_pkg", packages)
+
+
+# ---------------------------------------------------------------------------
+# Duration anomaly tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDurationAnomalies(unittest.TestCase):
+    def test_no_anomaly_consistent_durations(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[make_iteration(i, "pass", duration_s=10.0) for i in range(5)],
+        )
+        r.compute_aggregates()
+        anomalies = detect_duration_anomalies([r])
+        self.assertEqual(anomalies, [])
+
+    def test_anomaly_high_variance(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=50.0),
+                make_iteration(1, "pass", duration_s=10.0),
+                make_iteration(2, "pass", duration_s=10.0),
+                make_iteration(3, "pass", duration_s=10.0),
+                make_iteration(4, "pass", duration_s=10.0),
+            ],
+        )
+        r.compute_aggregates()
+        anomalies = detect_duration_anomalies([r])
+        self.assertEqual(len(anomalies), 1)
+        self.assertEqual(anomalies[0].anomaly_type, "high_variance")
+
+    def test_anomaly_progressive_slowdown(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=10.0),
+                make_iteration(1, "pass", duration_s=12.0),
+                make_iteration(2, "pass", duration_s=15.0),
+                make_iteration(3, "pass", duration_s=20.0),
+                make_iteration(4, "pass", duration_s=28.0),
+            ],
+        )
+        r.compute_aggregates()
+        anomalies = detect_duration_anomalies([r])
+        self.assertEqual(len(anomalies), 1)
+        self.assertEqual(anomalies[0].anomaly_type, "progressive_slowdown")
+
+    def test_anomaly_too_few_iterations(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=10.0),
+                make_iteration(1, "pass", duration_s=50.0),
+            ],
+        )
+        r.compute_aggregates()
+        anomalies = detect_duration_anomalies([r])
+        self.assertEqual(anomalies, [])
+
+    def test_anomaly_custom_threshold(self) -> None:
+        r = FTPackageResult(
+            package="pkg",
+            iterations=[
+                make_iteration(0, "pass", duration_s=10.0),
+                make_iteration(1, "pass", duration_s=10.0),
+                make_iteration(2, "pass", duration_s=15.0),
+                make_iteration(3, "pass", duration_s=10.0),
+            ],
+        )
+        r.compute_aggregates()
+        # With default threshold 0.3, might not trigger. With 0.1, should.
+        anomalies_strict = detect_duration_anomalies([r], cv_threshold=0.1)
+        anomalies_lenient = detect_duration_anomalies([r], cv_threshold=0.5)
+        self.assertGreaterEqual(len(anomalies_strict), len(anomalies_lenient))
+
+
+# ---------------------------------------------------------------------------
+# Full analysis report tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFtRun(unittest.TestCase):
+    def test_analyze_ft_run_basic(self) -> None:
+        results = [
+            make_package_result("compat", ["pass"] * 5),
+            make_package_result("inter", ["pass", "fail", "pass", "fail", "pass"]),
+            make_package_result("crash", ["pass", "pass", "crash"]),
+        ]
+        report = analyze_ft_run(results)
+        self.assertEqual(report.total_packages, 3)
+        self.assertGreater(len(report.triage), 0)
+        # intermittent and crash (with passes) get flaky profiles.
+        self.assertGreaterEqual(len(report.flaky_profiles), 1)
+
+    def test_analyze_ft_run_with_gil_comparison(self) -> None:
+        r = FTPackageResult(
+            package="ft_only",
+            iterations=[
+                make_iteration(0, "pass"),
+                make_iteration(1, "fail"),
+                make_iteration(2, "pass"),
+            ],
+            gil_enabled_iterations=[
+                make_iteration(0, "pass"),
+                make_iteration(1, "pass"),
+                make_iteration(2, "pass"),
+            ],
+        )
+        r.compute_aggregates()
+        r.categorize()
+        report = analyze_ft_run([r])
+        self.assertEqual(report.ft_specific_failures, 1)
+
+    def test_analyze_crash_signatures_aggregated(self) -> None:
+        r1 = FTPackageResult(
+            package="c1",
+            iterations=[make_iteration(0, "crash", crash_signature="sig_x")],
+        )
+        r1.compute_aggregates()
+        r1.categorize()
+        r2 = FTPackageResult(
+            package="c2",
+            iterations=[
+                make_iteration(0, "crash", crash_signature="sig_x"),
+                make_iteration(1, "crash", crash_signature="sig_y"),
+            ],
+        )
+        r2.compute_aggregates()
+        r2.categorize()
+        report = analyze_ft_run([r1, r2])
+        sigs = dict(report.most_common_crash_sigs)
+        self.assertEqual(sigs.get("sig_x"), 2)
+        self.assertEqual(sigs.get("sig_y"), 1)
+
+    def test_analyze_tsan_types_aggregated(self) -> None:
+        r1 = FTPackageResult(
+            package="t1",
+            iterations=[make_iteration(0, "pass", tsan_warnings=["data race"])],
+        )
+        r1.compute_aggregates()
+        r1.categorize()
+        r2 = FTPackageResult(
+            package="t2",
+            iterations=[
+                make_iteration(0, "pass", tsan_warnings=["data race", "thread leak"]),
+            ],
+        )
+        r2.compute_aggregates()
+        r2.categorize()
+        report = analyze_ft_run([r1, r2])
+        types = dict(report.most_common_tsan_types)
+        self.assertEqual(types.get("data race"), 2)
+        self.assertEqual(types.get("thread leak"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `ft/analysis.py` with flakiness profiling (`analyze_flakiness`), GIL mode comparison (`compare_gil_modes`), severity-scored triage (`prioritize_triage`), duration anomaly detection (`detect_duration_anomalies`), and full analysis pipeline (`analyze_ft_run`).
- 36 new tests covering all analysis functions.
- Dataclasses: `FlakyTest`, `FlakinessProfile`, `GILComparisonResult`, `TriageEntry`, `DurationAnomaly`, `FTAnalysisReport`.

## Test plan
- [x] ruff format — clean
- [x] ruff check — clean
- [x] mypy — clean
- [x] 1335 tests pass (36 new)

Closes #82

Generated with [Claude Code](https://claude.com/claude-code)