### PR TITLE
feat: add free-threading CLI commands and terminal display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `ft/display.py` module with terminal formatting for free-threading results: compatibility summaries, package tables, flakiness profiles, triage lists, GIL comparison reports, and progress output.
+- `ft_cli.py` module with `labeille ft` CLI subgroup: `run`, `show`, `compare`, `compat`, `flaky`, `report`, `export` commands for free-threading compatibility testing.
 - `ft/analysis.py` module with `FlakyTest`, `FlakinessProfile`, `GILComparisonResult`, `TriageEntry`, `DurationAnomaly`, and `FTAnalysisReport` dataclasses for free-threading result analysis.
 - `analyze_flakiness()` for detailed flakiness profiling with failure pattern classification and consecutive streak detection.
 - `compare_gil_modes()` for GIL-enabled vs free-threaded result comparison.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -40,6 +40,10 @@ from labeille.bench_cli import bench as bench_group  # noqa: E402
 
 main.add_command(bench_group)
 
+from labeille.ft_cli import ft as ft_group  # noqa: E402
+
+main.add_command(ft_group)
+
 
 @main.command()
 @click.argument("packages", nargs=-1)

--- a/src/labeille/ft/compare.py
+++ b/src/labeille/ft/compare.py
@@ -1,0 +1,29 @@
+"""Cross-run comparison for free-threading results.
+
+Stub module — full implementation in prompt 29.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class FTRunComparison:
+    """Comparison between two free-threading runs."""
+
+    improved: list[dict[str, Any]] = field(default_factory=list)
+    regressed: list[dict[str, Any]] = field(default_factory=list)
+    unchanged: list[dict[str, Any]] = field(default_factory=list)
+
+
+def compare_ft_runs(
+    results_a: list[Any],
+    results_b: list[Any],
+) -> FTRunComparison:
+    """Compare two sets of free-threading results.
+
+    Stub — returns empty comparison. Full implementation in prompt 29.
+    """
+    return FTRunComparison()

--- a/src/labeille/ft/display.py
+++ b/src/labeille/ft/display.py
@@ -1,0 +1,359 @@
+"""Terminal display formatting for free-threading results.
+
+Provides functions to format compatibility summaries, flakiness
+profiles, triage lists, GIL comparison tables, and progress output
+for terminal display.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("labeille")
+
+
+def format_compatibility_summary(
+    summary: dict[str, Any],
+    *,
+    python_info: str = "",
+    system_info: str = "",
+) -> str:
+    """Format the top-level compatibility summary.
+
+    Output::
+
+        Free-Threading Compatibility Report
+        ════════════════════════════════════
+
+        Python: 3.14.0b2 (free-threaded, --disable-gil)
+        System: AMD Ryzen 9 7950X, 64GB RAM, Ubuntu 24.04
+
+        Compatibility Summary
+        ─────────────────────
+          ✓ Compatible:              245  (70.6%)
+          ⚠ Compatible (GIL fallback): 28  ( 8.1%)
+          ...
+    """
+    lines = [
+        "Free-Threading Compatibility Report",
+        "════════════════════════════════════",
+        "",
+    ]
+
+    if python_info:
+        lines.append(python_info)
+    if system_info:
+        lines.append(system_info)
+    if python_info or system_info:
+        lines.append("")
+
+    total = summary.get("total_packages", 0)
+    categories = summary.get("categories", {})
+
+    lines.append("Compatibility Summary")
+    lines.append("─────────────────────")
+
+    # Display categories in severity order.
+    display_order = [
+        ("compatible", "✓", "Compatible"),
+        ("compatible_gil_fallback", "⚠", "Compatible (GIL fallback)"),
+        ("tsan_warnings", "⚡", "TSAN warnings (tests pass)"),
+        ("intermittent", "~", "Intermittent"),
+        ("incompatible", "✗", "Incompatible"),
+        ("crash", "💥", "Crash"),
+        ("deadlock", "🔒", "Deadlock"),
+        ("install_failure", "⚙", "Install failure"),
+        ("import_failure", "📦", "Import failure"),
+        ("unknown", "?", "Unknown"),
+    ]
+
+    for cat_value, symbol, label in display_order:
+        count = categories.get(cat_value, 0)
+        if count == 0:
+            continue
+        pct = count / total * 100 if total > 0 else 0
+        lines.append(f"  {symbol} {label + ':':<35s} {count:3d}  ({pct:5.1f}%)")
+
+    lines.append(f"  {'':37s} {'─' * 3}")
+    lines.append(f"  {'Total:':<37s} {total:3d}")
+
+    # Pure Python vs extension breakdown.
+    pp_count = summary.get("pure_python_count", 0)
+    ext_count = summary.get("extension_count", 0)
+    pp_pct = summary.get("pure_python_compatible_pct", 0)
+    ext_pct = summary.get("extension_compatible_pct", 0)
+
+    if pp_count > 0 or ext_count > 0:
+        lines.append("")
+        lines.append("By package type:")
+        if pp_count > 0:
+            lines.append(f"  Pure Python:    {pp_count:3d} packages, {pp_pct:.1f}% compatible")
+        if ext_count > 0:
+            lines.append(f"  C extensions:   {ext_count:3d} packages, {ext_pct:.1f}% compatible")
+
+    return "\n".join(lines)
+
+
+def format_package_table(
+    results: list[Any],
+    *,
+    sort_by: str = "category",
+    max_rows: int | None = None,
+    show_iterations: bool = False,
+) -> str:
+    """Format a table of per-package results.
+
+    Output::
+
+        Package          Category        Pass Rate  Iters  Crashes  Details
+        ─────────────────────────────────────────────────────────────────────
+        requests         ✓ compatible     10/10      10       0
+        numpy            💥 crash           7/10      10       3     SIGSEGV
+        aiohttp          ~ intermittent    7/10      10       0     3 flaky tests
+        ...
+    """
+    if sort_by == "category":
+        results = sorted(
+            results,
+            key=lambda r: (r.category.severity, -r.pass_rate, r.package),
+        )
+    elif sort_by == "pass_rate":
+        results = sorted(results, key=lambda r: (r.pass_rate, r.package))
+    else:
+        results = sorted(results, key=lambda r: r.package)
+
+    if max_rows and len(results) > max_rows:
+        total = len(results)
+        results = results[:max_rows]
+        truncated = True
+    else:
+        total = len(results)
+        truncated = False
+
+    # Header.
+    header = (
+        f"{'Package':<20s} {'Category':<25s} {'Pass Rate':>10s} "
+        f"{'Iters':>6s} {'Crashes':>8s}  {'Details'}"
+    )
+    separator = "─" * min(len(header) + 20, 100)
+
+    lines = [header, separator]
+
+    for r in results:
+        cat_str = f"{r.category.symbol} {r.category.value}"
+
+        if r.iterations_completed > 0:
+            rate_str = f"{r.pass_count}/{r.iterations_completed}"
+        else:
+            rate_str = "N/A"
+
+        # Details column.
+        details: list[str] = []
+        if r.failure_signatures:
+            details.append(r.failure_signatures[0][:30])
+        if r.flaky_tests:
+            details.append(f"{len(r.flaky_tests)} flaky tests")
+        if r.tsan_warning_types:
+            details.append(f"TSAN: {r.tsan_warning_types[0]}")
+        if r.deadlock_count > 0:
+            details.append(f"{r.deadlock_count} deadlocks")
+        if not r.install_ok:
+            details.append("install failed")
+        if not r.import_ok:
+            details.append("import failed")
+
+        detail_str = ", ".join(details)[:50]
+
+        lines.append(
+            f"{r.package:<20s} {cat_str:<25s} {rate_str:>10s} "
+            f"{r.iterations_completed:>6d} {r.crash_count:>8d}  "
+            f"{detail_str}"
+        )
+
+    if truncated:
+        lines.append(f"  ... ({total - max_rows} more)")  # type: ignore[operator]
+
+    return "\n".join(lines)
+
+
+def format_triage_list(
+    triage: list[Any],
+    *,
+    max_entries: int = 20,
+) -> str:
+    """Format the triage priority list.
+
+    Output::
+
+        Investigation Priority
+        ──────────────────────
+         1. numpy          💥 crash       (score: 70)  3 crashes; C extension
+         2. gevent         🔒 deadlock    (score: 60)  2 deadlocks
+         3. aiohttp        ~ intermittent (score: 35)  severity:intermittent
+         ...
+    """
+    from labeille.ft.results import FailureCategory
+
+    lines = ["Investigation Priority", "──────────────────────"]
+
+    for i, entry in enumerate(triage[:max_entries], 1):
+        cat = FailureCategory(entry.category)
+        lines.append(
+            f"  {i:2d}. {entry.package:<18s} {cat.symbol} "
+            f"{entry.category:<14s} (score: {entry.priority_score:.0f})  "
+            f"{entry.reason[:60]}"
+        )
+
+    if len(triage) > max_entries:
+        lines.append(f"  ... and {len(triage) - max_entries} more")
+
+    return "\n".join(lines)
+
+
+def format_flakiness_profile(profile: Any) -> str:
+    """Format a single flakiness profile for display.
+
+    Output::
+
+        Flakiness Profile: aiohttp
+        ──────────────────────────
+        Pass rate:          7/10 (70.0%)
+        Pattern:            consistent_test
+        Failure modes:      fail: 3
+        Consecutive passes: 4
+        Consecutive fails:  2
+
+        Flaky tests (fail intermittently):
+          test_connector::test_close     3/5 (60.0%)
+          test_client::test_timeout      1/5 (20.0%)
+    """
+    lines = [
+        f"Flakiness Profile: {profile.package}",
+        "─" * (20 + len(profile.package)),
+    ]
+
+    passes = int(profile.pass_rate * profile.total_iterations)
+    lines.append(
+        f"Pass rate:          {passes}/{profile.total_iterations} ({profile.pass_rate * 100:.1f}%)"
+    )
+    lines.append(f"Pattern:            {profile.pattern}")
+
+    if profile.failure_modes:
+        modes = ", ".join(f"{k}: {v}" for k, v in sorted(profile.failure_modes.items()))
+        lines.append(f"Failure modes:      {modes}")
+
+    lines.append(f"Consecutive passes: {profile.max_consecutive_passes}")
+    lines.append(f"Consecutive fails:  {profile.max_consecutive_failures}")
+
+    if profile.flaky_tests:
+        lines.append("")
+        lines.append("Flaky tests (fail intermittently):")
+        for t in profile.flaky_tests[:15]:
+            short_id = t.test_id
+            if len(short_id) > 50:
+                short_id = "..." + short_id[-47:]
+            lines.append(
+                f"  {short_id:<55s} {t.fail_count}/{t.total_seen} ({t.fail_rate * 100:.1f}%)"
+            )
+        if len(profile.flaky_tests) > 15:
+            lines.append(f"  ... and {len(profile.flaky_tests) - 15} more")
+
+    return "\n".join(lines)
+
+
+def format_gil_comparison(
+    comparisons: list[Any],
+) -> str:
+    """Format GIL-enabled vs GIL-disabled comparison table.
+
+    Output::
+
+        GIL Comparison (free-threaded vs GIL-enabled)
+        ──────────────────────────────────────────────
+        Package          GIL=0 Rate  GIL=1 Rate  Classification
+        ─────────────────────────────────────────────────────────
+        requests            100%        100%      ft_compatible
+        numpy                70%        100%      ft_intermittent  ← FT-specific
+        sqlalchemy           60%         80%      ft_exacerbated
+        celery               50%         50%      pre_existing
+        ...
+
+        Summary:
+          FT-specific failures: 12 packages
+          Pre-existing failures: 5 packages
+    """
+    lines = [
+        "GIL Comparison (free-threaded vs GIL-enabled)",
+        "──────────────────────────────────────────────",
+        f"{'Package':<20s} {'GIL=0 Rate':>11s} {'GIL=1 Rate':>11s}  {'Classification':<20s}",
+        "─" * 75,
+    ]
+
+    ft_specific = 0
+    pre_existing = 0
+
+    for c in comparisons:
+        ft_rate = f"{c.gil_disabled_pass_rate * 100:.0f}%"
+        gil_rate = f"{c.gil_enabled_pass_rate * 100:.0f}%"
+        marker = ""
+        if c.free_threading_specific:
+            marker = " ← FT-specific"
+            ft_specific += 1
+        if c.classification == "pre_existing":
+            pre_existing += 1
+
+        lines.append(
+            f"{c.package:<20s} {ft_rate:>11s} {gil_rate:>11s}  {c.classification:<20s}{marker}"
+        )
+
+    lines.append("")
+    lines.append("Summary:")
+    lines.append(f"  FT-specific failures: {ft_specific} packages")
+    lines.append(f"  Pre-existing failures: {pre_existing} packages")
+
+    return "\n".join(lines)
+
+
+def format_ft_comparison(
+    comparison: Any,
+    *,
+    label_a: str = "run_a",
+    label_b: str = "run_b",
+) -> str:
+    """Format a comparison between two free-threading runs.
+
+    This is a stub that will be fully implemented in prompt 29
+    when ft/compare.py is available.
+    """
+    lines = [
+        f"Free-Threading Run Comparison: {label_a} vs {label_b}",
+        "═" * 60,
+    ]
+    if hasattr(comparison, "improved") and hasattr(comparison, "regressed"):
+        lines.append(f"  Improved:   {len(comparison.improved)} packages")
+        lines.append(f"  Regressed:  {len(comparison.regressed)} packages")
+        lines.append(f"  Unchanged:  {len(comparison.unchanged)} packages")
+    else:
+        lines.append("  (comparison data not available)")
+    return "\n".join(lines)
+
+
+def format_progress(
+    package: str,
+    iteration: int,
+    total_iterations: int,
+    status: str,
+    duration: float,
+    packages_done: int,
+    packages_total: int,
+) -> str:
+    """Format a single-line progress update.
+
+    Output: ``(15/350) requests iter 3/10: pass (12.3s)``
+    """
+    return (
+        f"({packages_done}/{packages_total}) {package} "
+        f"iter {iteration}/{total_iterations}: "
+        f"{status} ({duration:.1f}s)"
+    )

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -1,0 +1,37 @@
+"""Export and report generation for free-threading results.
+
+Stub module — full implementation in prompt 29.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def generate_report(
+    meta: Any,
+    results: list[Any],
+    *,
+    format: str = "markdown",
+) -> str:
+    """Generate a comprehensive compatibility report.
+
+    Stub — returns placeholder. Full implementation in prompt 29.
+    """
+    return f"# Free-Threading Compatibility Report\n\n(Report generation not yet implemented)"
+
+
+def export_csv(results: list[Any]) -> str:
+    """Export results as CSV.
+
+    Stub — returns placeholder. Full implementation in prompt 29.
+    """
+    return "package,category,pass_rate,crash_count\n"
+
+
+def export_json(results: list[Any]) -> str:
+    """Export results as JSON.
+
+    Stub — returns placeholder. Full implementation in prompt 29.
+    """
+    return "[]"

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -1,0 +1,432 @@
+"""CLI commands for free-threading compatibility testing."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+log = logging.getLogger("labeille")
+
+
+@click.group()
+def ft() -> None:
+    """Free-threading compatibility testing.
+
+    Test PyPI packages against free-threaded CPython builds to
+    detect crashes, deadlocks, race conditions, and GIL fallback.
+    """
+
+
+# ---------------------------------------------------------------------------
+# ft run
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.option(
+    "--target-python",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to free-threaded Python build.",
+)
+@click.option("--iterations", "-n", default=10, help="Runs per package (default: 10).")
+@click.option("--timeout", default=600, help="Per-iteration timeout in seconds.")
+@click.option(
+    "--stall-threshold",
+    default=60,
+    help="Seconds without output before deadlock detection.",
+)
+@click.option("--packages", default=None, help="Comma-separated package filter.")
+@click.option(
+    "--top",
+    "top_n",
+    default=None,
+    type=int,
+    help="Test only top N packages by downloads.",
+)
+@click.option(
+    "--compare-with-gil",
+    is_flag=True,
+    help="Also run with GIL enabled for comparison.",
+)
+@click.option(
+    "--stop-on-first-pass",
+    is_flag=True,
+    help="Stop after first passing iteration per package.",
+)
+@click.option(
+    "--detect-extensions/--no-detect-extensions",
+    default=True,
+    help="Check extension GIL compatibility.",
+)
+@click.option("--tsan", "tsan_build", is_flag=True, help="Parse TSAN warnings from stderr.")
+@click.option(
+    "--check-stability/--no-check-stability",
+    default=False,
+    help="Check system stability before starting.",
+)
+@click.option("--extra-deps", default=None, help="Comma-separated extra dependencies.")
+@click.option("--test-command-suffix", default=None, help="Append to test commands.")
+@click.option("--test-command-override", default=None, help="Override all test commands.")
+@click.option(
+    "--results-dir",
+    type=click.Path(),
+    default="results",
+    help="Output directory for results.",
+)
+@click.option(
+    "--registry-dir", type=click.Path(exists=True), default="registry", help="Registry directory."
+)
+@click.option("--repos-dir", type=click.Path(), default="repos", help="Repos directory.")
+@click.option("--venvs-dir", type=click.Path(), default="venvs", help="Venvs directory.")
+@click.option(
+    "--env",
+    "env_pairs",
+    type=str,
+    multiple=True,
+    help="Extra env var as KEY=VALUE (repeatable).",
+)
+@click.option("-v", "--verbose", is_flag=True)
+def run(
+    target_python: str,
+    iterations: int,
+    timeout: int,
+    stall_threshold: int,
+    packages: str | None,
+    top_n: int | None,
+    compare_with_gil: bool,
+    stop_on_first_pass: bool,
+    detect_extensions: bool,
+    tsan_build: bool,
+    check_stability: bool,
+    extra_deps: str | None,
+    test_command_suffix: str | None,
+    test_command_override: str | None,
+    results_dir: str,
+    registry_dir: str,
+    repos_dir: str,
+    venvs_dir: str,
+    env_pairs: tuple[str, ...],
+    verbose: bool,
+) -> None:
+    """Run free-threading compatibility tests.
+
+    Tests each package's test suite multiple times under a
+    free-threaded CPython build to detect crashes, deadlocks,
+    race conditions, and GIL fallback behavior.
+
+    \b
+    Examples:
+        # Basic run with 10 iterations
+        labeille ft run --target-python /opt/cpython-ft/bin/python3
+
+        # Quick survey (stop on first pass)
+        labeille ft run --target-python /opt/cpython-ft/bin/python3 \\
+            --stop-on-first-pass --top 50
+
+        # With GIL comparison for precise classification
+        labeille ft run --target-python /opt/cpython-ft/bin/python3 \\
+            --compare-with-gil --iterations 5
+
+        # With TSAN for race detection
+        labeille ft run --target-python /opt/cpython-tsan/bin/python3 \\
+            --tsan --iterations 5
+    """
+    from labeille.ft.runner import FTRunConfig, run_ft
+
+    env_overrides: dict[str, str] = {}
+    for pair in env_pairs:
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            env_overrides[k] = v
+
+    config = FTRunConfig(
+        target_python=Path(target_python),
+        iterations=iterations,
+        timeout=timeout,
+        stall_threshold=stall_threshold,
+        packages_filter=(
+            [p.strip() for p in packages.split(",") if p.strip()] if packages else None
+        ),
+        top_n=top_n,
+        registry_dir=Path(registry_dir),
+        repos_dir=Path(repos_dir),
+        venvs_dir=Path(venvs_dir),
+        results_dir=Path(results_dir),
+        env_overrides=env_overrides,
+        extra_deps=([d.strip() for d in extra_deps.split(",") if d.strip()] if extra_deps else []),
+        test_command_suffix=test_command_suffix,
+        test_command_override=test_command_override,
+        detect_extensions=detect_extensions,
+        stop_on_first_pass=stop_on_first_pass,
+        tsan_build=tsan_build,
+        compare_with_gil=compare_with_gil,
+        check_stability=check_stability,
+        verbose=verbose,
+    )
+
+    results = run_ft(config)
+
+    # Print summary.
+    from labeille.ft.display import format_compatibility_summary
+    from labeille.ft.results import FTRunSummary
+
+    summary = FTRunSummary.compute(results)
+    click.echo()
+    click.echo(format_compatibility_summary(summary.to_dict()))
+
+
+# ---------------------------------------------------------------------------
+# ft show
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(["category", "pass_rate", "name"]),
+    default="category",
+)
+@click.option("--limit", default=None, type=int, help="Maximum packages to show.")
+def show(result_dir: str, sort_by: str, limit: int | None) -> None:
+    """Display free-threading test results.
+
+    Shows the compatibility summary, per-package table, and
+    highlights packages that need investigation.
+    """
+    from labeille.ft.display import format_compatibility_summary, format_package_table
+    from labeille.ft.results import FTRunSummary, load_ft_run
+
+    meta, results = load_ft_run(Path(result_dir))
+    summary = FTRunSummary.compute(results)
+
+    # System and Python info.
+    py_info = ""
+    if meta.python_profile:
+        py = meta.python_profile
+        flags: list[str] = []
+        if py.get("jit_enabled"):
+            flags.append("JIT")
+        if py.get("gil_disabled"):
+            flags.append("free-threaded")
+        flag_str = f" ({', '.join(flags)})" if flags else ""
+        py_info = f"Python: {py.get('version', '?')}{flag_str}"
+
+    sys_info = ""
+    if meta.system_profile:
+        sp = meta.system_profile
+        sys_info = (
+            f"System: {sp.get('cpu_model', '?')}, "
+            f"{sp.get('ram_total_gb', 0):.0f}GB RAM, "
+            f"{sp.get('os_distro', '?')}"
+        )
+
+    click.echo(
+        format_compatibility_summary(
+            summary.to_dict(),
+            python_info=py_info,
+            system_info=sys_info,
+        )
+    )
+    click.echo()
+    click.echo(
+        format_package_table(
+            results,
+            sort_by=sort_by,
+            max_rows=limit,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# ft flaky
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option("--package", default=None, help="Show flakiness for a specific package.")
+def flaky(result_dir: str, package: str | None) -> None:
+    """Analyze intermittent failures in detail.
+
+    Shows which specific tests fail intermittently, failure patterns,
+    and crash signature consistency.
+    """
+    from labeille.ft.analysis import analyze_flakiness
+    from labeille.ft.display import format_flakiness_profile
+    from labeille.ft.results import FailureCategory, load_ft_run
+
+    _, results = load_ft_run(Path(result_dir))
+
+    if package:
+        targets = [r for r in results if r.package == package]
+        if not targets:
+            click.echo(f"Package '{package}' not found in results.")
+            return
+    else:
+        targets = [
+            r
+            for r in results
+            if r.category
+            in (
+                FailureCategory.INTERMITTENT,
+                FailureCategory.CRASH,
+            )
+            and r.pass_count > 0
+        ]
+
+    if not targets:
+        click.echo("No intermittent packages found.")
+        return
+
+    for r in targets:
+        profile = analyze_flakiness(r)
+        click.echo(format_flakiness_profile(profile))
+        click.echo()
+
+
+# ---------------------------------------------------------------------------
+# ft compat
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option("--extensions-only", is_flag=True, help="Only show packages with C extensions.")
+def compat(result_dir: str, extensions_only: bool) -> None:
+    """Show extension GIL compatibility details.
+
+    Reports which packages have C extensions, whether they declare
+    Py_mod_gil, and whether GIL fallback was triggered at runtime.
+    """
+    from labeille.ft.compat import ExtensionCompat, format_extension_compat
+    from labeille.ft.results import load_ft_run
+
+    _, results = load_ft_run(Path(result_dir))
+
+    for r in sorted(results, key=lambda r: r.package):
+        if r.extension_compat is None:
+            continue
+
+        ext = ExtensionCompat.from_dict(r.extension_compat)
+
+        if extensions_only and ext.is_pure_python:
+            continue
+
+        click.echo(format_extension_compat(ext))
+        click.echo()
+
+
+# ---------------------------------------------------------------------------
+# ft compare
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("run_a", type=click.Path(exists=True))
+@click.argument("run_b", type=click.Path(exists=True))
+def compare(run_a: str, run_b: str) -> None:
+    """Compare two free-threading test runs.
+
+    Shows which packages improved, regressed, or stayed the same
+    between runs. Useful for tracking compatibility progress across
+    CPython versions.
+
+    \b
+    Examples:
+        labeille ft compare results/ft_314a1 results/ft_314b2
+    """
+    # Implementation uses ft/compare.py (prompt 29).
+    from labeille.ft.compare import compare_ft_runs
+    from labeille.ft.display import format_ft_comparison
+    from labeille.ft.results import load_ft_run
+
+    meta_a, results_a = load_ft_run(Path(run_a))
+    meta_b, results_b = load_ft_run(Path(run_b))
+
+    comparison = compare_ft_runs(results_a, results_b)
+
+    click.echo(
+        format_ft_comparison(
+            comparison,
+            label_a=meta_a.run_id,
+            label_b=meta_b.run_id,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# ft report
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["markdown", "text"]),
+    default="markdown",
+)
+@click.option("--output", "-o", default=None, help="Output file (default: stdout).")
+def report(result_dir: str, fmt: str, output: str | None) -> None:
+    """Generate a comprehensive compatibility report.
+
+    Produces a full report suitable for sharing with the CPython
+    core team or the free-threading compatibility tracker.
+    """
+    # Implementation uses ft/export.py (prompt 29).
+    from labeille.ft.export import generate_report
+    from labeille.ft.results import load_ft_run
+
+    meta, results = load_ft_run(Path(result_dir))
+    report_text = generate_report(meta, results, format=fmt)
+
+    if output:
+        Path(output).write_text(report_text, encoding="utf-8")
+        click.echo(f"Report written to {output}")
+    else:
+        click.echo(report_text)
+
+
+# ---------------------------------------------------------------------------
+# ft export
+# ---------------------------------------------------------------------------
+
+
+@ft.command()
+@click.argument("result_dir", type=click.Path(exists=True))
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["csv", "json"]),
+    default="csv",
+)
+@click.option("--output", "-o", default=None, help="Output file (default: stdout).")
+def export(result_dir: str, fmt: str, output: str | None) -> None:
+    """Export results for external analysis.
+
+    CSV format includes one row per package with category, pass rate,
+    crash count, and other key metrics. Suitable for pandas, R,
+    or spreadsheet analysis.
+    """
+    # Implementation uses ft/export.py (prompt 29).
+    from labeille.ft.export import export_csv, export_json
+    from labeille.ft.results import load_ft_run
+
+    _, results = load_ft_run(Path(result_dir))
+
+    if fmt == "csv":
+        text = export_csv(results)
+    else:
+        text = export_json(results)
+
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        click.echo(f"Exported to {output}")
+    else:
+        click.echo(text)

--- a/tests/test_ft_cli.py
+++ b/tests/test_ft_cli.py
@@ -1,0 +1,162 @@
+"""Tests for labeille.ft_cli — free-threading CLI commands."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from labeille.cli import main
+
+
+def _write_mock_run(tmpdir: Path) -> None:
+    """Write minimal ft_meta.json and ft_results.jsonl for testing."""
+    meta = {
+        "run_id": "test-run-001",
+        "timestamp": "2026-01-15T12:00:00",
+        "python_profile": {
+            "version": "3.14.0b2",
+            "jit_enabled": True,
+            "gil_disabled": True,
+        },
+        "system_profile": {
+            "cpu_model": "AMD Ryzen 9 7950X",
+            "ram_total_gb": 64,
+            "os_distro": "Ubuntu 24.04",
+        },
+    }
+    (tmpdir / "ft_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    results = [
+        {
+            "package": "requests",
+            "category": "compatible",
+            "iterations_completed": 10,
+            "pass_count": 10,
+            "crash_count": 0,
+            "pass_rate": 1.0,
+        },
+        {
+            "package": "numpy",
+            "category": "crash",
+            "iterations_completed": 10,
+            "pass_count": 7,
+            "crash_count": 3,
+            "pass_rate": 0.7,
+            "failure_signatures": ["SIGSEGV in _multiarray"],
+            "extension_compat": {
+                "package": "numpy",
+                "is_pure_python": False,
+                "extensions": [
+                    {
+                        "module_name": "_multiarray_umath",
+                        "is_extension": True,
+                        "triggered_gil_fallback": True,
+                    }
+                ],
+                "gil_fallback_active": True,
+            },
+        },
+        {
+            "package": "aiohttp",
+            "category": "intermittent",
+            "iterations_completed": 10,
+            "pass_count": 7,
+            "crash_count": 0,
+            "pass_rate": 0.7,
+            "flaky_tests": {"test_connector::test_close": 3, "test_client::test_timeout": 1},
+        },
+    ]
+    with (tmpdir / "ft_results.jsonl").open("w", encoding="utf-8") as f:
+        for r in results:
+            f.write(json.dumps(r) + "\n")
+
+
+class TestFtGroupHelp(unittest.TestCase):
+    def test_ft_group_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Free-threading", result.output)
+        self.assertIn("run", result.output)
+        self.assertIn("show", result.output)
+
+
+class TestFtRunHelp(unittest.TestCase):
+    def test_ft_run_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--target-python", result.output)
+        self.assertIn("--iterations", result.output)
+        self.assertIn("--compare-with-gil", result.output)
+
+
+class TestFtShowHelp(unittest.TestCase):
+    def test_ft_show_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "show", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("RESULT_DIR", result.output)
+
+
+class TestFtRunMissingPython(unittest.TestCase):
+    def test_ft_run_missing_python(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "run"])
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestFtShowNonexistentDir(unittest.TestCase):
+    def test_ft_show_nonexistent_dir(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "show", "/nonexistent/path"])
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestFtShowWithMockData(unittest.TestCase):
+    def test_ft_show_with_mock_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_mock_run(Path(tmpdir))
+            runner = CliRunner()
+            result = runner.invoke(main, ["ft", "show", tmpdir])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("Compatibility Summary", result.output)
+            self.assertIn("requests", result.output)
+            self.assertIn("numpy", result.output)
+
+
+class TestFtFlakyWithMockData(unittest.TestCase):
+    def test_ft_flaky_with_mock_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_mock_run(Path(tmpdir))
+            runner = CliRunner()
+            result = runner.invoke(main, ["ft", "flaky", tmpdir])
+            self.assertEqual(result.exit_code, 0, result.output)
+            # aiohttp is intermittent with pass_count>0 and numpy is crash with pass_count>0
+            self.assertIn("Flakiness Profile", result.output)
+
+    def test_ft_flaky_specific_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_mock_run(Path(tmpdir))
+            runner = CliRunner()
+            result = runner.invoke(main, ["ft", "flaky", "--package", "numpy", tmpdir])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("numpy", result.output)
+
+
+class TestFtCompatWithMockData(unittest.TestCase):
+    def test_ft_compat_with_mock_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_mock_run(Path(tmpdir))
+            runner = CliRunner()
+            result = runner.invoke(main, ["ft", "compat", tmpdir])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("numpy", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ft_display.py
+++ b/tests/test_ft_display.py
@@ -1,0 +1,340 @@
+"""Tests for labeille.ft.display — terminal display formatting."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from labeille.ft.display import (
+    format_compatibility_summary,
+    format_flakiness_profile,
+    format_gil_comparison,
+    format_package_table,
+    format_progress,
+    format_triage_list,
+)
+from labeille.ft.results import FailureCategory, FTPackageResult
+
+
+def _make_result(
+    package: str = "test-pkg",
+    category: FailureCategory = FailureCategory.COMPATIBLE,
+    pass_count: int = 10,
+    iterations_completed: int = 10,
+    crash_count: int = 0,
+    pass_rate: float = 1.0,
+    **kwargs: object,
+) -> FTPackageResult:
+    """Create a minimal FTPackageResult for display tests."""
+    return FTPackageResult(
+        package=package,
+        category=category,
+        pass_count=pass_count,
+        iterations_completed=iterations_completed,
+        crash_count=crash_count,
+        pass_rate=pass_rate,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_compatibility_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCompatibilitySummary(unittest.TestCase):
+    def test_summary_basic(self) -> None:
+        summary = {
+            "total_packages": 100,
+            "categories": {"compatible": 70, "crash": 10, "incompatible": 20},
+        }
+        output = format_compatibility_summary(summary)
+        self.assertIn("Compatible:", output)
+        self.assertIn("70", output)
+        self.assertIn("Crash", output)
+
+    def test_summary_percentages(self) -> None:
+        summary = {
+            "total_packages": 100,
+            "categories": {"compatible": 70},
+        }
+        output = format_compatibility_summary(summary)
+        self.assertIn("70.0%", output)
+
+    def test_summary_zero_categories_omitted(self) -> None:
+        summary = {
+            "total_packages": 100,
+            "categories": {"compatible": 100, "crash": 0},
+        }
+        output = format_compatibility_summary(summary)
+        self.assertNotIn("Crash", output)
+
+    def test_summary_with_python_info(self) -> None:
+        summary = {"total_packages": 10, "categories": {"compatible": 10}}
+        output = format_compatibility_summary(
+            summary, python_info="Python: 3.14.0b2 (free-threaded)"
+        )
+        self.assertIn("Python: 3.14.0b2 (free-threaded)", output)
+
+    def test_summary_with_system_info(self) -> None:
+        summary = {"total_packages": 10, "categories": {"compatible": 10}}
+        output = format_compatibility_summary(summary, system_info="System: AMD Ryzen 9, 64GB RAM")
+        self.assertIn("System: AMD Ryzen 9, 64GB RAM", output)
+
+    def test_summary_extension_breakdown(self) -> None:
+        summary = {
+            "total_packages": 350,
+            "categories": {"compatible": 250},
+            "pure_python_count": 200,
+            "extension_count": 150,
+            "pure_python_compatible_pct": 85.0,
+            "extension_compatible_pct": 60.0,
+        }
+        output = format_compatibility_summary(summary)
+        self.assertIn("Pure Python:", output)
+        self.assertIn("200", output)
+        self.assertIn("85.0%", output)
+        self.assertIn("C extensions:", output)
+        self.assertIn("150", output)
+        self.assertIn("60.0%", output)
+
+
+# ---------------------------------------------------------------------------
+# format_package_table tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPackageTable(unittest.TestCase):
+    def test_table_sorted_by_category(self) -> None:
+        results = [
+            _make_result("pkg-a", FailureCategory.CRASH, crash_count=3, pass_rate=0.7),
+            _make_result("pkg-b", FailureCategory.COMPATIBLE, pass_rate=1.0),
+            _make_result("pkg-c", FailureCategory.INCOMPATIBLE, pass_rate=0.0, pass_count=0),
+        ]
+        output = format_package_table(results, sort_by="category")
+        lines = output.split("\n")
+        # Compatible has lowest severity → first, then crash and incompatible.
+        data_lines = [ln for ln in lines if ln.startswith("pkg-")]
+        self.assertTrue(data_lines[0].startswith("pkg-b"))
+
+    def test_table_sorted_by_name(self) -> None:
+        results = [
+            _make_result("zlib", FailureCategory.COMPATIBLE),
+            _make_result("aiohttp", FailureCategory.CRASH),
+        ]
+        output = format_package_table(results, sort_by="name")
+        lines = [ln for ln in output.split("\n") if ln.startswith(("aiohttp", "zlib"))]
+        self.assertTrue(lines[0].startswith("aiohttp"))
+
+    def test_table_max_rows(self) -> None:
+        results = [_make_result(f"pkg-{i}") for i in range(10)]
+        output = format_package_table(results, max_rows=5)
+        self.assertIn("5 more", output)
+
+    def test_table_details_column(self) -> None:
+        r = _make_result(
+            "numpy",
+            FailureCategory.CRASH,
+            crash_count=3,
+            failure_signatures=["SIGSEGV in _multiarray"],
+        )
+        output = format_package_table([r])
+        self.assertIn("SIGSEGV", output)
+
+    def test_table_details_flaky(self) -> None:
+        r = _make_result(
+            "aiohttp",
+            FailureCategory.INTERMITTENT,
+            flaky_tests={"test_a": 2, "test_b": 1, "test_c": 3},
+        )
+        output = format_package_table([r])
+        self.assertIn("3 flaky tests", output)
+
+    def test_table_install_failure(self) -> None:
+        r = _make_result(
+            "broken-pkg",
+            FailureCategory.INSTALL_FAILURE,
+            install_ok=False,
+            pass_count=0,
+            iterations_completed=0,
+        )
+        output = format_package_table([r])
+        self.assertIn("install failed", output)
+
+
+# ---------------------------------------------------------------------------
+# format_triage_list tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTriageList(unittest.TestCase):
+    def _make_triage(
+        self,
+        package: str = "pkg",
+        score: float = 50.0,
+        category: str = "crash",
+        reason: str = "3 crashes",
+    ) -> MagicMock:
+        entry = MagicMock()
+        entry.package = package
+        entry.priority_score = score
+        entry.category = category
+        entry.reason = reason
+        return entry
+
+    def test_triage_ordered_by_score(self) -> None:
+        entries = [
+            self._make_triage("numpy", 70, "crash"),
+            self._make_triage("gevent", 60, "deadlock"),
+        ]
+        output = format_triage_list(entries)
+        lines = output.split("\n")
+        data_lines = [ln for ln in lines if ". " in ln]
+        self.assertIn("numpy", data_lines[0])
+        self.assertIn("gevent", data_lines[1])
+
+    def test_triage_max_entries(self) -> None:
+        entries = [self._make_triage(f"pkg-{i}", 100 - i) for i in range(30)]
+        output = format_triage_list(entries, max_entries=10)
+        self.assertIn("20 more", output)
+
+    def test_triage_shows_reason(self) -> None:
+        entries = [self._make_triage("numpy", 70, "crash", "3 crashes; C extension")]
+        output = format_triage_list(entries)
+        self.assertIn("3 crashes; C extension", output)
+
+
+# ---------------------------------------------------------------------------
+# format_flakiness_profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFlakinessProfile(unittest.TestCase):
+    def _make_profile(self, **kwargs: object) -> MagicMock:
+        profile = MagicMock()
+        profile.package = kwargs.get("package", "aiohttp")
+        profile.pass_rate = kwargs.get("pass_rate", 0.7)
+        profile.total_iterations = kwargs.get("total_iterations", 10)
+        profile.pattern = kwargs.get("pattern", "consistent_test")
+        profile.failure_modes = kwargs.get("failure_modes", {"fail": 3})
+        profile.max_consecutive_passes = kwargs.get("max_consecutive_passes", 4)
+        profile.max_consecutive_failures = kwargs.get("max_consecutive_failures", 2)
+        profile.flaky_tests = kwargs.get("flaky_tests", [])
+        return profile
+
+    def _make_flaky_test(
+        self, test_id: str = "test_a", fail_count: int = 3, total_seen: int = 5
+    ) -> MagicMock:
+        ft = MagicMock()
+        ft.test_id = test_id
+        ft.fail_count = fail_count
+        ft.total_seen = total_seen
+        ft.fail_rate = fail_count / total_seen
+        return ft
+
+    def test_flakiness_shows_pass_rate(self) -> None:
+        profile = self._make_profile(pass_rate=0.7)
+        output = format_flakiness_profile(profile)
+        self.assertIn("70.0%", output)
+
+    def test_flakiness_shows_pattern(self) -> None:
+        profile = self._make_profile(pattern="consistent_test")
+        output = format_flakiness_profile(profile)
+        self.assertIn("consistent_test", output)
+
+    def test_flakiness_shows_flaky_tests(self) -> None:
+        tests = [
+            self._make_flaky_test("test_connector::test_close", 3, 5),
+            self._make_flaky_test("test_client::test_timeout", 1, 5),
+            self._make_flaky_test("test_pool::test_reuse", 2, 5),
+        ]
+        profile = self._make_profile(flaky_tests=tests)
+        output = format_flakiness_profile(profile)
+        self.assertIn("test_connector::test_close", output)
+        self.assertIn("test_client::test_timeout", output)
+        self.assertIn("test_pool::test_reuse", output)
+
+    def test_flakiness_truncates_long_test_ids(self) -> None:
+        long_id = "test_very_" + "a" * 50 + "::test_something"
+        tests = [self._make_flaky_test(long_id, 2, 5)]
+        profile = self._make_profile(flaky_tests=tests)
+        output = format_flakiness_profile(profile)
+        self.assertIn("...", output)
+
+    def test_flakiness_truncates_many_tests(self) -> None:
+        tests = [self._make_flaky_test(f"test_{i}", 1, 5) for i in range(20)]
+        profile = self._make_profile(flaky_tests=tests)
+        output = format_flakiness_profile(profile)
+        self.assertIn("5 more", output)
+
+
+# ---------------------------------------------------------------------------
+# format_gil_comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatGilComparison(unittest.TestCase):
+    def _make_comparison(
+        self,
+        package: str = "pkg",
+        disabled_rate: float = 0.7,
+        enabled_rate: float = 1.0,
+        classification: str = "ft_intermittent",
+        ft_specific: bool = True,
+    ) -> MagicMock:
+        c = MagicMock()
+        c.package = package
+        c.gil_disabled_pass_rate = disabled_rate
+        c.gil_enabled_pass_rate = enabled_rate
+        c.classification = classification
+        c.free_threading_specific = ft_specific
+        return c
+
+    def test_gil_comparison_basic(self) -> None:
+        comparisons = [
+            self._make_comparison("requests", 1.0, 1.0, "ft_compatible", False),
+            self._make_comparison("numpy", 0.7, 1.0, "ft_intermittent", True),
+            self._make_comparison("celery", 0.5, 0.5, "pre_existing", False),
+        ]
+        output = format_gil_comparison(comparisons)
+        self.assertIn("requests", output)
+        self.assertIn("numpy", output)
+        self.assertIn("celery", output)
+
+    def test_gil_comparison_ft_specific_marker(self) -> None:
+        comparisons = [self._make_comparison("numpy", 0.7, 1.0, "ft_intermittent", True)]
+        output = format_gil_comparison(comparisons)
+        self.assertIn("FT-specific", output)
+
+    def test_gil_comparison_summary_counts(self) -> None:
+        comparisons = [
+            self._make_comparison("a", 0.7, 1.0, "ft_intermittent", True),
+            self._make_comparison("b", 0.5, 1.0, "ft_incompatible", True),
+            self._make_comparison("c", 0.5, 0.5, "pre_existing", False),
+        ]
+        output = format_gil_comparison(comparisons)
+        self.assertIn("FT-specific failures: 2", output)
+        self.assertIn("Pre-existing failures: 1", output)
+
+
+# ---------------------------------------------------------------------------
+# format_progress tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatProgress(unittest.TestCase):
+    def test_progress_basic(self) -> None:
+        output = format_progress(
+            package="requests",
+            iteration=3,
+            total_iterations=10,
+            status="pass",
+            duration=12.3,
+            packages_done=15,
+            packages_total=350,
+        )
+        self.assertEqual(output, "(15/350) requests iter 3/10: pass (12.3s)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `ft/display.py` with terminal formatting for compatibility summaries, package tables, flakiness profiles, triage lists, GIL comparison reports, and progress output.
- Adds `ft_cli.py` with `labeille ft` CLI subgroup: `run`, `show`, `compare`, `compat`, `flaky`, `report`, `export` commands.
- Registers `ft` subgroup in `cli.py` alongside existing `bench`, `analyze`, `registry` groups.
- Includes stub modules `ft/compare.py` and `ft/export.py` (to be fully implemented in prompt 29).

## Test plan
- [x] ruff format — clean
- [x] ruff check — clean
- [x] mypy — clean
- [x] 1368 tests pass (33 new: 24 display + 9 CLI)

Closes #84

Generated with [Claude Code](https://claude.com/claude-code)