### PR TITLE
feat: add resource-constrained benchmarking with ulimit/taskset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `constraints.py` module in `bench` subpackage with `ResourceConstraints` dataclass and ulimit/taskset command wrapping.
+- Resource constraints as part of the condition abstraction: `--memory-limit`, `--cpu-affinity`, and `--cpu-time-limit` CLI flags for `labeille bench run`.
+- Per-condition constraint specification in YAML benchmark profiles.
+- Inline condition constraint parsing (e.g. `--condition "constrained:memory_limit=1024,cpu_affinity=0+1"`).
+- OOM detection via `detect_oom_from_result()` with new `"oom"` iteration status.
+- `constraints_applied` and `oom_detected` fields on `BenchIteration`.
+- `constraints` field on `ConditionDef` for per-condition resource limits.
 - `cache.py` module in `bench` subpackage for filesystem cache management during benchmarks.
 - `--drop-caches` flag for `labeille bench run` to drop filesystem caches between iterations for cold-cache benchmarking.
 - `--warm-vs-cold` flag to automatically compare warm-cache and cold-cache performance.
@@ -62,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - New crash summary statistics in compare output showing repo unchanged/changed/unknown counts.
 
 ### Enhanced
+- `BenchRunner._run_iteration()` applies resource constraints via command wrapping before execution.
 - `BenchRunner.run()` now checks for root execution and refuses unless `--run-dangerously-as-root` is passed.
 - macOS support for system profiling: CPU info from `sysctl`, memory from `vm_stat`, OS from `sw_vers`, disk type from `diskutil`. All existing Linux code paths preserved unchanged.
 - `check_stability()` and `SystemSnapshot.capture()` now use cross-platform `_get_available_ram_gb()` helper instead of Linux-only `/proc/meminfo`.

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.results import ConditionDef
 
 log = logging.getLogger("labeille")
@@ -72,6 +73,9 @@ class BenchConfig:
 
     # Per-test timing
     per_test_timing: bool = False  # Capture per-test timing via pytest --durations=0
+
+    # Resource constraints
+    default_constraints: ResourceConstraints | None = None
 
     # Cache control
     drop_caches: bool = False  # Drop filesystem caches between iterations
@@ -329,6 +333,13 @@ def config_from_profile(
                 f"Condition '{name}' must be a mapping, got {type(cond_data).__name__}"
             )
 
+        constraints_data = cond_data.get("constraints")
+        cond_constraints = (
+            ResourceConstraints.from_dict(constraints_data)
+            if constraints_data and isinstance(constraints_data, dict)
+            else None
+        )
+
         config.conditions[name] = ConditionDef(
             name=name,
             description=cond_data.get("description", ""),
@@ -339,6 +350,7 @@ def config_from_profile(
             test_command_prefix=cond_data.get("test_command_prefix"),
             test_command_suffix=cond_data.get("test_command_suffix"),
             install_command=cond_data.get("install_command"),
+            constraints=cond_constraints,
         )
 
     # Apply CLI path overrides.
@@ -368,6 +380,11 @@ def config_from_profile(
         config.alternate = cli["alternate"]
     if cli.get("interleave"):
         config.interleave = True
+
+    # Default constraints from profile.
+    default_constraints_data = profile_data.get("constraints")
+    if default_constraints_data and isinstance(default_constraints_data, dict):
+        config.default_constraints = ResourceConstraints.from_dict(default_constraints_data)
 
     # Cache control — drop_caches is allowed in profiles.
     if profile_data.get("drop_caches"):
@@ -442,11 +459,24 @@ def parse_inline_condition(spec: str) -> ConditionDef:
         elif key.startswith("env."):
             env_key = key[4:]
             cond.env[env_key] = value
+        elif key == "memory_limit":
+            if cond.constraints is None:
+                cond.constraints = ResourceConstraints()
+            cond.constraints.memory_limit_mb = int(value)
+        elif key == "cpu_affinity":
+            if cond.constraints is None:
+                cond.constraints = ResourceConstraints()
+            cond.constraints.cpu_affinity = [int(c.strip()) for c in value.split("+")]
+        elif key == "cpu_time_limit":
+            if cond.constraints is None:
+                cond.constraints = ResourceConstraints()
+            cond.constraints.cpu_time_limit_s = int(value)
         else:
             raise ValueError(
                 f"Unknown condition key '{key}' in condition '{name}'. "
                 f"Valid keys: target_python, extra_deps, test_command_override, "
-                f"test_prefix, test_suffix, install_command, description, env.KEY"
+                f"test_prefix, test_suffix, install_command, description, env.KEY, "
+                f"memory_limit, cpu_affinity, cpu_time_limit"
             )
 
     return cond
@@ -578,3 +608,13 @@ def resolve_extra_deps(
             seen.add(dep)
             result.append(dep)
     return result
+
+
+def resolve_constraints(
+    condition: ConditionDef,
+    default: ResourceConstraints | None,
+) -> ResourceConstraints | None:
+    """Resolve constraints for a condition (condition overrides default)."""
+    if condition.constraints is not None:
+        return condition.constraints
+    return default

--- a/src/labeille/bench/constraints.py
+++ b/src/labeille/bench/constraints.py
@@ -1,0 +1,256 @@
+"""Resource constraints for benchmark execution.
+
+Applies per-process resource limits using ulimit (portable across
+Linux and macOS) and CPU affinity via taskset (Linux only).
+
+Constraints are specified per-condition in the ConditionDef, allowing
+A/B comparison under different resource limits. When a process exceeds
+a memory limit, it is killed by the OS — this is the intended behavior
+for benchmarking, as it clearly identifies packages that cannot run
+under the constraint.
+
+No root privileges are required. ulimit operates on the current process
+and its children. taskset requires the target CPUs to be available to
+the current user (which is the default).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger("labeille")
+
+
+@dataclass
+class ResourceConstraints:
+    """Resource limits applied during benchmark iteration execution.
+
+    All limits are optional. When set, they're applied via ulimit
+    (memory, CPU time) and taskset (CPU affinity).
+
+    This is part of the condition abstraction: different conditions
+    can have different constraints.
+    """
+
+    # Memory: virtual memory limit in MB.
+    # Maps to ulimit -v (in KB). When exceeded, malloc returns NULL
+    # or the process gets SIGSEGV/SIGKILL depending on the OS.
+    memory_limit_mb: int | None = None
+
+    # CPU time limit in seconds.
+    # Maps to ulimit -t. Sends SIGXCPU when exceeded, then SIGKILL.
+    cpu_time_limit_s: int | None = None
+
+    # File size limit in MB.
+    # Maps to ulimit -f (in 512-byte blocks). Prevents runaway disk usage.
+    file_size_limit_mb: int | None = None
+
+    # CPU affinity: list of CPU core indices to pin execution to.
+    # Uses taskset on Linux. Ignored on macOS (with a warning).
+    cpu_affinity: list[int] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (sparse: omits None values)."""
+        d: dict[str, Any] = {}
+        if self.memory_limit_mb is not None:
+            d["memory_limit_mb"] = self.memory_limit_mb
+        if self.cpu_time_limit_s is not None:
+            d["cpu_time_limit_s"] = self.cpu_time_limit_s
+        if self.file_size_limit_mb is not None:
+            d["file_size_limit_mb"] = self.file_size_limit_mb
+        if self.cpu_affinity is not None:
+            d["cpu_affinity"] = self.cpu_affinity
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResourceConstraints:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    @property
+    def has_any(self) -> bool:
+        """True if any constraint is set."""
+        return any(
+            [
+                self.memory_limit_mb is not None,
+                self.cpu_time_limit_s is not None,
+                self.file_size_limit_mb is not None,
+                self.cpu_affinity is not None,
+            ]
+        )
+
+    @property
+    def has_cpu_affinity(self) -> bool:
+        """True if CPU affinity is set with at least one core."""
+        return self.cpu_affinity is not None and len(self.cpu_affinity) > 0
+
+
+def build_ulimit_prefix(constraints: ResourceConstraints) -> str:
+    """Build a shell ulimit prefix string for the given constraints.
+
+    Generates ulimit flags that set resource limits before executing
+    the test command.
+
+    Args:
+        constraints: Resource constraints to apply.
+
+    Returns:
+        A shell prefix string. Empty string if no ulimit constraints.
+        The returned string ends with ``"; exec "`` — the caller
+        appends the actual command.
+    """
+    parts: list[str] = []
+
+    if constraints.memory_limit_mb is not None:
+        parts.append(f"ulimit -v {constraints.memory_limit_mb * 1024}")
+    if constraints.cpu_time_limit_s is not None:
+        parts.append(f"ulimit -t {constraints.cpu_time_limit_s}")
+    if constraints.file_size_limit_mb is not None:
+        parts.append(f"ulimit -f {constraints.file_size_limit_mb * 2048}")
+
+    if not parts:
+        return ""
+
+    return "; ".join(parts) + "; exec "
+
+
+def build_taskset_prefix(constraints: ResourceConstraints) -> str:
+    """Build a taskset prefix for CPU affinity.
+
+    Only works on Linux. Returns empty string on other platforms
+    or if taskset is not available.
+
+    Args:
+        constraints: Resource constraints with cpu_affinity set.
+
+    Returns:
+        A command prefix like ``"taskset -c 0,1 "`` or empty string.
+    """
+    if not constraints.has_cpu_affinity:
+        return ""
+
+    if sys.platform != "linux":
+        return ""
+
+    if not shutil.which("taskset"):
+        log.warning("taskset not found, CPU affinity ignored.")
+        return ""
+
+    assert constraints.cpu_affinity is not None  # for type checker
+    cores = ",".join(str(c) for c in constraints.cpu_affinity)
+    return f"taskset -c {cores} "
+
+
+def apply_constraints_to_command(
+    command: str,
+    constraints: ResourceConstraints | None,
+) -> str:
+    """Wrap a command with resource constraints.
+
+    Applies taskset prefix (if applicable) and ulimit wrapper
+    (if applicable) to the given command string.
+
+    Order: taskset wraps the ulimit-wrapped command, so CPU affinity
+    applies to the shell that sets ulimits.
+
+    Args:
+        command: The original shell command.
+        constraints: Resource constraints to apply, or None.
+
+    Returns:
+        The (possibly wrapped) command string.
+    """
+    if constraints is None or not constraints.has_any:
+        return command
+
+    result = command
+
+    ulimit = build_ulimit_prefix(constraints)
+    if ulimit:
+        result = f"bash -c '{ulimit}{result}'"
+
+    taskset = build_taskset_prefix(constraints)
+    if taskset:
+        result = f"{taskset}{result}"
+
+    return result
+
+
+def check_constraints_available(
+    constraints: ResourceConstraints,
+) -> list[str]:
+    """Check which constraints are available on this platform.
+
+    Returns a list of warning messages for constraints that cannot
+    be applied (e.g., CPU affinity on macOS). Empty list means all
+    constraints are available.
+    """
+    warnings: list[str] = []
+
+    if constraints.has_cpu_affinity:
+        if sys.platform != "linux":
+            warnings.append(
+                "CPU affinity (taskset) is only available on Linux. Affinity will be ignored."
+            )
+        elif not shutil.which("taskset"):
+            warnings.append(
+                "taskset not found. Install util-linux or CPU affinity will be ignored."
+            )
+
+        # Validate core indices.
+        cpu_count = os.cpu_count() or 1
+        assert constraints.cpu_affinity is not None  # for type checker
+        invalid = [c for c in constraints.cpu_affinity if c >= cpu_count]
+        if invalid:
+            warnings.append(
+                f"CPU core indices {invalid} are >= cpu_count ({cpu_count}). "
+                f"These cores may not exist."
+            )
+
+    return warnings
+
+
+def detect_oom_from_result(
+    exit_code: int,
+    stderr: str,
+    constraints: ResourceConstraints | None,
+) -> bool:
+    """Detect whether a process was killed due to OOM from resource limits.
+
+    Heuristics:
+    - Exit code -9 (SIGKILL) with memory_limit_mb set.
+    - Exit code -11 (SIGSEGV) with memory_limit_mb set (malloc returns NULL).
+    - "Cannot allocate memory" or "MemoryError" in stderr.
+
+    Args:
+        exit_code: Process exit code.
+        stderr: Process stderr output.
+        constraints: The constraints that were applied.
+
+    Returns:
+        True if the process likely died from memory limits.
+    """
+    if constraints is None:
+        return False
+
+    has_memory_limit = constraints.memory_limit_mb is not None
+
+    # Signal-based detection (only with memory limit).
+    if has_memory_limit and exit_code in (-9, -11):
+        return True
+
+    # Stderr-based detection (works with or without explicit limit).
+    if has_memory_limit:
+        stderr_lower = stderr.lower()
+        if "cannot allocate memory" in stderr_lower:
+            return True
+        if "memoryerror" in stderr_lower:
+            return True
+
+    return False

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.stats import DescriptiveStats, describe, detect_outliers
 from labeille.bench.system import PythonProfile, SystemProfile
 from labeille.bench.timing import PerTestTimings
@@ -55,6 +56,8 @@ class BenchIteration:
     load_avg_end: float = 0.0
     ram_available_start_gb: float = 0.0
     caches_dropped: bool = False  # Whether caches were dropped before this iteration
+    constraints_applied: bool = False  # Whether resource constraints were active
+    oom_detected: bool = False  # Whether OOM was detected for this iteration
     per_test_timings: PerTestTimings | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -75,6 +78,10 @@ class BenchIteration:
         }
         if self.caches_dropped:
             d["caches_dropped"] = True
+        if self.constraints_applied:
+            d["constraints_applied"] = True
+        if self.oom_detected:
+            d["oom_detected"] = True
         if self.per_test_timings is not None:
             d["per_test_timings"] = self.per_test_timings.to_dict()
         return d
@@ -247,6 +254,7 @@ class ConditionDef:
     test_command_prefix: str | None = None
     test_command_suffix: str | None = None
     install_command: str | None = None
+    constraints: ResourceConstraints | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict (sparse: omits defaults)."""
@@ -267,11 +275,19 @@ class ConditionDef:
             d["test_command_suffix"] = self.test_command_suffix
         if self.install_command:
             d["install_command"] = self.install_command
+        if self.constraints is not None and self.constraints.has_any:
+            d["constraints"] = self.constraints.to_dict()
         return d
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ConditionDef:
         """Deserialize from a dict."""
+        constraints_data = data.get("constraints")
+        constraints = (
+            ResourceConstraints.from_dict(constraints_data)
+            if constraints_data and isinstance(constraints_data, dict)
+            else None
+        )
         return cls(
             name=data["name"],
             description=data.get("description", ""),
@@ -282,6 +298,7 @@ class ConditionDef:
             test_command_prefix=data.get("test_command_prefix"),
             test_command_suffix=data.get("test_command_suffix"),
             install_command=data.get("install_command"),
+            constraints=constraints,
         )
 
 

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from labeille.bench.config import (
     BenchConfig,
+    resolve_constraints,
     resolve_env,
     resolve_extra_deps,
     resolve_target_python,
@@ -52,6 +53,11 @@ from labeille.bench.system import (
     format_system_profile,
 )
 from labeille.bench.cache import check_cache_drop_available, check_not_root, drop_caches
+from labeille.bench.constraints import (
+    apply_constraints_to_command,
+    check_constraints_available,
+    detect_oom_from_result,
+)
 from labeille.bench.timing import (
     parse_pytest_durations,
     prepare_per_test_command,
@@ -211,6 +217,14 @@ class BenchRunner:
             if not status.available:
                 raise SystemExit(status.message)
             log.info("Cache dropping enabled.")
+
+        # Phase 3c: Validate resource constraints.
+        for cond_name, cond in self.config.conditions.items():
+            resolved = resolve_constraints(cond, self.config.default_constraints)
+            if resolved and resolved.has_any:
+                constraint_warnings = check_constraints_available(resolved)
+                for cw in constraint_warnings:
+                    log.warning("Constraints [%s]: %s", cond_name, cw)
 
         # Phase 4: Prepare output directory and metadata.
         output_dir = self.config.output_dir
@@ -661,6 +675,12 @@ class BenchRunner:
             test_framework = getattr(pkg, "test_framework", "") or ""
             test_cmd, per_test_enabled = prepare_per_test_command(test_cmd, test_framework)
 
+        # Apply resource constraints.
+        constraints = resolve_constraints(cond, self.config.default_constraints)
+        constraints_applied = constraints is not None and constraints.has_any
+        if constraints_applied:
+            test_cmd = apply_constraints_to_command(test_cmd, constraints)
+
         # Build environment.
         env = resolve_env(cond, self.config.default_env)
         env.setdefault("PYTHONFAULTHANDLER", "1")
@@ -700,6 +720,11 @@ class BenchRunner:
         else:
             status = "fail"
 
+        # OOM detection.
+        oom_detected = detect_oom_from_result(timed.exit_code, timed.stderr, constraints)
+        if oom_detected:
+            status = "oom"
+
         # Parse per-test timings if enabled.
         per_test_timings = None
         if per_test_enabled:
@@ -718,6 +743,8 @@ class BenchRunner:
             load_avg_end=snap_after.load_avg_1m,
             ram_available_start_gb=snap_before.ram_available_gb,
             caches_dropped=caches_dropped,
+            constraints_applied=constraints_applied,
+            oom_detected=oom_detected,
             per_test_timings=per_test_timings,
         )
 

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -172,6 +172,24 @@ def bench() -> None:
     help="Capture per-test timing via pytest --durations=0.",
 )
 @click.option(
+    "--memory-limit",
+    type=int,
+    default=None,
+    help="Memory limit in MB for all conditions (ulimit -v).",
+)
+@click.option(
+    "--cpu-affinity",
+    type=str,
+    default=None,
+    help="CPU core list (e.g. '0,1') for all conditions (taskset).",
+)
+@click.option(
+    "--cpu-time-limit",
+    type=int,
+    default=None,
+    help="CPU time limit in seconds for all conditions (ulimit -t).",
+)
+@click.option(
     "--drop-caches",
     is_flag=True,
     default=False,
@@ -213,6 +231,9 @@ def run(  # noqa: PLR0913
     wait_for_stability: bool,
     quick: bool,
     per_test_timing: bool,
+    memory_limit: int | None,
+    cpu_affinity: str | None,
+    cpu_time_limit: int | None,
     drop_caches: bool,
     warm_vs_cold: bool,
     run_dangerously_as_root: bool,
@@ -320,6 +341,17 @@ def run(  # noqa: PLR0913
     config.drop_caches = drop_caches or warm_vs_cold  # warm-vs-cold implies drop-caches
     config.warm_vs_cold = warm_vs_cold
     config.run_dangerously_as_root = run_dangerously_as_root
+
+    if memory_limit or cpu_affinity or cpu_time_limit:
+        from labeille.bench.constraints import ResourceConstraints
+
+        affinity_list = [int(c.strip()) for c in cpu_affinity.split(",")] if cpu_affinity else None
+        config.default_constraints = ResourceConstraints(
+            memory_limit_mb=memory_limit,
+            cpu_affinity=affinity_list,
+            cpu_time_limit_s=cpu_time_limit,
+        )
+
     config.cli_args = sys.argv[1:]
 
     if quick:

--- a/tests/test_bench_constraints.py
+++ b/tests/test_bench_constraints.py
@@ -1,0 +1,385 @@
+"""Tests for labeille.bench.constraints — resource limits for benchmarking."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from labeille.bench.constraints import (
+    ResourceConstraints,
+    apply_constraints_to_command,
+    build_taskset_prefix,
+    build_ulimit_prefix,
+    check_constraints_available,
+    detect_oom_from_result,
+)
+from labeille.bench.results import BenchIteration, ConditionDef
+
+
+# ---------------------------------------------------------------------------
+# TestResourceConstraints
+# ---------------------------------------------------------------------------
+
+
+class TestResourceConstraints(unittest.TestCase):
+    """Tests for ResourceConstraints dataclass."""
+
+    def test_has_any_with_memory(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertTrue(c.has_any)
+
+    def test_has_any_empty(self) -> None:
+        c = ResourceConstraints()
+        self.assertFalse(c.has_any)
+
+    def test_has_any_with_affinity(self) -> None:
+        c = ResourceConstraints(cpu_affinity=[0])
+        self.assertTrue(c.has_any)
+
+    def test_to_dict_sparse(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        d = c.to_dict()
+        self.assertEqual(d, {"memory_limit_mb": 1024})
+        self.assertNotIn("cpu_time_limit_s", d)
+        self.assertNotIn("file_size_limit_mb", d)
+        self.assertNotIn("cpu_affinity", d)
+
+    def test_to_dict_roundtrip(self) -> None:
+        c = ResourceConstraints(
+            memory_limit_mb=1024,
+            cpu_time_limit_s=300,
+            file_size_limit_mb=100,
+            cpu_affinity=[0, 1, 2],
+        )
+        d = c.to_dict()
+        restored = ResourceConstraints.from_dict(d)
+        self.assertEqual(restored.memory_limit_mb, 1024)
+        self.assertEqual(restored.cpu_time_limit_s, 300)
+        self.assertEqual(restored.file_size_limit_mb, 100)
+        self.assertEqual(restored.cpu_affinity, [0, 1, 2])
+
+    def test_from_dict_ignores_unknown(self) -> None:
+        d = {"memory_limit_mb": 1024, "unknown_field": "ignored"}
+        c = ResourceConstraints.from_dict(d)
+        self.assertEqual(c.memory_limit_mb, 1024)
+        self.assertFalse(hasattr(c, "unknown_field"))
+
+    def test_has_cpu_affinity(self) -> None:
+        self.assertTrue(ResourceConstraints(cpu_affinity=[0]).has_cpu_affinity)
+        self.assertFalse(ResourceConstraints(cpu_affinity=[]).has_cpu_affinity)
+        self.assertFalse(ResourceConstraints().has_cpu_affinity)
+
+
+# ---------------------------------------------------------------------------
+# TestBuildUlimitPrefix
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUlimitPrefix(unittest.TestCase):
+    """Tests for build_ulimit_prefix()."""
+
+    def test_memory_only(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        result = build_ulimit_prefix(c)
+        self.assertIn("ulimit -v 1048576", result)  # 1024 * 1024
+
+    def test_cpu_time_only(self) -> None:
+        c = ResourceConstraints(cpu_time_limit_s=300)
+        result = build_ulimit_prefix(c)
+        self.assertIn("ulimit -t 300", result)
+
+    def test_file_size_only(self) -> None:
+        c = ResourceConstraints(file_size_limit_mb=100)
+        result = build_ulimit_prefix(c)
+        self.assertIn("ulimit -f 204800", result)  # 100 * 2048
+
+    def test_multiple_constraints(self) -> None:
+        c = ResourceConstraints(
+            memory_limit_mb=1024,
+            cpu_time_limit_s=300,
+            file_size_limit_mb=100,
+        )
+        result = build_ulimit_prefix(c)
+        self.assertIn("ulimit -v 1048576", result)
+        self.assertIn("ulimit -t 300", result)
+        self.assertIn("ulimit -f 204800", result)
+
+    def test_no_constraints(self) -> None:
+        c = ResourceConstraints()
+        result = build_ulimit_prefix(c)
+        self.assertEqual(result, "")
+
+    def test_ends_with_exec(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        result = build_ulimit_prefix(c)
+        self.assertTrue(result.endswith("; exec "))
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTasksetPrefix
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTasksetPrefix(unittest.TestCase):
+    """Tests for build_taskset_prefix()."""
+
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_linux_with_taskset(self, mock_which: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 1])
+        result = build_taskset_prefix(c)
+        self.assertEqual(result, "taskset -c 0,1 ")
+
+    @patch("labeille.bench.constraints.sys.platform", "darwin")
+    def test_macos_ignored(self) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 1])
+        result = build_taskset_prefix(c)
+        self.assertEqual(result, "")
+
+    @patch("labeille.bench.constraints.shutil.which", return_value=None)
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_no_taskset_binary(self, mock_which: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 1])
+        result = build_taskset_prefix(c)
+        self.assertEqual(result, "")
+
+    def test_no_affinity(self) -> None:
+        c = ResourceConstraints()
+        result = build_taskset_prefix(c)
+        self.assertEqual(result, "")
+
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_single_core(self, mock_which: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[2])
+        result = build_taskset_prefix(c)
+        self.assertEqual(result, "taskset -c 2 ")
+
+
+# ---------------------------------------------------------------------------
+# TestApplyConstraintsToCommand
+# ---------------------------------------------------------------------------
+
+
+class TestApplyConstraintsToCommand(unittest.TestCase):
+    """Tests for apply_constraints_to_command()."""
+
+    def test_no_constraints(self) -> None:
+        result = apply_constraints_to_command("python -m pytest", None)
+        self.assertEqual(result, "python -m pytest")
+
+    def test_ulimit_wrapping(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        result = apply_constraints_to_command("python -m pytest", c)
+        self.assertIn("bash -c '", result)
+        self.assertIn("ulimit -v 1048576", result)
+        self.assertIn("python -m pytest", result)
+
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_taskset_prefixed(self, mock_which: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 1])
+        result = apply_constraints_to_command("python -m pytest", c)
+        self.assertTrue(result.startswith("taskset -c 0,1 "))
+
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_both_ulimit_and_taskset(self, mock_which: object) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024, cpu_affinity=[0, 1])
+        result = apply_constraints_to_command("python -m pytest", c)
+        self.assertTrue(result.startswith("taskset -c 0,1 "))
+        self.assertIn("bash -c '", result)
+        self.assertIn("ulimit -v", result)
+
+    def test_empty_constraints(self) -> None:
+        c = ResourceConstraints()
+        result = apply_constraints_to_command("python -m pytest", c)
+        self.assertEqual(result, "python -m pytest")
+
+
+# ---------------------------------------------------------------------------
+# TestCheckConstraintsAvailable
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConstraintsAvailable(unittest.TestCase):
+    """Tests for check_constraints_available()."""
+
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_all_available_linux(self, mock_which: object) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024, cpu_affinity=[0])
+        warnings = check_constraints_available(c)
+        self.assertEqual(warnings, [])
+
+    @patch("labeille.bench.constraints.sys.platform", "darwin")
+    def test_affinity_on_macos(self) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 1])
+        warnings = check_constraints_available(c)
+        self.assertTrue(any("only available on Linux" in w for w in warnings))
+
+    @patch("labeille.bench.constraints.shutil.which", return_value=None)
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_taskset_missing(self, mock_which: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[0])
+        warnings = check_constraints_available(c)
+        self.assertTrue(any("taskset not found" in w for w in warnings))
+
+    @patch("labeille.bench.constraints.os.cpu_count", return_value=4)
+    @patch("labeille.bench.constraints.shutil.which", return_value="/usr/bin/taskset")
+    @patch("labeille.bench.constraints.sys.platform", "linux")
+    def test_invalid_core_index(self, mock_which: object, mock_cpu: object) -> None:
+        c = ResourceConstraints(cpu_affinity=[0, 8])
+        warnings = check_constraints_available(c)
+        self.assertTrue(any("8" in w for w in warnings))
+
+    def test_no_constraints(self) -> None:
+        c = ResourceConstraints()
+        warnings = check_constraints_available(c)
+        self.assertEqual(warnings, [])
+
+
+# ---------------------------------------------------------------------------
+# TestDetectOomFromResult
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOomFromResult(unittest.TestCase):
+    """Tests for detect_oom_from_result()."""
+
+    def test_sigkill_with_memory_limit(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertTrue(detect_oom_from_result(-9, "", c))
+
+    def test_sigsegv_with_memory_limit(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertTrue(detect_oom_from_result(-11, "", c))
+
+    def test_memory_error_in_stderr(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertTrue(detect_oom_from_result(1, "MemoryError: out of memory", c))
+
+    def test_cannot_allocate_in_stderr(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertTrue(detect_oom_from_result(1, "Cannot allocate memory", c))
+
+    def test_sigkill_without_memory_limit(self) -> None:
+        c = ResourceConstraints(cpu_time_limit_s=300)
+        self.assertFalse(detect_oom_from_result(-9, "", c))
+
+    def test_normal_exit(self) -> None:
+        c = ResourceConstraints(memory_limit_mb=1024)
+        self.assertFalse(detect_oom_from_result(0, "", c))
+
+    def test_no_constraints(self) -> None:
+        self.assertFalse(detect_oom_from_result(-9, "", None))
+
+
+# ---------------------------------------------------------------------------
+# TestConditionDefConstraints
+# ---------------------------------------------------------------------------
+
+
+class TestConditionDefConstraints(unittest.TestCase):
+    """Tests for ConditionDef constraints field."""
+
+    def test_condition_with_constraints_roundtrip(self) -> None:
+        cond = ConditionDef(
+            name="constrained",
+            constraints=ResourceConstraints(memory_limit_mb=2048, cpu_affinity=[0, 1]),
+        )
+        d = cond.to_dict()
+        self.assertIn("constraints", d)
+        self.assertEqual(d["constraints"]["memory_limit_mb"], 2048)
+
+        restored = ConditionDef.from_dict(d)
+        assert restored.constraints is not None
+        self.assertEqual(restored.constraints.memory_limit_mb, 2048)
+        self.assertEqual(restored.constraints.cpu_affinity, [0, 1])
+
+    def test_condition_without_constraints(self) -> None:
+        cond = ConditionDef(name="baseline")
+        d = cond.to_dict()
+        self.assertNotIn("constraints", d)
+
+    def test_condition_from_old_format(self) -> None:
+        d = {"name": "old_baseline", "target_python": "/usr/bin/python3"}
+        cond = ConditionDef.from_dict(d)
+        self.assertIsNone(cond.constraints)
+
+
+# ---------------------------------------------------------------------------
+# TestBenchIterationConstraintFields
+# ---------------------------------------------------------------------------
+
+
+class TestBenchIterationConstraintFields(unittest.TestCase):
+    """Tests for BenchIteration constraint-related fields."""
+
+    def test_defaults(self) -> None:
+        it = BenchIteration(
+            index=1,
+            warmup=False,
+            wall_time_s=5.0,
+            user_time_s=4.0,
+            sys_time_s=0.5,
+            peak_rss_mb=256.0,
+            exit_code=0,
+            status="ok",
+        )
+        self.assertFalse(it.constraints_applied)
+        self.assertFalse(it.oom_detected)
+
+    def test_constraints_applied_serialization(self) -> None:
+        it = BenchIteration(
+            index=1,
+            warmup=False,
+            wall_time_s=5.0,
+            user_time_s=4.0,
+            sys_time_s=0.5,
+            peak_rss_mb=256.0,
+            exit_code=0,
+            status="ok",
+            constraints_applied=True,
+            oom_detected=True,
+        )
+        d = it.to_dict()
+        self.assertTrue(d["constraints_applied"])
+        self.assertTrue(d["oom_detected"])
+        restored = BenchIteration.from_dict(d)
+        self.assertTrue(restored.constraints_applied)
+        self.assertTrue(restored.oom_detected)
+
+    def test_false_fields_not_in_dict(self) -> None:
+        it = BenchIteration(
+            index=1,
+            warmup=False,
+            wall_time_s=5.0,
+            user_time_s=4.0,
+            sys_time_s=0.5,
+            peak_rss_mb=256.0,
+            exit_code=0,
+            status="ok",
+        )
+        d = it.to_dict()
+        self.assertNotIn("constraints_applied", d)
+        self.assertNotIn("oom_detected", d)
+
+    def test_backward_compat_missing_keys(self) -> None:
+        d = {
+            "index": 1,
+            "warmup": False,
+            "wall_time_s": 5.0,
+            "user_time_s": 4.0,
+            "sys_time_s": 0.5,
+            "peak_rss_mb": 256.0,
+            "exit_code": 0,
+            "status": "ok",
+        }
+        it = BenchIteration.from_dict(d)
+        self.assertFalse(it.constraints_applied)
+        self.assertFalse(it.oom_detected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `constraints.py` module with `ResourceConstraints` dataclass, ulimit/taskset command wrapping, and OOM detection
- Add `--memory-limit`, `--cpu-affinity`, `--cpu-time-limit` CLI flags to `bench run` and per-condition constraints in YAML profiles/inline conditions
- Add `constraints` field on `ConditionDef`, `constraints_applied`/`oom_detected` on `BenchIteration` with backward-compatible serialization

## Test plan
- [x] 42 new tests in `test_bench_constraints.py` covering ResourceConstraints, ulimit/taskset prefix building, command wrapping, availability checks, OOM detection, ConditionDef constraints, and BenchIteration fields
- [x] All 1536 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)