### PR TITLE
feat: add benchmark tracking series for longitudinal comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `tracking.py` module in `bench` subpackage with `TrackingSeries` and `TrackingRunEntry` dataclasses for longitudinal benchmark tracking.
+- `compute_config_fingerprint()` for comparing benchmark configurations across runs (ignores package list and system profile).
+- Series management: `init_series()`, `add_run_to_series()`, `pin_baseline()`, `unpin_baseline()`, `load_series()`, `save_series()`, `list_series()`.
+- `labeille bench track` CLI subgroup with `init`, `add`, `show`, `list`, `pin`, and `unpin` commands.
+- Symlink-based run storage within tracking directories to avoid data duplication.
 - `constraints.py` module in `bench` subpackage with `ResourceConstraints` dataclass and ulimit/taskset command wrapping.
 - Resource constraints as part of the condition abstraction: `--memory-limit`, `--cpu-affinity`, and `--cpu-time-limit` CLI flags for `labeille bench run`.
 - Per-condition constraint specification in YAML benchmark profiles.

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -1,0 +1,431 @@
+"""Benchmark tracking series for longitudinal comparison.
+
+A tracking series is a named collection of benchmark runs intended
+for regression detection over time. Runs in a series should share
+the same benchmark configuration (conditions, iteration count,
+warmup count) so that results are comparable.
+
+The series tracks a "config fingerprint" — a hash of the
+configuration aspects that affect comparability. Package list
+changes do NOT break the fingerprint, since the registry naturally
+grows over time and packages missing from earlier runs simply have
+shorter histories.
+
+Series data is stored as JSON files alongside symlinks to the
+original benchmark run directories.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from labeille.bench.results import BenchMeta, BenchPackageResult, load_bench_run
+
+log = logging.getLogger("labeille")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrackingRunEntry:
+    """Index entry for one run within a tracking series."""
+
+    bench_id: str
+    timestamp: str  # ISO 8601 from bench_meta.json start_time
+    run_dir: str  # Relative path within tracking dir (or absolute symlink target)
+    packages_completed: int
+    config_fingerprint: str  # Fingerprint of this run's config
+    commit_info: dict[str, str] = field(default_factory=dict)
+    # e.g. {"cpython": "abc1234", "labeille": "def5678"}
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (sparse)."""
+        d: dict[str, Any] = {
+            "bench_id": self.bench_id,
+            "timestamp": self.timestamp,
+            "run_dir": self.run_dir,
+            "packages_completed": self.packages_completed,
+            "config_fingerprint": self.config_fingerprint,
+        }
+        if self.commit_info:
+            d["commit_info"] = self.commit_info
+        if self.notes:
+            d["notes"] = self.notes
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrackingRunEntry:
+        """Deserialize from a dict, ignoring unknown fields."""
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class TrackingSeries:
+    """A named series of benchmark runs for longitudinal tracking."""
+
+    series_id: str  # e.g. "jit-overhead"
+    description: str = ""
+    created: str = ""  # ISO 8601 timestamp
+    config_fingerprint: str = ""  # Fingerprint from the first run
+    pinned_baseline_id: str | None = None  # bench_id of the pinned baseline
+    runs: list[TrackingRunEntry] = field(default_factory=list)
+
+    @property
+    def n_runs(self) -> int:
+        """Number of runs in the series."""
+        return len(self.runs)
+
+    @property
+    def latest_run(self) -> TrackingRunEntry | None:
+        """Most recent run by timestamp."""
+        if not self.runs:
+            return None
+        return max(self.runs, key=lambda r: r.timestamp)
+
+    @property
+    def baseline_run(self) -> TrackingRunEntry | None:
+        """The pinned baseline run, or the first run if not pinned."""
+        if self.pinned_baseline_id:
+            for r in self.runs:
+                if r.bench_id == self.pinned_baseline_id:
+                    return r
+        return self.runs[0] if self.runs else None
+
+    @property
+    def date_range(self) -> tuple[str, str] | None:
+        """Earliest and latest timestamps, or None if no runs."""
+        if not self.runs:
+            return None
+        timestamps = [r.timestamp for r in self.runs]
+        return (min(timestamps), max(timestamps))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        d: dict[str, Any] = {
+            "series_id": self.series_id,
+            "description": self.description,
+            "created": self.created,
+            "config_fingerprint": self.config_fingerprint,
+            "runs": [r.to_dict() for r in self.runs],
+        }
+        if self.pinned_baseline_id is not None:
+            d["pinned_baseline_id"] = self.pinned_baseline_id
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrackingSeries:
+        """Deserialize from a dict."""
+        runs = [TrackingRunEntry.from_dict(r) for r in data.get("runs", [])]
+        return cls(
+            series_id=data["series_id"],
+            description=data.get("description", ""),
+            created=data.get("created", ""),
+            config_fingerprint=data.get("config_fingerprint", ""),
+            pinned_baseline_id=data.get("pinned_baseline_id"),
+            runs=runs,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config fingerprinting
+# ---------------------------------------------------------------------------
+
+
+def compute_config_fingerprint(meta: BenchMeta) -> str:
+    """Compute a fingerprint for a benchmark's configuration.
+
+    The fingerprint covers aspects that affect comparability:
+    - Condition names and their definitions (env, deps, python, constraints)
+    - Iteration count and warmup count
+    - Timeout
+
+    It does NOT include:
+    - Package list (registry grows over time)
+    - System profile (hardware may change, but results should still be trackable)
+    - Start/end times, bench_id
+    - CLI args (different invocations of the same profile are fine)
+
+    Returns:
+        A hex digest string (SHA-256, first 16 chars).
+    """
+    # Build a canonical dict of comparability-affecting config.
+    conditions_canonical: dict[str, Any] = {}
+    for name in sorted(meta.conditions):
+        cond = meta.conditions[name]
+        cond_dict = cond.to_dict()
+        # Remove fields that don't affect comparability.
+        cond_dict.pop("name", None)
+        cond_dict.pop("description", None)
+        conditions_canonical[name] = cond_dict
+
+    fingerprint_data = {
+        "conditions": conditions_canonical,
+        "iterations": meta.config.get("iterations", 5),
+        "warmup": meta.config.get("warmup", 1),
+        "timeout": meta.config.get("timeout", 600),
+    }
+
+    canonical = json.dumps(fingerprint_data, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return digest[:16]
+
+
+# ---------------------------------------------------------------------------
+# I/O functions
+# ---------------------------------------------------------------------------
+
+
+def load_series(series_dir: Path) -> TrackingSeries:
+    """Load a tracking series from its directory.
+
+    Args:
+        series_dir: Path to the series directory containing tracking.json.
+
+    Returns:
+        The loaded TrackingSeries.
+
+    Raises:
+        FileNotFoundError: If tracking.json doesn't exist.
+        ValueError: If tracking.json is malformed.
+    """
+    tracking_file = series_dir / "tracking.json"
+    if not tracking_file.exists():
+        raise FileNotFoundError(f"No tracking.json found in {series_dir}")
+
+    text = tracking_file.read_text()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed tracking.json in {series_dir}: {exc}") from exc
+
+    if not isinstance(data, dict) or "series_id" not in data:
+        raise ValueError(f"Invalid tracking.json in {series_dir}: missing series_id")
+
+    return TrackingSeries.from_dict(data)
+
+
+def save_series(series: TrackingSeries, series_dir: Path) -> None:
+    """Save a tracking series to its directory.
+
+    Creates the directory if needed. Writes tracking.json atomically
+    (write to temp file, then rename).
+
+    Args:
+        series: The series to save.
+        series_dir: Path to the series directory.
+    """
+    series_dir.mkdir(parents=True, exist_ok=True)
+    tracking_file = series_dir / "tracking.json"
+    tmp_file = series_dir / "tracking.json.tmp"
+
+    text = json.dumps(series.to_dict(), indent=2) + "\n"
+    tmp_file.write_text(text)
+    os.replace(str(tmp_file), str(tracking_file))
+
+
+def list_series(tracking_dir: Path) -> list[TrackingSeries]:
+    """List all tracking series in a tracking directory.
+
+    Args:
+        tracking_dir: Parent directory containing series subdirectories.
+
+    Returns:
+        List of TrackingSeries, sorted by series_id.
+    """
+    if not tracking_dir.exists():
+        return []
+
+    result: list[TrackingSeries] = []
+    for entry in sorted(tracking_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        tracking_file = entry / "tracking.json"
+        if not tracking_file.exists():
+            continue
+        try:
+            series = load_series(entry)
+            result.append(series)
+        except (ValueError, FileNotFoundError):
+            log.warning("Skipping malformed series in %s", entry)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Series management
+# ---------------------------------------------------------------------------
+
+
+def init_series(
+    tracking_dir: Path,
+    series_id: str,
+    *,
+    description: str = "",
+) -> TrackingSeries:
+    """Create a new tracking series.
+
+    Creates the series directory and initial tracking.json.
+    The config fingerprint is set when the first run is added.
+
+    Args:
+        tracking_dir: Parent directory for all series.
+        series_id: Unique name (used as directory name).
+        description: Human-readable description.
+
+    Returns:
+        The newly created TrackingSeries.
+
+    Raises:
+        ValueError: If series_id already exists.
+    """
+    series_dir = tracking_dir / series_id
+    if series_dir.exists():
+        raise ValueError(f"Series '{series_id}' already exists at {series_dir}")
+
+    series = TrackingSeries(
+        series_id=series_id,
+        description=description,
+        created=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+    save_series(series, series_dir)
+    return series
+
+
+def add_run_to_series(
+    series_dir: Path,
+    bench_run_dir: Path,
+    *,
+    notes: str = "",
+    commit_info: dict[str, str] | None = None,
+) -> TrackingRunEntry:
+    """Add a benchmark run to a tracking series.
+
+    Validates the run's config fingerprint against the series.
+    On the first run, sets the series fingerprint. On subsequent runs,
+    warns if the fingerprint differs (but still adds the run — the user
+    may have intentionally changed iterations, etc.).
+
+    Creates a symlink from the series directory to the bench run.
+
+    Args:
+        series_dir: Path to the series directory.
+        bench_run_dir: Path to the benchmark output directory.
+        notes: Free-form annotation for this run.
+        commit_info: Optional commit hashes for tracking.
+
+    Returns:
+        The TrackingRunEntry that was added.
+
+    Raises:
+        FileNotFoundError: If bench_run_dir doesn't contain valid bench data.
+    """
+    series = load_series(series_dir)
+    meta, results = load_bench_run(bench_run_dir)
+
+    fingerprint = compute_config_fingerprint(meta)
+
+    # Set or check fingerprint.
+    if not series.config_fingerprint:
+        series.config_fingerprint = fingerprint
+    elif series.config_fingerprint != fingerprint:
+        log.warning(
+            "Config fingerprint for run '%s' (%s) differs from series '%s' (%s). "
+            "Results may not be directly comparable.",
+            meta.bench_id,
+            fingerprint,
+            series.series_id,
+            series.config_fingerprint,
+        )
+
+    # Check for duplicate.
+    for existing in series.runs:
+        if existing.bench_id == meta.bench_id:
+            log.info("Run '%s' already in series, skipping.", meta.bench_id)
+            return existing
+
+    # Create symlink.
+    link_path = series_dir / bench_run_dir.name
+    if not link_path.exists():
+        link_path.symlink_to(bench_run_dir.resolve())
+
+    entry = TrackingRunEntry(
+        bench_id=meta.bench_id,
+        timestamp=meta.start_time,
+        run_dir=bench_run_dir.name,
+        packages_completed=meta.packages_completed,
+        config_fingerprint=fingerprint,
+        commit_info=commit_info or {},
+        notes=notes,
+    )
+
+    series.runs.append(entry)
+    series.runs.sort(key=lambda r: r.timestamp)
+    save_series(series, series_dir)
+    return entry
+
+
+def pin_baseline(
+    series_dir: Path,
+    bench_id: str,
+) -> None:
+    """Pin a specific run as the baseline for comparison.
+
+    Args:
+        series_dir: Path to the series directory.
+        bench_id: The bench_id to pin.
+
+    Raises:
+        ValueError: If bench_id is not found in the series.
+    """
+    series = load_series(series_dir)
+    if not any(r.bench_id == bench_id for r in series.runs):
+        raise ValueError(
+            f"Bench ID '{bench_id}' not found in series '{series.series_id}'. "
+            f"Available: {', '.join(r.bench_id for r in series.runs)}"
+        )
+    series.pinned_baseline_id = bench_id
+    save_series(series, series_dir)
+
+
+def unpin_baseline(series_dir: Path) -> None:
+    """Remove the pinned baseline, reverting to using the first run."""
+    series = load_series(series_dir)
+    series.pinned_baseline_id = None
+    save_series(series, series_dir)
+
+
+def load_series_run(
+    series: TrackingSeries,
+    series_dir: Path,
+    entry: TrackingRunEntry,
+) -> tuple[BenchMeta, list[BenchPackageResult]]:
+    """Load the full benchmark data for a run in a series.
+
+    Resolves the symlink and loads via load_bench_run().
+
+    Args:
+        series: The tracking series.
+        series_dir: Path to the series directory.
+        entry: The run entry to load.
+
+    Returns:
+        Tuple of (BenchMeta, list of BenchPackageResult).
+    """
+    run_path = series_dir / entry.run_dir
+    # Resolve symlinks to get the actual directory.
+    if run_path.is_symlink():
+        run_path = run_path.resolve()
+    return load_bench_run(run_path)

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -724,3 +724,196 @@ def setup_cache_drop(show_script: bool) -> None:
         click.echo("Cache dropping is already configured and working.")
     else:
         click.echo(format_setup_instructions())
+
+
+# ---------------------------------------------------------------------------
+# bench track (subgroup)
+# ---------------------------------------------------------------------------
+
+
+@bench.group("track")
+def track() -> None:
+    """Manage benchmark tracking series for longitudinal comparison."""
+
+
+@track.command("init")
+@click.argument("series_name")
+@click.option("--description", "-d", default="", help="Series description.")
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_init(series_name: str, description: str, tracking_dir: str) -> None:
+    """Create a new benchmark tracking series."""
+    from labeille.bench.tracking import init_series
+
+    try:
+        series = init_series(Path(tracking_dir), series_name, description=description)
+        click.echo(f"Created tracking series '{series.series_id}'.")
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+
+@track.command("add")
+@click.argument("series_name")
+@click.argument("bench_run_dir", type=click.Path(exists=True))
+@click.option("--notes", "-n", default="", help="Notes for this run.")
+@click.option(
+    "--commit",
+    type=str,
+    multiple=True,
+    help="key=value commit info (repeatable).",
+)
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_add(
+    series_name: str,
+    bench_run_dir: str,
+    notes: str,
+    commit: tuple[str, ...],
+    tracking_dir: str,
+) -> None:
+    """Add a benchmark run to a tracking series."""
+    from labeille.bench.tracking import add_run_to_series
+
+    commit_info: dict[str, str] = {}
+    for pair in commit:
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            commit_info[k] = v
+
+    series_dir = Path(tracking_dir) / series_name
+    try:
+        entry = add_run_to_series(
+            series_dir,
+            Path(bench_run_dir),
+            notes=notes,
+            commit_info=commit_info,
+        )
+        click.echo(f"Added run '{entry.bench_id}' to series '{series_name}'.")
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+
+@track.command("show")
+@click.argument("series_name")
+@click.option("--last", "last_n", type=int, default=None, help="Show only last N runs.")
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_show(series_name: str, last_n: int | None, tracking_dir: str) -> None:
+    """Show runs in a tracking series."""
+    from labeille.bench.tracking import load_series
+
+    series_dir = Path(tracking_dir) / series_name
+    try:
+        series = load_series(series_dir)
+    except FileNotFoundError:
+        click.echo(f"Series '{series_name}' not found.", err=True)
+        raise SystemExit(1)  # noqa: B904
+
+    click.echo(f"Series: {series.series_id}")
+    if series.description:
+        click.echo(f"  {series.description}")
+    click.echo(f"  Created: {series.created}")
+    click.echo(f"  Config fingerprint: {series.config_fingerprint or '(none yet)'}")
+    if series.pinned_baseline_id:
+        click.echo(f"  Pinned baseline: {series.pinned_baseline_id}")
+    click.echo()
+
+    runs = series.runs
+    if last_n and last_n < len(runs):
+        runs = runs[-last_n:]
+
+    if not runs:
+        click.echo("  No runs yet.")
+        return
+
+    # Table header.
+    click.echo(f"  {'#':>3}  {'Date':20s}  {'Bench ID':30s}  {'Pkgs':>5}  Notes")
+    click.echo(f"  {'---':>3}  {'----':20s}  {'--------':30s}  {'----':>5}  -----")
+    for i, run in enumerate(runs, 1):
+        date_str = run.timestamp[:19] if run.timestamp else "unknown"
+        baseline_marker = " *" if run.bench_id == series.pinned_baseline_id else ""
+        click.echo(
+            f"  {i:3d}  {date_str:20s}  {run.bench_id:30s}  "
+            f"{run.packages_completed:5d}  {run.notes}{baseline_marker}"
+        )
+
+
+@track.command("pin")
+@click.argument("series_name")
+@click.argument("bench_id")
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_pin(series_name: str, bench_id: str, tracking_dir: str) -> None:
+    """Pin a run as the baseline for trend analysis."""
+    from labeille.bench.tracking import pin_baseline
+
+    series_dir = Path(tracking_dir) / series_name
+    try:
+        pin_baseline(series_dir, bench_id)
+        click.echo(f"Pinned '{bench_id}' as baseline for series '{series_name}'.")
+    except (FileNotFoundError, ValueError) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+
+@track.command("unpin")
+@click.argument("series_name")
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_unpin(series_name: str, tracking_dir: str) -> None:
+    """Remove the pinned baseline."""
+    from labeille.bench.tracking import unpin_baseline
+
+    series_dir = Path(tracking_dir) / series_name
+    try:
+        unpin_baseline(series_dir)
+        click.echo(f"Unpinned baseline for series '{series_name}'.")
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+
+@track.command("list")
+@click.option(
+    "--tracking-dir",
+    type=click.Path(),
+    default="results/tracking",
+    help="Parent directory for tracking series.",
+)
+def track_list(tracking_dir: str) -> None:
+    """List all tracking series."""
+    from labeille.bench.tracking import list_series
+
+    all_series = list_series(Path(tracking_dir))
+    if not all_series:
+        click.echo("No tracking series found.")
+        return
+
+    click.echo(f"{'Name':25s}  {'Runs':>5}  {'Date Range':43s}  Description")
+    click.echo(f"{'----':25s}  {'----':>5}  {'----------':43s}  -----------")
+    for s in all_series:
+        dr = s.date_range
+        date_str = f"{dr[0][:19]} .. {dr[1][:19]}" if dr else "no runs"
+        click.echo(f"{s.series_id:25s}  {s.n_runs:5d}  {date_str:43s}  {s.description}")

--- a/tests/test_bench_tracking.py
+++ b/tests/test_bench_tracking.py
@@ -1,0 +1,543 @@
+"""Tests for labeille.bench.tracking — benchmark tracking series."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from labeille.bench.results import BenchMeta, ConditionDef
+from labeille.bench.tracking import (
+    TrackingRunEntry,
+    TrackingSeries,
+    add_run_to_series,
+    compute_config_fingerprint,
+    init_series,
+    list_series,
+    load_series,
+    pin_baseline,
+    save_series,
+    unpin_baseline,
+)
+
+
+def _make_bench_run_dir(
+    parent: Path,
+    *,
+    bench_id: str = "bench_20260301_100000",
+    start_time: str = "2026-03-01T10:00:00+0000",
+    conditions: dict[str, dict[str, object]] | None = None,
+    config: dict[str, object] | None = None,
+    packages_completed: int = 10,
+) -> Path:
+    """Create a mock bench run directory with valid files."""
+    run_dir = parent / bench_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    if conditions is None:
+        conditions = {"baseline": {"name": "baseline"}}
+    if config is None:
+        config = {"iterations": 5, "warmup": 1, "timeout": 600}
+
+    meta = {
+        "bench_id": bench_id,
+        "name": bench_id,
+        "start_time": start_time,
+        "end_time": start_time,
+        "conditions": conditions,
+        "config": config,
+        "system": {},
+        "python_profiles": {},
+        "packages_total": packages_completed,
+        "packages_completed": packages_completed,
+        "packages_skipped": 0,
+    }
+    (run_dir / "bench_meta.json").write_text(json.dumps(meta, indent=2))
+    (run_dir / "bench_results.jsonl").write_text("")
+    return run_dir
+
+
+# ---------------------------------------------------------------------------
+# TestComputeConfigFingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestComputeConfigFingerprint(unittest.TestCase):
+    """Tests for compute_config_fingerprint()."""
+
+    def _make_meta(
+        self,
+        *,
+        conditions: dict[str, ConditionDef] | None = None,
+        config: dict[str, object] | None = None,
+        bench_id: str = "test_001",
+        packages_completed: int = 10,
+    ) -> BenchMeta:
+        meta = BenchMeta(bench_id=bench_id)
+        meta.conditions = conditions or {"baseline": ConditionDef(name="baseline")}
+        meta.config = config or {"iterations": 5, "warmup": 1, "timeout": 600}
+        meta.packages_completed = packages_completed
+        return meta
+
+    def test_same_config_same_fingerprint(self) -> None:
+        m1 = self._make_meta(bench_id="run1")
+        m2 = self._make_meta(bench_id="run2")
+        self.assertEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_different_conditions_different_fingerprint(self) -> None:
+        m1 = self._make_meta()
+        m2 = self._make_meta(
+            conditions={
+                "baseline": ConditionDef(name="baseline"),
+                "jit": ConditionDef(name="jit", env={"PYTHON_JIT": "1"}),
+            }
+        )
+        self.assertNotEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_different_iterations_different_fingerprint(self) -> None:
+        m1 = self._make_meta()
+        m2 = self._make_meta(config={"iterations": 10, "warmup": 1, "timeout": 600})
+        self.assertNotEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_different_packages_same_fingerprint(self) -> None:
+        m1 = self._make_meta(packages_completed=10)
+        m2 = self._make_meta(packages_completed=50)
+        self.assertEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_different_bench_id_same_fingerprint(self) -> None:
+        m1 = self._make_meta(bench_id="run_001")
+        m2 = self._make_meta(bench_id="run_002")
+        self.assertEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_different_system_same_fingerprint(self) -> None:
+        m1 = self._make_meta()
+        m2 = self._make_meta()
+        m2.system.cpu_model = "AMD EPYC 7763"
+        self.assertEqual(compute_config_fingerprint(m1), compute_config_fingerprint(m2))
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        m = self._make_meta()
+        fp1 = compute_config_fingerprint(m)
+        fp2 = compute_config_fingerprint(m)
+        self.assertEqual(fp1, fp2)
+
+
+# ---------------------------------------------------------------------------
+# TestTrackingSeries
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingSeries(unittest.TestCase):
+    """Tests for TrackingSeries dataclass."""
+
+    def _make_entries(self) -> list[TrackingRunEntry]:
+        return [
+            TrackingRunEntry(
+                bench_id="run_001",
+                timestamp="2026-03-01T10:00:00+0000",
+                run_dir="run_001",
+                packages_completed=10,
+                config_fingerprint="abc123",
+            ),
+            TrackingRunEntry(
+                bench_id="run_002",
+                timestamp="2026-03-08T10:00:00+0000",
+                run_dir="run_002",
+                packages_completed=15,
+                config_fingerprint="abc123",
+            ),
+        ]
+
+    def test_series_roundtrip(self) -> None:
+        entries = self._make_entries()
+        series = TrackingSeries(
+            series_id="test",
+            description="Test series",
+            created="2026-03-01T10:00:00",
+            config_fingerprint="abc123",
+            pinned_baseline_id="run_001",
+            runs=entries,
+        )
+        d = series.to_dict()
+        restored = TrackingSeries.from_dict(d)
+        self.assertEqual(restored.series_id, "test")
+        self.assertEqual(restored.description, "Test series")
+        self.assertEqual(restored.pinned_baseline_id, "run_001")
+        self.assertEqual(len(restored.runs), 2)
+
+    def test_latest_run(self) -> None:
+        series = TrackingSeries(series_id="test", runs=self._make_entries())
+        latest = series.latest_run
+        assert latest is not None
+        self.assertEqual(latest.bench_id, "run_002")
+
+    def test_latest_run_empty(self) -> None:
+        series = TrackingSeries(series_id="test")
+        self.assertIsNone(series.latest_run)
+
+    def test_baseline_run_pinned(self) -> None:
+        series = TrackingSeries(
+            series_id="test",
+            pinned_baseline_id="run_002",
+            runs=self._make_entries(),
+        )
+        baseline = series.baseline_run
+        assert baseline is not None
+        self.assertEqual(baseline.bench_id, "run_002")
+
+    def test_baseline_run_unpinned(self) -> None:
+        series = TrackingSeries(series_id="test", runs=self._make_entries())
+        baseline = series.baseline_run
+        assert baseline is not None
+        self.assertEqual(baseline.bench_id, "run_001")
+
+    def test_baseline_run_pinned_not_found(self) -> None:
+        series = TrackingSeries(
+            series_id="test",
+            pinned_baseline_id="nonexistent",
+            runs=self._make_entries(),
+        )
+        baseline = series.baseline_run
+        assert baseline is not None
+        self.assertEqual(baseline.bench_id, "run_001")  # Falls back to first
+
+    def test_date_range(self) -> None:
+        series = TrackingSeries(series_id="test", runs=self._make_entries())
+        dr = series.date_range
+        assert dr is not None
+        self.assertEqual(dr[0], "2026-03-01T10:00:00+0000")
+        self.assertEqual(dr[1], "2026-03-08T10:00:00+0000")
+
+    def test_date_range_empty(self) -> None:
+        series = TrackingSeries(series_id="test")
+        self.assertIsNone(series.date_range)
+
+
+# ---------------------------------------------------------------------------
+# TestTrackingRunEntry
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingRunEntry(unittest.TestCase):
+    """Tests for TrackingRunEntry dataclass."""
+
+    def test_roundtrip(self) -> None:
+        entry = TrackingRunEntry(
+            bench_id="run_001",
+            timestamp="2026-03-01T10:00:00+0000",
+            run_dir="run_001",
+            packages_completed=10,
+            config_fingerprint="abc123",
+            commit_info={"cpython": "abc1234"},
+            notes="Test run",
+        )
+        d = entry.to_dict()
+        restored = TrackingRunEntry.from_dict(d)
+        self.assertEqual(restored.bench_id, "run_001")
+        self.assertEqual(restored.commit_info, {"cpython": "abc1234"})
+        self.assertEqual(restored.notes, "Test run")
+
+    def test_sparse_serialization(self) -> None:
+        entry = TrackingRunEntry(
+            bench_id="run_001",
+            timestamp="2026-03-01T10:00:00+0000",
+            run_dir="run_001",
+            packages_completed=10,
+            config_fingerprint="abc123",
+        )
+        d = entry.to_dict()
+        self.assertNotIn("commit_info", d)
+        self.assertNotIn("notes", d)
+
+
+# ---------------------------------------------------------------------------
+# TestInitSeries
+# ---------------------------------------------------------------------------
+
+
+class TestInitSeries(unittest.TestCase):
+    """Tests for init_series()."""
+
+    def test_init_creates_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            series = init_series(Path(tmpdir), "test-series")
+            self.assertTrue((Path(tmpdir) / "test-series").is_dir())
+            self.assertEqual(series.series_id, "test-series")
+
+    def test_init_creates_tracking_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init_series(Path(tmpdir), "test-series")
+            tracking_file = Path(tmpdir) / "test-series" / "tracking.json"
+            self.assertTrue(tracking_file.exists())
+            data = json.loads(tracking_file.read_text())
+            self.assertEqual(data["series_id"], "test-series")
+
+    def test_init_duplicate_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init_series(Path(tmpdir), "test-series")
+            with self.assertRaises(ValueError):
+                init_series(Path(tmpdir), "test-series")
+
+    def test_init_empty_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            series = init_series(Path(tmpdir), "test-series")
+            self.assertEqual(series.config_fingerprint, "")
+
+
+# ---------------------------------------------------------------------------
+# TestAddRunToSeries
+# ---------------------------------------------------------------------------
+
+
+class TestAddRunToSeries(unittest.TestCase):
+    """Tests for add_run_to_series()."""
+
+    def test_add_first_run_sets_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run_dir = _make_bench_run_dir(base / "runs")
+
+            add_run_to_series(base / "tracking" / "test-series", run_dir)
+            series = load_series(base / "tracking" / "test-series")
+            self.assertNotEqual(series.config_fingerprint, "")
+            self.assertEqual(series.n_runs, 1)
+
+    def test_add_second_run_same_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run1 = _make_bench_run_dir(
+                base / "runs", bench_id="run_001", start_time="2026-03-01T10:00:00"
+            )
+            run2 = _make_bench_run_dir(
+                base / "runs", bench_id="run_002", start_time="2026-03-08T10:00:00"
+            )
+
+            add_run_to_series(base / "tracking" / "test-series", run1)
+            add_run_to_series(base / "tracking" / "test-series", run2)
+            series = load_series(base / "tracking" / "test-series")
+            self.assertEqual(series.n_runs, 2)
+
+    def test_add_run_different_fingerprint_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run1 = _make_bench_run_dir(base / "runs", bench_id="run_001")
+            run2 = _make_bench_run_dir(
+                base / "runs",
+                bench_id="run_002",
+                config={"iterations": 10, "warmup": 2, "timeout": 600},
+            )
+
+            add_run_to_series(base / "tracking" / "test-series", run1)
+            # Should warn but still add.
+            add_run_to_series(base / "tracking" / "test-series", run2)
+            series = load_series(base / "tracking" / "test-series")
+            self.assertEqual(series.n_runs, 2)
+
+    def test_add_run_creates_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run_dir = _make_bench_run_dir(base / "runs")
+
+            add_run_to_series(base / "tracking" / "test-series", run_dir)
+            link = base / "tracking" / "test-series" / run_dir.name
+            self.assertTrue(link.is_symlink())
+            self.assertEqual(link.resolve(), run_dir.resolve())
+
+    def test_add_duplicate_bench_id_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run_dir = _make_bench_run_dir(base / "runs")
+
+            add_run_to_series(base / "tracking" / "test-series", run_dir)
+            add_run_to_series(base / "tracking" / "test-series", run_dir)
+            series = load_series(base / "tracking" / "test-series")
+            self.assertEqual(series.n_runs, 1)
+
+    def test_add_run_sorted_by_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run2 = _make_bench_run_dir(
+                base / "runs", bench_id="run_002", start_time="2026-03-08T10:00:00"
+            )
+            run1 = _make_bench_run_dir(
+                base / "runs", bench_id="run_001", start_time="2026-03-01T10:00:00"
+            )
+
+            # Add in reverse chronological order.
+            add_run_to_series(base / "tracking" / "test-series", run2)
+            add_run_to_series(base / "tracking" / "test-series", run1)
+            series = load_series(base / "tracking" / "test-series")
+            self.assertEqual(series.runs[0].bench_id, "run_001")
+            self.assertEqual(series.runs[1].bench_id, "run_002")
+
+    def test_add_run_with_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run_dir = _make_bench_run_dir(base / "runs")
+
+            entry = add_run_to_series(
+                base / "tracking" / "test-series", run_dir, notes="First run"
+            )
+            self.assertEqual(entry.notes, "First run")
+
+    def test_add_run_with_commit_info(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            run_dir = _make_bench_run_dir(base / "runs")
+
+            entry = add_run_to_series(
+                base / "tracking" / "test-series",
+                run_dir,
+                commit_info={"cpython": "abc1234"},
+            )
+            self.assertEqual(entry.commit_info, {"cpython": "abc1234"})
+
+    def test_add_invalid_run_dir_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base / "tracking", "test-series")
+            fake_dir = base / "not_a_run"
+            fake_dir.mkdir()
+
+            with self.assertRaises(FileNotFoundError):
+                add_run_to_series(base / "tracking" / "test-series", fake_dir)
+
+
+# ---------------------------------------------------------------------------
+# TestPinUnpinBaseline
+# ---------------------------------------------------------------------------
+
+
+class TestPinUnpinBaseline(unittest.TestCase):
+    """Tests for pin_baseline() and unpin_baseline()."""
+
+    def _setup_series_with_run(self) -> tuple[Path, Path]:
+        self._tmpdir = tempfile.mkdtemp()
+        base = Path(self._tmpdir)
+        init_series(base / "tracking", "test-series")
+        run_dir = _make_bench_run_dir(base / "runs")
+        add_run_to_series(base / "tracking" / "test-series", run_dir)
+        return base / "tracking" / "test-series", run_dir
+
+    def tearDown(self) -> None:
+        import shutil
+
+        if hasattr(self, "_tmpdir"):
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_pin_baseline(self) -> None:
+        series_dir, _ = self._setup_series_with_run()
+        series = load_series(series_dir)
+        bench_id = series.runs[0].bench_id
+        pin_baseline(series_dir, bench_id)
+        reloaded = load_series(series_dir)
+        self.assertEqual(reloaded.pinned_baseline_id, bench_id)
+
+    def test_pin_invalid_bench_id(self) -> None:
+        series_dir, _ = self._setup_series_with_run()
+        with self.assertRaises(ValueError):
+            pin_baseline(series_dir, "nonexistent")
+
+    def test_unpin_baseline(self) -> None:
+        series_dir, _ = self._setup_series_with_run()
+        series = load_series(series_dir)
+        pin_baseline(series_dir, series.runs[0].bench_id)
+        unpin_baseline(series_dir)
+        reloaded = load_series(series_dir)
+        self.assertIsNone(reloaded.pinned_baseline_id)
+
+    def test_unpin_when_not_pinned(self) -> None:
+        series_dir, _ = self._setup_series_with_run()
+        # Should not raise.
+        unpin_baseline(series_dir)
+
+
+# ---------------------------------------------------------------------------
+# TestLoadSaveSeries
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSaveSeries(unittest.TestCase):
+    """Tests for load_series() and save_series()."""
+
+    def test_save_then_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            series_dir = Path(tmpdir) / "test-series"
+            series = TrackingSeries(
+                series_id="test-series",
+                description="Test",
+                created="2026-03-01T10:00:00",
+                config_fingerprint="abc123",
+            )
+            save_series(series, series_dir)
+            loaded = load_series(series_dir)
+            self.assertEqual(loaded.series_id, "test-series")
+            self.assertEqual(loaded.config_fingerprint, "abc123")
+
+    def test_save_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            series_dir = Path(tmpdir) / "test-series"
+            series = TrackingSeries(series_id="test-series", created="2026-03-01T10:00:00")
+            save_series(series, series_dir)
+            # Verify no temp file left behind.
+            self.assertFalse((series_dir / "tracking.json.tmp").exists())
+
+    def test_load_missing_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(FileNotFoundError):
+                load_series(Path(tmpdir) / "nonexistent")
+
+    def test_load_malformed_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            series_dir = Path(tmpdir) / "bad"
+            series_dir.mkdir()
+            (series_dir / "tracking.json").write_text("not valid json")
+            with self.assertRaises(ValueError):
+                load_series(series_dir)
+
+
+# ---------------------------------------------------------------------------
+# TestListSeries
+# ---------------------------------------------------------------------------
+
+
+class TestListSeries(unittest.TestCase):
+    """Tests for list_series()."""
+
+    def test_list_empty_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = list_series(Path(tmpdir))
+            self.assertEqual(result, [])
+
+    def test_list_multiple_series(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base, "beta-series")
+            init_series(base, "alpha-series")
+            result = list_series(base)
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0].series_id, "alpha-series")
+            self.assertEqual(result[1].series_id, "beta-series")
+
+    def test_list_ignores_non_series_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            init_series(base, "real-series")
+            # Create a dir without tracking.json.
+            (base / "not-a-series").mkdir()
+            result = list_series(base)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0].series_id, "real-series")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `tracking.py` module with `TrackingSeries`, `TrackingRunEntry` dataclasses, config fingerprinting (`compute_config_fingerprint()`), and series management functions
- Add `bench track` CLI subgroup with `init`, `add`, `show`, `list`, `pin`, and `unpin` commands
- Uses symlink-based run storage to avoid data duplication

## Test plan
- [x] 41 new tests in `test_bench_tracking.py` covering fingerprinting, series properties, init, add, pin/unpin, load/save, and list
- [x] All 1577 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)