### PR TITLE
feat: add per-test timing capture via pytest durations output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Per-test timing capture via pytest `--durations=0` output, enabled with `--per-test-timing` flag on `labeille bench run`.
+- `TestTiming` and `PerTestTimings` dataclasses in `bench/timing.py` with pytest output parser.
+- `compare_per_test()` in `bench/compare.py` for per-test overhead analysis between conditions.
+- `--per-test <package>` option for `labeille bench show` and `labeille bench compare` to display per-test timing breakdown.
 - `anomaly.py` module in `bench` subpackage with `PackageAnomaly` and `AnomalyReport` dataclasses for proactive measurement-quality assessment.
 - `detect_anomalies()` with five anomaly types: `high_cv`, `bimodal`, `outlier_heavy`, `status_mixed`, and `trend`.
 - `is_bimodal()` gap-analysis heuristic and `has_monotonic_trend()` Spearman rank correlation for pure-Python distribution analysis.

--- a/src/labeille/bench/compare.py
+++ b/src/labeille/bench/compare.py
@@ -18,6 +18,7 @@ from labeille.bench.stats import (
     OverheadResult,
     compute_overhead,
 )
+from typing import Any
 
 log = logging.getLogger("labeille")
 
@@ -276,3 +277,120 @@ def compare_runs(
         name_b,
         ci_seed=ci_seed,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-test overhead comparison
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TestOverhead:
+    """Overhead for a single test between two conditions."""
+
+    test_id: str
+    baseline_median_s: float
+    treatment_median_s: float
+    absolute_diff_s: float
+    overhead_pct: float
+    n_baseline: int
+    n_treatment: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "test_id": self.test_id,
+            "baseline_median_s": round(self.baseline_median_s, 6),
+            "treatment_median_s": round(self.treatment_median_s, 6),
+            "absolute_diff_s": round(self.absolute_diff_s, 6),
+            "overhead_pct": round(self.overhead_pct, 2),
+            "n_baseline": self.n_baseline,
+            "n_treatment": self.n_treatment,
+        }
+
+
+def compare_per_test(
+    results: list[BenchPackageResult],
+    baseline_name: str,
+    treatment_name: str,
+    package_name: str,
+) -> list[TestOverhead]:
+    """Compare per-test timings for a specific package.
+
+    Collects per-test call durations across all measured iterations for
+    both conditions, computes median durations per test, and returns
+    overhead sorted by overhead_pct descending.
+
+    Returns an empty list if per-test timings are not available for
+    both conditions.
+
+    Args:
+        results: Benchmark results.
+        baseline_name: Baseline condition name.
+        treatment_name: Treatment condition name.
+        package_name: The package to analyze.
+
+    Returns:
+        List of TestOverhead, sorted by overhead_pct descending.
+    """
+    # Find the package.
+    pkg_result = None
+    for r in results:
+        if r.package == package_name:
+            pkg_result = r
+            break
+    if not pkg_result:
+        return []
+
+    base_cond = pkg_result.conditions.get(baseline_name)
+    treat_cond = pkg_result.conditions.get(treatment_name)
+    if not base_cond or not treat_cond:
+        return []
+
+    # Collect per-test call durations across measured iterations.
+    def _collect_call_durations(
+        cond: Any,
+    ) -> dict[str, list[float]]:
+        durations: dict[str, list[float]] = {}
+        for it in cond.measured_iterations:
+            if it.per_test_timings is None:
+                continue
+            for t in it.per_test_timings.timings:
+                if t.phase == "call":
+                    durations.setdefault(t.test_id, []).append(t.duration_s)
+        return durations
+
+    base_durations = _collect_call_durations(base_cond)
+    treat_durations = _collect_call_durations(treat_cond)
+
+    if not base_durations or not treat_durations:
+        return []
+
+    # Compute overhead for tests present in both conditions.
+    common_tests = sorted(set(base_durations.keys()) & set(treat_durations.keys()))
+    overheads: list[TestOverhead] = []
+
+    for test_id in common_tests:
+        base_vals = sorted(base_durations[test_id])
+        treat_vals = sorted(treat_durations[test_id])
+
+        base_median = base_vals[len(base_vals) // 2]
+        treat_median = treat_vals[len(treat_vals) // 2]
+
+        diff = treat_median - base_median
+        pct = (diff / base_median * 100) if base_median > 0 else 0.0
+
+        overheads.append(
+            TestOverhead(
+                test_id=test_id,
+                baseline_median_s=base_median,
+                treatment_median_s=treat_median,
+                absolute_diff_s=diff,
+                overhead_pct=pct,
+                n_baseline=len(base_vals),
+                n_treatment=len(treat_vals),
+            )
+        )
+
+    overheads.sort(key=lambda o: o.overhead_pct, reverse=True)
+    return overheads

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -70,6 +70,9 @@ class BenchConfig:
     max_load: float = 1.0
     min_available_ram_gb: float = 2.0
 
+    # Per-test timing
+    per_test_timing: bool = False  # Capture per-test timing via pytest --durations=0
+
     # CLI provenance
     cli_args: list[str] = field(default_factory=list)
 

--- a/src/labeille/bench/display.py
+++ b/src/labeille/bench/display.py
@@ -11,7 +11,7 @@ import math
 import statistics as _stats
 
 from labeille.bench.anomaly import AnomalyReport
-from labeille.bench.compare import ComparisonReport, compare_conditions
+from labeille.bench.compare import ComparisonReport, TestOverhead, compare_conditions
 from labeille.bench.results import (
     BenchMeta,
     BenchPackageResult,
@@ -19,6 +19,7 @@ from labeille.bench.results import (
 from labeille.bench.stats import (
     compute_overhead,
 )
+from labeille.bench.timing import PerTestTimings
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +389,103 @@ def format_comparison_report(report: ComparisonReport) -> str:
             lines.append(f"    High CV (>10%):        {report.high_cv_count} packages")
         if report.status_mismatch_count:
             lines.append(f"    Status mismatch:       {report.status_mismatch_count} packages")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Per-test timing display
+# ---------------------------------------------------------------------------
+
+
+def format_per_test_comparison(
+    overheads: list[TestOverhead],
+    *,
+    top_n: int = 20,
+) -> str:
+    """Format per-test overhead comparison as a table.
+
+    Shows top N tests by overhead percentage. Columns:
+    Test | Baseline (s) | Treatment (s) | Overhead
+
+    Args:
+        overheads: List of TestOverhead from compare_per_test().
+        top_n: Maximum number of tests to show.
+
+    Returns:
+        Formatted string.
+    """
+    if not overheads:
+        return "No per-test comparison data available."
+
+    lines: list[str] = []
+    lines.append("Per-Test Overhead Comparison")
+    lines.append("\u2500" * 27)
+
+    header = f"  {'Test':<50s} {'Baseline':>10s} {'Treatment':>10s} {'Overhead':>10s}"
+    lines.append(header)
+    lines.append("  " + "\u2500" * (len(header) - 2))
+
+    for oh in overheads[:top_n]:
+        test_name = oh.test_id
+        if len(test_name) > 50:
+            test_name = "..." + test_name[-47:]
+        sign = "+" if oh.overhead_pct >= 0 else ""
+        lines.append(
+            f"  {test_name:<50s} "
+            f"{oh.baseline_median_s:>9.4f}s "
+            f"{oh.treatment_median_s:>9.4f}s "
+            f"{sign}{oh.overhead_pct:>8.1f}%"
+        )
+
+    total = len(overheads)
+    if total > top_n:
+        lines.append(f"  ... and {total - top_n} more tests")
+
+    return "\n".join(lines)
+
+
+def format_per_test_summary(
+    timings: PerTestTimings,
+    *,
+    top_n: int = 10,
+) -> str:
+    """Format per-test timing summary for a single run.
+
+    Shows top N slowest tests with their call durations. Also
+    shows total test count and total test time.
+
+    Args:
+        timings: Per-test timings from an iteration.
+        top_n: Number of slowest tests to show.
+
+    Returns:
+        Formatted string.
+    """
+    if not timings.timings:
+        return "No per-test timing data available."
+
+    lines: list[str] = []
+    lines.append("Per-Test Timing Summary")
+    lines.append("\u2500" * 22)
+    lines.append(f"  Tests: {timings.test_count}")
+    lines.append(f"  Total test time: {timings.total_test_time_s:.2f}s")
+
+    if not timings.parse_success:
+        lines.append("  (Warning: durations output was partially parsed)")
+
+    slowest = timings.slowest_tests
+    if slowest:
+        lines.append("")
+        lines.append(f"  {'Slowest tests:':<50s} {'Duration':>10s}")
+        lines.append("  " + "\u2500" * 62)
+        for test_id, duration in slowest[:top_n]:
+            name = test_id
+            if len(name) > 50:
+                name = "..." + name[-47:]
+            lines.append(f"  {name:<50s} {duration:>9.4f}s")
+        if len(slowest) > top_n:
+            lines.append(f"  ... and {len(slowest) - top_n} more tests")
 
     return "\n".join(lines)
 

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from labeille.bench.stats import DescriptiveStats, describe, detect_outliers
 from labeille.bench.system import PythonProfile, SystemProfile
+from labeille.bench.timing import PerTestTimings
 
 log = logging.getLogger("labeille")
 
@@ -53,10 +54,11 @@ class BenchIteration:
     load_avg_start: float = 0.0
     load_avg_end: float = 0.0
     ram_available_start_gb: float = 0.0
+    per_test_timings: PerTestTimings | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict."""
-        return {
+        d: dict[str, Any] = {
             "index": self.index,
             "warmup": self.warmup,
             "wall_time_s": round(self.wall_time_s, 6),
@@ -70,13 +72,20 @@ class BenchIteration:
             "load_avg_end": self.load_avg_end,
             "ram_available_start_gb": self.ram_available_start_gb,
         }
+        if self.per_test_timings is not None:
+            d["per_test_timings"] = self.per_test_timings.to_dict()
+        return d
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> BenchIteration:
         """Deserialize from a dict, ignoring unknown fields."""
+        per_test_data = data.pop("per_test_timings", None)
         known = {f.name for f in cls.__dataclass_fields__.values()}
         filtered = {k: v for k, v in data.items() if k in known}
-        return cls(**filtered)
+        instance = cls(**filtered)
+        if per_test_data is not None:
+            instance.per_test_timings = PerTestTimings.from_dict(per_test_data)
+        return instance
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -51,7 +51,11 @@ from labeille.bench.system import (
     format_python_profile,
     format_system_profile,
 )
-from labeille.bench.timing import run_timed_in_venv
+from labeille.bench.timing import (
+    parse_pytest_durations,
+    prepare_per_test_command,
+    run_timed_in_venv,
+)
 
 log = logging.getLogger("labeille")
 
@@ -642,6 +646,12 @@ class BenchRunner:
             default_suffix=self.config.default_test_command_suffix,
         )
 
+        # Per-test timing: modify command if enabled.
+        per_test_enabled = False
+        if self.config.per_test_timing:
+            test_framework = getattr(pkg, "test_framework", "") or ""
+            test_cmd, per_test_enabled = prepare_per_test_command(test_cmd, test_framework)
+
         # Build environment.
         env = resolve_env(cond, self.config.default_env)
         env.setdefault("PYTHONFAULTHANDLER", "1")
@@ -672,6 +682,11 @@ class BenchRunner:
         else:
             status = "fail"
 
+        # Parse per-test timings if enabled.
+        per_test_timings = None
+        if per_test_enabled:
+            per_test_timings = parse_pytest_durations(timed.stdout)
+
         return BenchIteration(
             index=iter_index,
             warmup=is_warmup,
@@ -684,6 +699,7 @@ class BenchRunner:
             load_avg_start=snap_before.load_avg_1m,
             load_avg_end=snap_after.load_avg_1m,
             ram_available_start_gb=snap_before.ram_available_gb,
+            per_test_timings=per_test_timings,
         )
 
     def _wait_for_stability(self) -> None:

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import resource
 import shlex
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 log = logging.getLogger("labeille")
 
@@ -248,3 +250,178 @@ def run_timed_in_venv(
         env=run_env,
         timeout=timeout,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-test timing capture
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TestTiming:
+    """Timing for a single test phase from pytest --durations output."""
+
+    test_id: str  # e.g. "tests/test_foo.py::test_heavy_computation"
+    phase: str  # "setup", "call", "teardown"
+    duration_s: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "test_id": self.test_id,
+            "phase": self.phase,
+            "duration_s": round(self.duration_s, 6),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TestTiming:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class PerTestTimings:
+    """All test timings parsed from a single pytest run's output."""
+
+    timings: list[TestTiming] = field(default_factory=list)
+    parse_success: bool = True
+    raw_output: str = ""  # Preserved for debugging (not serialized by default)
+
+    @property
+    def by_test(self) -> dict[str, dict[str, float]]:
+        """Group by test_id -> {phase: duration_s}."""
+        result: dict[str, dict[str, float]] = {}
+        for t in self.timings:
+            result.setdefault(t.test_id, {})[t.phase] = t.duration_s
+        return result
+
+    @property
+    def slowest_tests(self) -> list[tuple[str, float]]:
+        """Top tests by call duration, sorted descending."""
+        calls = [(t.test_id, t.duration_s) for t in self.timings if t.phase == "call"]
+        return sorted(calls, key=lambda x: x[1], reverse=True)
+
+    @property
+    def total_test_time_s(self) -> float:
+        """Sum of all call durations."""
+        return sum(t.duration_s for t in self.timings if t.phase == "call")
+
+    @property
+    def test_count(self) -> int:
+        """Number of unique test IDs."""
+        return len({t.test_id for t in self.timings})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "timings": [t.to_dict() for t in self.timings],
+            "parse_success": self.parse_success,
+            # raw_output intentionally omitted to save space
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PerTestTimings:
+        """Deserialize from a dict."""
+        return cls(
+            timings=[TestTiming.from_dict(t) for t in data.get("timings", [])],
+            parse_success=data.get("parse_success", True),
+        )
+
+
+# Header pattern for pytest --durations output.
+_DURATIONS_HEADER_RE = re.compile(
+    r"={3,}\s*slowest\s+(test\s+)?durations\s*={3,}",
+    re.IGNORECASE,
+)
+
+# Line pattern: "1.23s call     tests/test_foo.py::test_heavy"
+_TIMING_LINE_RE = re.compile(
+    r"^\s*(\d+\.\d+)s\s+(setup|call|teardown)\s+(.+)$",
+)
+
+
+def parse_pytest_durations(output: str) -> PerTestTimings:
+    """Parse pytest --durations=0 output into structured test timings.
+
+    Expects the standard pytest format::
+
+        ===== slowest durations =====
+        1.23s call     tests/test_foo.py::test_heavy
+        0.45s call     tests/test_bar.py::test_network
+        0.12s setup    tests/test_foo.py::test_heavy
+        0.01s teardown tests/test_foo.py::test_heavy
+
+    The parser is lenient: if the durations section cannot be found or
+    individual lines don't match the expected format, parse_success is
+    set to False and whatever was successfully parsed is returned.
+    Never raises -- a failed parse should not fail a benchmark.
+
+    Args:
+        output: The combined stdout from a pytest run.
+
+    Returns:
+        PerTestTimings with parsed data and success flag.
+    """
+    timings: list[TestTiming] = []
+    parse_success = True
+
+    # Find the durations header.
+    lines = output.splitlines()
+    header_idx = -1
+    for i, line in enumerate(lines):
+        if _DURATIONS_HEADER_RE.search(line):
+            header_idx = i
+            break
+
+    if header_idx < 0:
+        return PerTestTimings(
+            timings=[],
+            parse_success=False,
+            raw_output=output,
+        )
+
+    # Parse lines after the header until the next === section or end.
+    for line in lines[header_idx + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("==="):
+            break
+        match = _TIMING_LINE_RE.match(stripped)
+        if match:
+            duration = float(match.group(1))
+            phase = match.group(2)
+            test_id = match.group(3).strip()
+            timings.append(TestTiming(test_id=test_id, phase=phase, duration_s=duration))
+        # Non-matching lines are silently skipped.
+
+    return PerTestTimings(
+        timings=timings,
+        parse_success=parse_success,
+        raw_output=output,
+    )
+
+
+def prepare_per_test_command(
+    test_command: str,
+    test_framework: str,
+) -> tuple[str, bool]:
+    """Prepare a test command for per-test timing capture.
+
+    Appends --durations=0 to pytest commands. Returns the original
+    command unchanged for non-pytest frameworks.
+
+    Args:
+        test_command: The original test command.
+        test_framework: From the registry ("pytest" or "unittest").
+
+    Returns:
+        Tuple of (modified_command, per_test_enabled). per_test_enabled
+        is True only if --durations=0 was successfully added.
+    """
+    if test_framework != "pytest":
+        return (test_command, False)
+    if "--durations" in test_command:
+        return (test_command, False)
+    return (f"{test_command} --durations=0", True)

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -165,6 +165,12 @@ def bench() -> None:
     multiple=True,
     help="KEY=VALUE env var for all conditions (repeatable).",
 )
+@click.option(
+    "--per-test-timing",
+    is_flag=True,
+    default=False,
+    help="Capture per-test timing via pytest --durations=0.",
+)
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def run(  # noqa: PLR0913
     profile_path: str | None,
@@ -188,6 +194,7 @@ def run(  # noqa: PLR0913
     check_stability: bool,
     wait_for_stability: bool,
     quick: bool,
+    per_test_timing: bool,
     env_pairs: tuple[str, ...],
     verbose: bool,
 ) -> None:
@@ -288,6 +295,7 @@ def run(  # noqa: PLR0913
 
     config.check_stability = check_stability
     config.wait_for_stability = wait_for_stability
+    config.per_test_timing = per_test_timing
     config.cli_args = sys.argv[1:]
 
     if quick:
@@ -321,7 +329,14 @@ def run(  # noqa: PLR0913
 @bench.command("show")
 @click.argument("result_dir", type=click.Path(exists=True))
 @click.option("--anomalies", is_flag=True, default=False, help="Show measurement anomalies.")
-def show(result_dir: str, anomalies: bool) -> None:
+@click.option(
+    "--per-test",
+    "per_test_package",
+    type=str,
+    default=None,
+    help="Show per-test timing for a specific package.",
+)
+def show(result_dir: str, anomalies: bool, per_test_package: str | None) -> None:
     """Display results from a benchmark run.
 
     RESULT_DIR is the path to a benchmark output directory
@@ -332,6 +347,21 @@ def show(result_dir: str, anomalies: bool) -> None:
 
     meta, results = load_bench_run(Path(result_dir))
     click.echo(format_bench_show(meta, results))
+
+    if per_test_package:
+        from labeille.bench.display import format_per_test_summary
+
+        pkg_result = next((r for r in results if r.package == per_test_package), None)
+        if not pkg_result:
+            click.echo(f"\nPackage '{per_test_package}' not found.", err=True)
+        else:
+            # Use the last measured iteration's timings.
+            for cond_name, cond in pkg_result.conditions.items():
+                for it in reversed(cond.measured_iterations):
+                    if it.per_test_timings:
+                        click.echo(f"\n{cond_name}:")
+                        click.echo(format_per_test_summary(it.per_test_timings))
+                        break
 
     if anomalies:
         from labeille.bench.anomaly import detect_anomalies
@@ -368,7 +398,19 @@ def show(result_dir: str, anomalies: bool) -> None:
     default="wall",
     help="Metric to compare.",
 )
-def compare(result_dirs: tuple[str, ...], baseline: str | None, metric: str) -> None:
+@click.option(
+    "--per-test",
+    "per_test_package",
+    type=str,
+    default=None,
+    help="Show per-test overhead for a specific package.",
+)
+def compare(
+    result_dirs: tuple[str, ...],
+    baseline: str | None,
+    metric: str,
+    per_test_package: str | None,
+) -> None:
     """Compare results from two or more benchmark runs.
 
     Accepts either:
@@ -418,6 +460,19 @@ def compare(result_dirs: tuple[str, ...], baseline: str | None, metric: str) -> 
             click.echo(f"\n{baseline_name} vs {cond_name}")
             click.echo("=" * (len(baseline_name) + len(cond_name) + 4))
             click.echo(format_comparison_summary(results, baseline_name, cond_name))
+
+        # Per-test comparison.
+        if per_test_package:
+            from labeille.bench.compare import compare_per_test
+            from labeille.bench.display import format_per_test_comparison
+
+            for cond_name in conditions:
+                if cond_name == baseline_name:
+                    continue
+                overheads = compare_per_test(results, baseline_name, cond_name, per_test_package)
+                if overheads:
+                    click.echo()
+                    click.echo(format_per_test_comparison(overheads))
 
         # Anomaly summary.
         from labeille.bench.anomaly import detect_anomalies

--- a/tests/test_bench_per_test.py
+++ b/tests/test_bench_per_test.py
@@ -1,0 +1,426 @@
+"""Tests for per-test timing capture, parsing, and comparison."""
+
+from __future__ import annotations
+
+import unittest
+
+from bench_test_helpers import make_package_result
+from labeille.bench.compare import TestOverhead, compare_per_test
+from labeille.bench.display import format_per_test_comparison, format_per_test_summary
+from labeille.bench.results import BenchIteration, BenchPackageResult
+from labeille.bench.timing import (
+    PerTestTimings,
+    TestTiming,
+    parse_pytest_durations,
+    prepare_per_test_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Standard pytest durations output for testing
+# ---------------------------------------------------------------------------
+
+STANDARD_DURATIONS_OUTPUT = """\
+============================= test session starts ==============================
+platform linux -- Python 3.15.0a4, pytest-8.3.4
+collected 42 items
+
+tests/test_foo.py ....
+tests/test_bar.py ....
+
+=============================== slowest durations ===============================
+1.23s call     tests/test_foo.py::test_heavy_computation
+0.45s call     tests/test_bar.py::test_network
+0.12s setup    tests/test_foo.py::test_heavy_computation
+0.01s teardown tests/test_foo.py::test_heavy_computation
+0.08s call     tests/test_foo.py::test_light
+=============================== 42 passed in 3.50s ===============================
+"""
+
+
+# ---------------------------------------------------------------------------
+# TestParsePytestDurations
+# ---------------------------------------------------------------------------
+
+
+class TestParsePytestDurations(unittest.TestCase):
+    """Tests for parse_pytest_durations() parser."""
+
+    def test_parse_standard_output(self) -> None:
+        result = parse_pytest_durations(STANDARD_DURATIONS_OUTPUT)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 5)
+
+        calls = [t for t in result.timings if t.phase == "call"]
+        setups = [t for t in result.timings if t.phase == "setup"]
+        teardowns = [t for t in result.timings if t.phase == "teardown"]
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(len(setups), 1)
+        self.assertEqual(len(teardowns), 1)
+
+    def test_parse_empty_output(self) -> None:
+        result = parse_pytest_durations("")
+        self.assertFalse(result.parse_success)
+        self.assertEqual(len(result.timings), 0)
+
+    def test_parse_no_durations_section(self) -> None:
+        output = "===== test session starts =====\n42 passed in 3.50s\n"
+        result = parse_pytest_durations(output)
+        self.assertFalse(result.parse_success)
+        self.assertEqual(len(result.timings), 0)
+
+    def test_parse_partial_output(self) -> None:
+        output = """\
+=== slowest durations ===
+1.23s call     tests/test_foo.py::test_heavy
+this is a bad line
+0.45s call     tests/test_bar.py::test_network
+=== 42 passed ===
+"""
+        result = parse_pytest_durations(output)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 2)
+
+    def test_parse_multiple_tests(self) -> None:
+        lines = ["=== slowest durations ==="]
+        for i in range(7):
+            lines.append(f"{0.5 + i * 0.1:.2f}s call     tests/test_mod.py::test_{i}")
+        lines.append("=== 7 passed ===")
+        output = "\n".join(lines)
+        result = parse_pytest_durations(output)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 7)
+
+    def test_parse_stops_at_next_section(self) -> None:
+        output = """\
+=== slowest durations ===
+1.00s call     tests/test_a.py::test_one
+=== short test summary info ===
+FAILED tests/test_a.py::test_one
+=== 1 failed ===
+"""
+        result = parse_pytest_durations(output)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 1)
+        self.assertEqual(result.timings[0].test_id, "tests/test_a.py::test_one")
+
+    def test_parse_case_insensitive_header(self) -> None:
+        output = "=== SLOWEST DURATIONS ===\n0.50s call     tests/test.py::test_x\n"
+        result = parse_pytest_durations(output)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 1)
+
+    def test_parse_slow_test_durations_header(self) -> None:
+        output = "=== slowest test durations ===\n0.50s call     tests/test.py::test_x\n"
+        result = parse_pytest_durations(output)
+        self.assertTrue(result.parse_success)
+        self.assertEqual(len(result.timings), 1)
+
+
+# ---------------------------------------------------------------------------
+# TestPreparePerTestCommand
+# ---------------------------------------------------------------------------
+
+
+class TestPreparePerTestCommand(unittest.TestCase):
+    """Tests for prepare_per_test_command()."""
+
+    def test_pytest_gets_durations(self) -> None:
+        cmd, enabled = prepare_per_test_command("python -m pytest tests/", "pytest")
+        self.assertEqual(cmd, "python -m pytest tests/ --durations=0")
+        self.assertTrue(enabled)
+
+    def test_unittest_unchanged(self) -> None:
+        cmd, enabled = prepare_per_test_command("python -m unittest discover", "unittest")
+        self.assertEqual(cmd, "python -m unittest discover")
+        self.assertFalse(enabled)
+
+    def test_existing_durations_unchanged(self) -> None:
+        cmd, enabled = prepare_per_test_command("python -m pytest --durations=10", "pytest")
+        self.assertEqual(cmd, "python -m pytest --durations=10")
+        self.assertFalse(enabled)
+
+    def test_empty_framework(self) -> None:
+        cmd, enabled = prepare_per_test_command("python -m pytest tests/", "")
+        self.assertEqual(cmd, "python -m pytest tests/")
+        self.assertFalse(enabled)
+
+
+# ---------------------------------------------------------------------------
+# TestPerTestTimingsProperties
+# ---------------------------------------------------------------------------
+
+
+class TestPerTestTimingsProperties(unittest.TestCase):
+    """Tests for PerTestTimings properties."""
+
+    def _make_timings(self) -> PerTestTimings:
+        return PerTestTimings(
+            timings=[
+                TestTiming(test_id="test_a", phase="setup", duration_s=0.1),
+                TestTiming(test_id="test_a", phase="call", duration_s=1.0),
+                TestTiming(test_id="test_a", phase="teardown", duration_s=0.05),
+                TestTiming(test_id="test_b", phase="call", duration_s=2.0),
+                TestTiming(test_id="test_c", phase="call", duration_s=0.5),
+            ]
+        )
+
+    def test_by_test_grouping(self) -> None:
+        timings = self._make_timings()
+        by_test = timings.by_test
+        self.assertIn("test_a", by_test)
+        self.assertEqual(by_test["test_a"]["call"], 1.0)
+        self.assertEqual(by_test["test_a"]["setup"], 0.1)
+
+    def test_slowest_tests(self) -> None:
+        timings = self._make_timings()
+        slowest = timings.slowest_tests
+        self.assertEqual(slowest[0], ("test_b", 2.0))
+        self.assertEqual(slowest[1], ("test_a", 1.0))
+        self.assertEqual(slowest[2], ("test_c", 0.5))
+
+    def test_total_test_time(self) -> None:
+        timings = self._make_timings()
+        self.assertAlmostEqual(timings.total_test_time_s, 3.5)
+
+    def test_test_count(self) -> None:
+        timings = self._make_timings()
+        self.assertEqual(timings.test_count, 3)
+
+    def test_serialization_roundtrip(self) -> None:
+        original = self._make_timings()
+        d = original.to_dict()
+        restored = PerTestTimings.from_dict(d)
+        self.assertEqual(len(restored.timings), 5)
+        self.assertTrue(restored.parse_success)
+        self.assertEqual(restored.timings[0].test_id, "test_a")
+
+
+# ---------------------------------------------------------------------------
+# TestTestTiming
+# ---------------------------------------------------------------------------
+
+
+class TestTestTiming(unittest.TestCase):
+    """Tests for TestTiming serialization."""
+
+    def test_to_dict_roundtrip(self) -> None:
+        t = TestTiming(test_id="tests/test_x.py::test_y", phase="call", duration_s=1.234)
+        d = t.to_dict()
+        restored = TestTiming.from_dict(d)
+        self.assertEqual(restored.test_id, t.test_id)
+        self.assertEqual(restored.phase, t.phase)
+        self.assertAlmostEqual(restored.duration_s, 1.234, places=3)
+
+    def test_from_dict_ignores_unknown(self) -> None:
+        d = {
+            "test_id": "test_x",
+            "phase": "call",
+            "duration_s": 0.5,
+            "unknown_field": "should be ignored",
+        }
+        t = TestTiming.from_dict(d)
+        self.assertEqual(t.test_id, "test_x")
+        self.assertFalse(hasattr(t, "unknown_field"))
+
+
+# ---------------------------------------------------------------------------
+# TestComparePerTest
+# ---------------------------------------------------------------------------
+
+
+def _make_pkg_with_per_test(
+    baseline_timings: list[list[TestTiming]],
+    treatment_timings: list[list[TestTiming]],
+) -> BenchPackageResult:
+    """Create a BenchPackageResult with per-test timing data."""
+    pkg = make_package_result(
+        "test-pkg",
+        {
+            "baseline": [5.0] * len(baseline_timings),
+            "treatment": [5.0] * len(treatment_timings),
+        },
+    )
+    # Attach per-test timings to measured iterations.
+    for i, test_timings in enumerate(baseline_timings):
+        pkg.conditions["baseline"].measured_iterations[i].per_test_timings = PerTestTimings(
+            timings=test_timings
+        )
+    for i, test_timings in enumerate(treatment_timings):
+        pkg.conditions["treatment"].measured_iterations[i].per_test_timings = PerTestTimings(
+            timings=test_timings
+        )
+    return pkg
+
+
+class TestComparePerTest(unittest.TestCase):
+    """Tests for compare_per_test()."""
+
+    def test_compare_two_conditions(self) -> None:
+        base_timings = [
+            [TestTiming("test_a", "call", 1.0), TestTiming("test_b", "call", 2.0)],
+        ]
+        treat_timings = [
+            [TestTiming("test_a", "call", 1.5), TestTiming("test_b", "call", 2.2)],
+        ]
+        pkg = _make_pkg_with_per_test(base_timings, treat_timings)
+        overheads = compare_per_test([pkg], "baseline", "treatment", "test-pkg")
+        self.assertEqual(len(overheads), 2)
+        # Sorted by overhead_pct descending.
+        self.assertEqual(overheads[0].test_id, "test_a")  # 50% overhead
+        self.assertAlmostEqual(overheads[0].overhead_pct, 50.0, places=0)
+
+    def test_compare_missing_per_test_data(self) -> None:
+        pkg = make_package_result(
+            "test-pkg",
+            {"baseline": [5.0, 5.0], "treatment": [5.0, 5.0]},
+        )
+        overheads = compare_per_test([pkg], "baseline", "treatment", "test-pkg")
+        self.assertEqual(overheads, [])
+
+    def test_compare_empty_results(self) -> None:
+        overheads = compare_per_test([], "baseline", "treatment", "test-pkg")
+        self.assertEqual(overheads, [])
+
+    def test_compare_test_only_in_one_condition(self) -> None:
+        base_timings = [
+            [TestTiming("test_a", "call", 1.0), TestTiming("test_unique", "call", 3.0)],
+        ]
+        treat_timings = [
+            [TestTiming("test_a", "call", 1.5)],
+        ]
+        pkg = _make_pkg_with_per_test(base_timings, treat_timings)
+        overheads = compare_per_test([pkg], "baseline", "treatment", "test-pkg")
+        # Only test_a is in both conditions.
+        self.assertEqual(len(overheads), 1)
+        self.assertEqual(overheads[0].test_id, "test_a")
+
+    def test_compare_median_across_iterations(self) -> None:
+        # Multiple iterations: median should be computed across them.
+        base_timings = [
+            [TestTiming("test_a", "call", 1.0)],
+            [TestTiming("test_a", "call", 2.0)],
+            [TestTiming("test_a", "call", 3.0)],
+        ]
+        treat_timings = [
+            [TestTiming("test_a", "call", 2.0)],
+            [TestTiming("test_a", "call", 4.0)],
+            [TestTiming("test_a", "call", 6.0)],
+        ]
+        pkg = _make_pkg_with_per_test(base_timings, treat_timings)
+        overheads = compare_per_test([pkg], "baseline", "treatment", "test-pkg")
+        self.assertEqual(len(overheads), 1)
+        # Median baseline = 2.0, median treatment = 4.0
+        self.assertAlmostEqual(overheads[0].baseline_median_s, 2.0)
+        self.assertAlmostEqual(overheads[0].treatment_median_s, 4.0)
+        self.assertAlmostEqual(overheads[0].overhead_pct, 100.0)
+
+
+# ---------------------------------------------------------------------------
+# TestBenchIterationPerTest
+# ---------------------------------------------------------------------------
+
+
+class TestBenchIterationPerTest(unittest.TestCase):
+    """Tests for BenchIteration per_test_timings field."""
+
+    def test_iteration_with_per_test_roundtrip(self) -> None:
+        iteration = BenchIteration(
+            index=1,
+            warmup=False,
+            wall_time_s=5.0,
+            user_time_s=4.0,
+            sys_time_s=0.5,
+            peak_rss_mb=256.0,
+            exit_code=0,
+            status="ok",
+            per_test_timings=PerTestTimings(
+                timings=[TestTiming("test_x", "call", 1.0)],
+            ),
+        )
+        d = iteration.to_dict()
+        self.assertIn("per_test_timings", d)
+
+        restored = BenchIteration.from_dict(d)
+        self.assertIsNotNone(restored.per_test_timings)
+        assert restored.per_test_timings is not None
+        self.assertEqual(len(restored.per_test_timings.timings), 1)
+        self.assertEqual(restored.per_test_timings.timings[0].test_id, "test_x")
+
+    def test_iteration_without_per_test(self) -> None:
+        iteration = BenchIteration(
+            index=1,
+            warmup=False,
+            wall_time_s=5.0,
+            user_time_s=4.0,
+            sys_time_s=0.5,
+            peak_rss_mb=256.0,
+            exit_code=0,
+            status="ok",
+        )
+        d = iteration.to_dict()
+        self.assertNotIn("per_test_timings", d)
+
+    def test_iteration_from_old_format(self) -> None:
+        d = {
+            "index": 1,
+            "warmup": False,
+            "wall_time_s": 5.0,
+            "user_time_s": 4.0,
+            "sys_time_s": 0.5,
+            "peak_rss_mb": 256.0,
+            "exit_code": 0,
+            "status": "ok",
+        }
+        iteration = BenchIteration.from_dict(d)
+        self.assertIsNone(iteration.per_test_timings)
+
+
+# ---------------------------------------------------------------------------
+# TestFormatPerTest (display integration)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPerTest(unittest.TestCase):
+    """Tests for per-test display formatting functions."""
+
+    def test_format_per_test_summary_empty(self) -> None:
+        timings = PerTestTimings(timings=[])
+        text = format_per_test_summary(timings)
+        self.assertIn("No per-test timing data", text)
+
+    def test_format_per_test_summary_with_data(self) -> None:
+        timings = PerTestTimings(
+            timings=[
+                TestTiming("test_a", "call", 1.5),
+                TestTiming("test_b", "call", 0.5),
+            ]
+        )
+        text = format_per_test_summary(timings)
+        self.assertIn("test_a", text)
+        self.assertIn("test_b", text)
+        self.assertIn("2.00s", text)  # total test time
+
+    def test_format_per_test_comparison_empty(self) -> None:
+        text = format_per_test_comparison([])
+        self.assertIn("No per-test comparison", text)
+
+    def test_format_per_test_comparison_with_data(self) -> None:
+        overheads = [
+            TestOverhead(
+                test_id="tests/test_foo.py::test_heavy",
+                baseline_median_s=1.0,
+                treatment_median_s=1.5,
+                absolute_diff_s=0.5,
+                overhead_pct=50.0,
+                n_baseline=5,
+                n_treatment=5,
+            ),
+        ]
+        text = format_per_test_comparison(overheads)
+        self.assertIn("test_heavy", text)
+        self.assertIn("50.0%", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `TestTiming` and `PerTestTimings` dataclasses in `bench/timing.py` with pytest `--durations=0` output parser
- Add `compare_per_test()` in `bench/compare.py` for per-test overhead analysis between conditions
- Add `--per-test-timing` flag to `bench run` and `--per-test <package>` option to `bench show`/`bench compare`
- Integrate per-test timings into `BenchIteration` serialization with backward compatibility

## Test plan
- [x] 31 new tests in `test_bench_per_test.py` covering parser, command prep, dataclass properties, comparison, serialization, and display
- [x] All 1467 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)