### PR TITLE
feat: optional uv integration for faster venv creation and package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Optional uv integration for faster venv creation and package installation via `--installer` flag (auto/uv/pip).
+- `InstallerBackend` enum, `detect_uv()`, `resolve_installer()`, and `_rewrite_install_command()` in `runner.py`.
+- `install_with_fallback()` for automatic pip fallback when uv install fails.
+- `installer_backend` field on `PackageResult` and in run metadata.
+- `--installer` CLI option on `run`, `bench run`, and `bisect` commands.
 - Scaled registry from ~350 to 1500 packages: 720 active, 362 skip_versions (3.15 blockers), 418 fully skipped, with 86.4% working test harness coverage.
 - 5-tier test directory detection in `_auto_detect_test_dirs()`: standard dirs (`t/`, `spec/`), package-named/internal dirs, monorepo subdirs, root-level test files, and scattered test files in package source.
 - Multi-forge URL normalization via `_normalize_forge_url()` supporting GitHub, GitLab, Bitbucket, and Codeberg.

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -82,6 +82,9 @@ class BenchConfig:
     warm_vs_cold: bool = False  # Run both warm and cold cache, compare
     run_dangerously_as_root: bool = False  # Allow running as root (for containers)
 
+    # Installer backend
+    installer: str = "auto"
+
     # CLI provenance
     cli_args: list[str] = field(default_factory=list)
 

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -536,7 +536,13 @@ class BenchRunner:
         Returns a setup dict with repo_dir, venvs, and durations.
         Returns None if setup fails.
         """
-        from labeille.runner import clone_repo, create_venv, install_package
+        from labeille.runner import (
+            clone_repo,
+            create_venv,
+            install_package,
+            install_with_fallback,
+            resolve_installer,
+        )
 
         setup: dict[str, Any] = {}
 
@@ -563,6 +569,9 @@ class BenchRunner:
         setup["clone_duration"] = time.monotonic() - clone_start
         setup["repo_dir"] = repo_dir
 
+        # Resolve installer backend.
+        installer = resolve_installer(self.config.installer)
+
         # Create a venv per condition.
         venvs: dict[str, Path] = {}
         venvs_base = self.config.venvs_dir or (self.config.output_dir / "venvs")
@@ -579,7 +588,7 @@ class BenchRunner:
                     import shutil
 
                     shutil.rmtree(venv_dir)
-                create_venv(python_path, venv_dir)
+                create_venv(python_path, venv_dir, installer)
             except Exception as exc:  # noqa: BLE001
                 log.error(
                     "Failed to create venv for %s/%s: %s",
@@ -602,13 +611,16 @@ class BenchRunner:
 
             install_start = time.monotonic()
             try:
-                result = install_package(
-                    venv_python,
+                result, actual_backend = install_with_fallback(
+                    python_path,
+                    venv_dir,
                     install_cmd,
-                    cwd=repo_dir,
-                    env=install_env,
-                    timeout=self.config.timeout,
+                    repo_dir,
+                    install_env,
+                    self.config.timeout,
+                    installer,
                 )
+                venv_python = venv_dir / "bin" / "python"  # refresh after possible recreate
                 if hasattr(result, "returncode") and result.returncode != 0:
                     log.error(
                         "Install failed for %s/%s (exit %d)",
@@ -633,6 +645,7 @@ class BenchRunner:
                         cwd=repo_dir,
                         env=install_env,
                         timeout=self.config.timeout,
+                        installer=actual_backend,
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.warning(

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -207,6 +207,13 @@ def bench() -> None:
     default=False,
     help="Allow running as root (for containers). Not recommended.",
 )
+@click.option(
+    "--installer",
+    type=click.Choice(["auto", "uv", "pip"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Package installer backend. 'auto' uses uv if available.",
+)
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def run(  # noqa: PLR0913
     profile_path: str | None,
@@ -237,6 +244,7 @@ def run(  # noqa: PLR0913
     drop_caches: bool,
     warm_vs_cold: bool,
     run_dangerously_as_root: bool,
+    installer: str,
     env_pairs: tuple[str, ...],
     verbose: bool,
 ) -> None:
@@ -335,6 +343,7 @@ def run(  # noqa: PLR0913
             k, v = pair.split("=", 1)
             config.default_env[k] = v
 
+    config.installer = installer
     config.check_stability = check_stability
     config.wait_for_stability = wait_for_stability
     config.per_test_timing = per_test_timing

--- a/src/labeille/bisect.py
+++ b/src/labeille/bisect.py
@@ -14,7 +14,14 @@ from pathlib import Path
 
 from labeille.crash import detect_crash
 from labeille.logging import get_logger
-from labeille.runner import _clean_env, create_venv, install_package, run_test_command
+from labeille.runner import (
+    _clean_env,
+    create_venv,
+    install_package,
+    install_with_fallback,
+    resolve_installer,
+    run_test_command,
+)
 
 log = get_logger("bisect")
 
@@ -41,6 +48,7 @@ class BisectConfig:
     env_overrides: dict[str, str] = field(default_factory=dict)
     work_dir: Path | None = None
     verbose: bool = False
+    installer: str = "auto"
 
 
 @dataclass
@@ -186,11 +194,14 @@ def test_revision(repo_dir: Path, commit: str, config: BisectConfig) -> BisectSt
         check=False,
     )
 
+    # Resolve installer backend.
+    installer = resolve_installer(config.installer)
+
     # Create a fresh venv for this revision.
     with tempfile.TemporaryDirectory(prefix=f"bisect-{short}-") as venv_str:
         venv_path = Path(venv_str)
         try:
-            create_venv(config.target_python, venv_path)
+            create_venv(config.target_python, venv_path, installer)
         except (subprocess.CalledProcessError, OSError) as exc:
             return BisectStep(
                 commit=commit,
@@ -212,9 +223,16 @@ def test_revision(repo_dir: Path, commit: str, config: BisectConfig) -> BisectSt
         # Install the package.
         install_cmd = config.install_command or "pip install -e ."
         try:
-            install_result = install_package(
-                venv_python, install_cmd, cwd=repo_dir, env=env, timeout=config.timeout
+            install_result, installer = install_with_fallback(
+                config.target_python,
+                venv_path,
+                install_cmd,
+                repo_dir,
+                env,
+                config.timeout,
+                installer,
             )
+            venv_python = venv_path / "bin" / "python"  # refresh after possible recreate
             if install_result.returncode != 0:
                 stderr_tail = (install_result.stderr or "").strip()[-200:]
                 return BisectStep(
@@ -238,7 +256,12 @@ def test_revision(repo_dir: Path, commit: str, config: BisectConfig) -> BisectSt
             extra_cmd = f"pip install {' '.join(config.extra_deps)}"
             try:
                 install_package(
-                    venv_python, extra_cmd, cwd=repo_dir, env=env, timeout=config.timeout
+                    venv_python,
+                    extra_cmd,
+                    cwd=repo_dir,
+                    env=env,
+                    timeout=config.timeout,
+                    installer=installer,
                 )
             except (subprocess.TimeoutExpired, OSError):
                 pass

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -257,6 +257,13 @@ def resolve(
     show_default=True,
     help="Number of packages to test in parallel.",
 )
+@click.option(
+    "--installer",
+    type=click.Choice(["auto", "uv", "pip"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Package installer backend. 'auto' uses uv if available.",
+)
 @click.pass_context
 def run_cmd(
     ctx: click.Context,
@@ -288,6 +295,7 @@ def run_cmd(
     no_shallow: bool,
     work_dir: Path | None,
     workers: int,
+    installer: str,
 ) -> None:
     """Run test suites against a JIT-enabled Python build and detect crashes."""
     from datetime import datetime, timezone
@@ -401,6 +409,7 @@ def run_cmd(
         test_command_override=test_command_override,
         test_command_suffix=test_command_suffix,
         repo_overrides=repo_overrides,
+        installer=installer,
     )
 
     click.echo(f"Run ID: {run_id}")
@@ -658,6 +667,13 @@ def _print_human_format(result: "ScanResult", install_command: str | None) -> No
     help="Persistent work directory for clones (default: temp dir).",
 )
 @click.option("-v", "--verbose", is_flag=True)
+@click.option(
+    "--installer",
+    type=click.Choice(["auto", "uv", "pip"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Package installer backend. 'auto' uses uv if available.",
+)
 def bisect_cmd(
     package: str,
     good_rev: str,
@@ -672,6 +688,7 @@ def bisect_cmd(
     env_pairs: tuple[str, ...],
     work_dir: Path | None,
     verbose: bool,
+    installer: str,
 ) -> None:
     """Bisect a package's git history to find the first commit that introduced a crash."""
     from labeille.bisect import BisectConfig, run_bisect
@@ -704,6 +721,7 @@ def bisect_cmd(
         env_overrides=env_overrides,
         work_dir=work_dir,
         verbose=verbose,
+        installer=installer,
     )
 
     click.echo(f"Bisecting {package}: good={good_rev} bad={bad_rev}")

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -14,6 +14,7 @@ the results including any crashes (segfaults, aborts, assertion failures).
 
 from __future__ import annotations
 
+import enum
 import json
 import os
 import platform
@@ -34,6 +35,51 @@ from labeille.logging import get_logger
 from labeille.registry import Index, PackageEntry, load_index, load_package, package_exists
 
 log = get_logger("runner")
+
+
+# ---------------------------------------------------------------------------
+# Installer backend
+# ---------------------------------------------------------------------------
+
+
+class InstallerBackend(enum.Enum):
+    """Package installer backend."""
+
+    PIP = "pip"
+    UV = "uv"
+
+
+def detect_uv() -> str | None:
+    """Return the path to uv if available on PATH, else None."""
+    return shutil.which("uv")
+
+
+def resolve_installer(preference: str = "auto") -> InstallerBackend:
+    """Resolve the installer backend from a preference string.
+
+    Args:
+        preference: One of ``"auto"``, ``"uv"``, or ``"pip"``.
+
+    Returns:
+        The resolved backend.
+
+    Raises:
+        RuntimeError: If ``"uv"`` is requested but not found.
+    """
+    pref = preference.lower().strip()
+    if pref == "pip":
+        return InstallerBackend.PIP
+    if pref == "uv":
+        if detect_uv() is None:
+            raise RuntimeError(
+                "uv requested as installer but not found on PATH. "
+                "Install it: https://docs.astral.sh/uv/getting-started/installation/"
+            )
+        return InstallerBackend.UV
+    # auto: use uv if available, else pip.
+    if detect_uv() is not None:
+        return InstallerBackend.UV
+    return InstallerBackend.PIP
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +119,7 @@ class RunnerConfig:
     test_command_override: str | None = None
     test_command_suffix: str | None = None
     repo_overrides: dict[str, str] = field(default_factory=dict)
+    installer: str = "auto"
 
 
 @dataclass
@@ -95,6 +142,7 @@ class PackageResult:
     installed_dependencies: dict[str, str] = field(default_factory=dict)
     error_message: str | None = None
     requested_revision: str | None = None
+    installer_backend: str = ""
     timestamp: str = ""
 
 
@@ -161,6 +209,8 @@ def write_run_meta(
         "env_overrides": config.env_overrides,
         "hostname": socket.gethostname(),
         "platform": platform.platform(),
+        "installer": config.installer,
+        "uv_available": detect_uv() is not None,
     }
     if summary is not None:
         meta["packages_tested"] = summary.tested
@@ -189,6 +239,7 @@ def append_result(run_dir: Path, result: PackageResult) -> None:
         "installed_dependencies": result.installed_dependencies,
         "error_message": result.error_message,
         "requested_revision": result.requested_revision,
+        "installer_backend": result.installer_backend,
         "timestamp": result.timestamp,
     }
     with open(run_dir / "results.jsonl", "a", encoding="utf-8") as f:
@@ -440,12 +491,34 @@ def pull_repo(dest: Path) -> str | None:
     return None
 
 
-def create_venv(python_path: Path, venv_dir: Path) -> None:
+def create_venv(
+    python_path: Path,
+    venv_dir: Path,
+    installer: InstallerBackend = InstallerBackend.PIP,
+) -> None:
     """Create a virtual environment using the target Python.
+
+    When *installer* is :attr:`InstallerBackend.UV`, uv creates the venv
+    directly (no ensurepip step).  Otherwise falls back to ``python -m venv``
+    with ensurepip.
 
     Raises:
         subprocess.CalledProcessError: If venv creation fails.
     """
+    if installer is InstallerBackend.UV:
+        uv_path = detect_uv()
+        if uv_path:
+            log.debug("Running: %s venv --python %s %s", uv_path, python_path, venv_dir)
+            subprocess.run(
+                [uv_path, "venv", "--python", str(python_path), str(venv_dir)],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=True,
+                env=_clean_env(ASAN_OPTIONS="detect_leaks=0"),
+            )
+            return
+
     log.debug("Running: %s -m venv %s", python_path, venv_dir)
     subprocess.run(
         [str(python_path), "-m", "venv", str(venv_dir)],
@@ -528,26 +601,33 @@ def _run_in_process_group(
         raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
 
 
-def install_package(
-    venv_python: Path,
+def _rewrite_install_command(
     install_command: str,
-    cwd: Path,
-    env: dict[str, str],
-    timeout: int,
-) -> subprocess.CompletedProcess[str]:
-    """Install a package in the venv.
+    venv_python: Path,
+    installer: InstallerBackend = InstallerBackend.PIP,
+) -> str:
+    """Rewrite an install command for the given backend.
 
-    The *install_command* is interpreted as a shell command with ``pip`` and
-    ``python`` replaced by the venv paths.  Runs in its own process group
-    so the entire process tree is killed on timeout.
-
-    Returns:
-        The completed process.
+    For pip: replaces ``pip`` and ``python`` with venv-local paths.
+    For uv: rewrites ``pip install`` to ``uv pip install --python <path>``.
     """
     venv_bin = venv_python.parent
-    venv_pip = venv_bin / "pip"
-
     cmd = install_command
+
+    if installer is InstallerBackend.UV:
+        uv_path = detect_uv()
+        if uv_path:
+            # Replace "python " with venv python FIRST (before introducing --python).
+            cmd = cmd.replace("python ", f"{venv_python} ")
+            # Replace "pip install" with "uv pip install --python <venv_python>"
+            cmd = cmd.replace("pip install", f"{uv_path} pip install --python {venv_python}")
+            # Replace standalone "pip " at the start
+            if cmd.startswith("pip "):
+                cmd = f"{uv_path} pip --python {venv_python} {cmd[4:]}"
+            return cmd
+
+    # pip path.
+    venv_pip = venv_bin / "pip"
     cmd = cmd.replace("pip install", f"{venv_pip} install")
     cmd = cmd.replace("python ", f"{venv_python} ")
 
@@ -555,6 +635,28 @@ def install_package(
     if cmd.startswith("pip "):
         cmd = f"{venv_pip} {cmd[4:]}"
 
+    return cmd
+
+
+def install_package(
+    venv_python: Path,
+    install_command: str,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    installer: InstallerBackend = InstallerBackend.PIP,
+) -> subprocess.CompletedProcess[str]:
+    """Install a package in the venv.
+
+    The *install_command* is interpreted as a shell command with ``pip`` and
+    ``python`` replaced by the venv paths (or ``uv pip`` when using uv).
+    Runs in its own process group so the entire process tree is killed on
+    timeout.
+
+    Returns:
+        The completed process.
+    """
+    cmd = _rewrite_install_command(install_command, venv_python, installer)
     log.debug("Install command (resolved): %s", cmd)
     return _run_in_process_group(cmd, cwd=str(cwd), env=env, timeout=timeout)
 
@@ -589,11 +691,23 @@ def run_test_command(
     return _run_in_process_group(cmd, cwd=str(cwd), env=run_env, timeout=timeout)
 
 
-def get_installed_packages(venv_python: Path, env: dict[str, str]) -> dict[str, str]:
+def get_installed_packages(
+    venv_python: Path,
+    env: dict[str, str],
+    installer: InstallerBackend = InstallerBackend.PIP,
+) -> dict[str, str]:
     """Get installed packages and versions from the venv."""
     try:
+        if installer is InstallerBackend.UV:
+            uv_path = detect_uv()
+            if uv_path:
+                cmd = [uv_path, "pip", "list", "--python", str(venv_python), "--format=json"]
+            else:
+                cmd = [str(venv_python), "-m", "pip", "list", "--format=json"]
+        else:
+            cmd = [str(venv_python), "-m", "pip", "list", "--format=json"]
         proc = subprocess.run(
-            [str(venv_python), "-m", "pip", "list", "--format=json"],
+            cmd,
             capture_output=True,
             text=True,
             timeout=60,
@@ -617,6 +731,44 @@ def get_package_version(package_name: str, installed: dict[str, str]) -> str | N
         if name.lower().replace("-", "_") == normalised:
             return version
     return None
+
+
+def install_with_fallback(
+    python_path: Path,
+    venv_dir: Path,
+    install_command: str,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    installer: InstallerBackend,
+) -> tuple[subprocess.CompletedProcess[str], InstallerBackend]:
+    """Install a package with automatic fallback from uv to pip.
+
+    If the initial install with the chosen backend fails and the backend
+    is uv, deletes the venv, recreates it with pip, and retries.
+
+    Returns:
+        A tuple of (completed_process, actual_backend_used).
+    """
+    venv_python = venv_dir / "bin" / "python"
+    proc = install_package(venv_python, install_command, cwd, env, timeout, installer)
+
+    if proc.returncode == 0 or installer is InstallerBackend.PIP:
+        return proc, installer
+
+    # uv failed — fall back to pip.
+    log.warning(
+        "uv install failed (exit %d), falling back to pip for %s",
+        proc.returncode,
+        cwd.name,
+    )
+    shutil.rmtree(venv_dir, ignore_errors=True)
+    create_venv(python_path, venv_dir, InstallerBackend.PIP)
+    venv_python = venv_dir / "bin" / "python"
+    pip_proc = install_package(
+        venv_python, install_command, cwd, env, timeout, InstallerBackend.PIP
+    )
+    return pip_proc, InstallerBackend.PIP
 
 
 def check_import(
@@ -922,13 +1074,18 @@ def _run_package_inner(
         shutil.rmtree(venv_dir)
         venv_existed = False
 
+    # Resolve installer backend.
+    installer = resolve_installer(config.installer)
+    result.installer_backend = installer.value
+    log.debug("Installer backend for %s: %s", pkg.package, installer.value)
+
     if venv_existed:
         log.info("Reusing venv for %s at %s", pkg.package, venv_dir)
     else:
         log.info("Creating venv for %s at %s", pkg.package, venv_dir)
         venv_start = time.monotonic()
         try:
-            create_venv(config.target_python, venv_dir)
+            create_venv(config.target_python, venv_dir, installer)
         except (subprocess.CalledProcessError, OSError) as exc:
             result.status = "error"
             result.error_message = f"Venv creation failed: {exc}"
@@ -949,9 +1106,25 @@ def _run_package_inner(
         log.info("Installing %s: %s", pkg.package, install_cmd)
         install_start = time.monotonic()
         try:
-            install_proc = install_package(
-                venv_python, install_cmd, repo_dir, env, per_pkg_timeout
+            install_proc, actual_backend = install_with_fallback(
+                config.target_python,
+                venv_dir,
+                install_cmd,
+                repo_dir,
+                env,
+                per_pkg_timeout,
+                installer,
             )
+            venv_python = venv_dir / "bin" / "python"  # refresh after possible recreate
+            if actual_backend is not installer:
+                result.installer_backend = actual_backend.value
+                log.info(
+                    "Installer fell back from %s to %s for %s",
+                    installer.value,
+                    actual_backend.value,
+                    pkg.package,
+                )
+            installer = actual_backend
         except subprocess.TimeoutExpired:
             result.status = "install_error"
             result.error_message = "Install timed out"
@@ -1011,7 +1184,9 @@ def _run_package_inner(
         extra_cmd = f"pip install {' '.join(config.extra_deps)}"
         log.info("Installing extra deps for %s: %s", pkg.package, extra_cmd)
         try:
-            extra_proc = install_package(venv_python, extra_cmd, repo_dir, env, per_pkg_timeout)
+            extra_proc = install_package(
+                venv_python, extra_cmd, repo_dir, env, per_pkg_timeout, installer
+            )
             if extra_proc.returncode != 0:
                 log.warning(
                     "Extra deps install failed for %s (exit %d, non-fatal)",
@@ -1022,7 +1197,7 @@ def _run_package_inner(
             log.warning("Failed to install extra deps for %s: %s", pkg.package, exc)
 
     # --- Collect installed packages ---
-    result.installed_dependencies = get_installed_packages(venv_python, env)
+    result.installed_dependencies = get_installed_packages(venv_python, env, installer)
     result.package_version = get_package_version(pkg.package, result.installed_dependencies)
     if result.installed_dependencies:
         dep_count = len(result.installed_dependencies)

--- a/tests/test_bisect.py
+++ b/tests/test_bisect.py
@@ -17,6 +17,7 @@ from labeille.bisect import (
     run_bisect,
     test_revision,
 )
+from labeille.runner import InstallerBackend
 
 
 class TestLog2(unittest.TestCase):
@@ -136,7 +137,7 @@ class TestTestRevision(unittest.TestCase):
 
     @patch("labeille.bisect.detect_crash")
     @patch("labeille.bisect.run_test_command")
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_good_revision_no_crash(
@@ -151,8 +152,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="", stderr=""
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            InstallerBackend.PIP,
         )
         mock_test.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
@@ -166,7 +168,7 @@ class TestTestRevision(unittest.TestCase):
 
     @patch("labeille.bisect.detect_crash")
     @patch("labeille.bisect.run_test_command")
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_bad_revision_with_crash(
@@ -180,8 +182,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="", stderr=""
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            InstallerBackend.PIP,
         )
         mock_test.return_value = subprocess.CompletedProcess(
             args=[], returncode=-11, stdout="", stderr="Segmentation fault"
@@ -197,7 +200,7 @@ class TestTestRevision(unittest.TestCase):
 
     @patch("labeille.bisect.detect_crash")
     @patch("labeille.bisect.run_test_command")
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_crash_signature_mismatch_returns_good(
@@ -211,8 +214,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="", stderr=""
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            InstallerBackend.PIP,
         )
         mock_test.return_value = subprocess.CompletedProcess(
             args=[], returncode=-11, stdout="", stderr="Segmentation fault"
@@ -228,7 +232,7 @@ class TestTestRevision(unittest.TestCase):
 
     @patch("labeille.bisect.detect_crash")
     @patch("labeille.bisect.run_test_command")
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_crash_signature_match_returns_bad(
@@ -242,8 +246,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="", stderr=""
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            InstallerBackend.PIP,
         )
         mock_test.return_value = subprocess.CompletedProcess(
             args=[], returncode=-11, stdout="", stderr="Segmentation fault"
@@ -256,7 +261,7 @@ class TestTestRevision(unittest.TestCase):
         step = test_revision(Path("/repo"), "abc1234567890", config)
         self.assertEqual(step.status, "bad")
 
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_install_failure_returns_skip(
@@ -268,8 +273,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="", stderr="install error"
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="install error"),
+            InstallerBackend.PIP,
         )
 
         config = self._make_config()
@@ -277,7 +283,7 @@ class TestTestRevision(unittest.TestCase):
         self.assertEqual(step.status, "skip")
         self.assertIn("install failed", step.detail)
 
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_install_timeout_returns_skip(
@@ -314,7 +320,7 @@ class TestTestRevision(unittest.TestCase):
         self.assertIn("venv creation failed", step.detail)
 
     @patch("labeille.bisect.run_test_command")
-    @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_test_timeout_returns_skip(
@@ -327,8 +333,9 @@ class TestTestRevision(unittest.TestCase):
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        mock_install.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="", stderr=""
+        mock_install.return_value = (
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            InstallerBackend.PIP,
         )
         mock_test.side_effect = subprocess.TimeoutExpired(cmd="pytest", timeout=600)
 
@@ -338,23 +345,29 @@ class TestTestRevision(unittest.TestCase):
         self.assertIn("tests timed out", step.detail)
 
     @patch("labeille.bisect.install_package")
+    @patch("labeille.bisect.install_with_fallback")
     @patch("labeille.bisect.create_venv")
     @patch("labeille.bisect.subprocess.run")
     def test_extra_deps_installed(
         self,
         mock_run: MagicMock,
         mock_create_venv: MagicMock,
+        mock_fallback: MagicMock,
         mock_install: MagicMock,
     ) -> None:
         """Extra deps are installed after the main package."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        # First call: main install succeeds. Second call: extra deps.
-        mock_install.side_effect = [
+        # Main install via install_with_fallback.
+        mock_fallback.return_value = (
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
-        ]
+            InstallerBackend.PIP,
+        )
+        # Extra deps via install_package.
+        mock_install.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
 
         with (
             patch("labeille.bisect.run_test_command") as mock_test,
@@ -368,10 +381,11 @@ class TestTestRevision(unittest.TestCase):
             config = self._make_config(extra_deps=["pytest-xdist", "coverage"])
             test_revision(Path("/repo"), "abc1234567890", config)
 
-        self.assertEqual(mock_install.call_count, 2)
-        extra_call = mock_install.call_args_list[1]
-        self.assertIn("pytest-xdist", extra_call.args[1])
-        self.assertIn("coverage", extra_call.args[1])
+        mock_fallback.assert_called_once()
+        mock_install.assert_called_once()
+        extra_call_cmd = mock_install.call_args
+        self.assertIn("pytest-xdist", extra_call_cmd.args[1])
+        self.assertIn("coverage", extra_call_cmd.args[1])
 
 
 class TestTryNeighbors(unittest.TestCase):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,374 @@
+"""Tests for installer backend integration (uv/pip)."""
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from labeille.runner import (
+    InstallerBackend,
+    PackageResult,
+    RunnerConfig,
+    _rewrite_install_command,
+    create_venv,
+    detect_uv,
+    get_installed_packages,
+    install_package,
+    install_with_fallback,
+    resolve_installer,
+)
+
+
+class TestDetectUv(unittest.TestCase):
+    """Tests for detect_uv()."""
+
+    @patch("labeille.runner.shutil.which")
+    def test_found(self, mock_which: MagicMock) -> None:
+        mock_which.return_value = "/usr/local/bin/uv"
+        self.assertEqual(detect_uv(), "/usr/local/bin/uv")
+        mock_which.assert_called_once_with("uv")
+
+    @patch("labeille.runner.shutil.which")
+    def test_not_found(self, mock_which: MagicMock) -> None:
+        mock_which.return_value = None
+        self.assertIsNone(detect_uv())
+
+
+class TestResolveInstaller(unittest.TestCase):
+    """Tests for resolve_installer()."""
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    def test_auto_with_uv(self, _mock: MagicMock) -> None:
+        self.assertEqual(resolve_installer("auto"), InstallerBackend.UV)
+
+    @patch("labeille.runner.detect_uv", return_value=None)
+    def test_auto_without_uv(self, _mock: MagicMock) -> None:
+        self.assertEqual(resolve_installer("auto"), InstallerBackend.PIP)
+
+    def test_pip_explicit(self) -> None:
+        self.assertEqual(resolve_installer("pip"), InstallerBackend.PIP)
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    def test_uv_explicit(self, _mock: MagicMock) -> None:
+        self.assertEqual(resolve_installer("uv"), InstallerBackend.UV)
+
+    @patch("labeille.runner.detect_uv", return_value=None)
+    def test_uv_explicit_not_found(self, _mock: MagicMock) -> None:
+        with self.assertRaises(RuntimeError):
+            resolve_installer("uv")
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    def test_case_insensitive(self, _mock: MagicMock) -> None:
+        self.assertEqual(resolve_installer("UV"), InstallerBackend.UV)
+        self.assertEqual(resolve_installer("Pip"), InstallerBackend.PIP)
+        self.assertEqual(resolve_installer("AUTO"), InstallerBackend.UV)
+
+
+class TestRewriteInstallCommand(unittest.TestCase):
+    """Tests for _rewrite_install_command()."""
+
+    def test_pip_basic(self) -> None:
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command("pip install -e .", venv_python, InstallerBackend.PIP)
+        self.assertIn("/venv/bin/pip", result)
+        self.assertIn("install -e .", result)
+
+    def test_pip_python_prefix(self) -> None:
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command(
+            "python -m pip install foo", venv_python, InstallerBackend.PIP
+        )
+        self.assertIn("/venv/bin/python", result)
+
+    def test_pip_standalone(self) -> None:
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command("pip list", venv_python, InstallerBackend.PIP)
+        self.assertIn("/venv/bin/pip", result)
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    def test_uv_basic(self, _mock: MagicMock) -> None:
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command("pip install -e .", venv_python, InstallerBackend.UV)
+        self.assertIn("/usr/bin/uv", result)
+        self.assertIn("pip install", result)
+        self.assertIn("--python", result)
+        self.assertIn("/venv/bin/python", result)
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    def test_uv_standalone_pip(self, _mock: MagicMock) -> None:
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command("pip list", venv_python, InstallerBackend.UV)
+        self.assertIn("/usr/bin/uv", result)
+        self.assertIn("--python", result)
+
+    @patch("labeille.runner.detect_uv", return_value=None)
+    def test_uv_fallback_to_pip_when_not_found(self, _mock: MagicMock) -> None:
+        """When UV is selected but detect_uv returns None, falls back to pip-style rewrite."""
+        venv_python = Path("/venv/bin/python")
+        result = _rewrite_install_command("pip install -e .", venv_python, InstallerBackend.UV)
+        self.assertIn("/venv/bin/pip", result)
+
+    def test_compound_command(self) -> None:
+        venv_python = Path("/venv/bin/python")
+        cmd = "pip install -e . && pip install pytest"
+        result = _rewrite_install_command(cmd, venv_python, InstallerBackend.PIP)
+        self.assertIn("/venv/bin/pip install -e .", result)
+        self.assertIn("/venv/bin/pip install pytest", result)
+
+
+class TestCreateVenvInstaller(unittest.TestCase):
+    """Tests for create_venv() with installer parameter."""
+
+    @patch("labeille.runner.subprocess.run")
+    def test_pip_backend(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        create_venv(Path("/usr/bin/python3"), Path("/tmp/venv"), InstallerBackend.PIP)
+        # Should call python -m venv and ensurepip.
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIn("-m", calls[0][0][0])
+        self.assertIn("venv", calls[0][0][0])
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    @patch("labeille.runner.subprocess.run")
+    def test_uv_backend(self, mock_run: MagicMock, _mock_uv: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        create_venv(Path("/usr/bin/python3"), Path("/tmp/venv"), InstallerBackend.UV)
+        # Should call uv venv only (no ensurepip).
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0][0][0], "/usr/bin/uv")
+        self.assertEqual(calls[0][0][0][1], "venv")
+
+    @patch("labeille.runner.detect_uv", return_value=None)
+    @patch("labeille.runner.subprocess.run")
+    def test_uv_backend_falls_back_when_not_found(
+        self, mock_run: MagicMock, _mock_uv: MagicMock
+    ) -> None:
+        """When UV is selected but uv binary not found, falls back to python -m venv."""
+        mock_run.return_value = MagicMock(returncode=0)
+        create_venv(Path("/usr/bin/python3"), Path("/tmp/venv"), InstallerBackend.UV)
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 2)  # venv + ensurepip
+
+    @patch("labeille.runner.subprocess.run")
+    def test_default_is_pip(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        create_venv(Path("/usr/bin/python3"), Path("/tmp/venv"))
+        calls = mock_run.call_args_list
+        self.assertEqual(len(calls), 2)  # venv + ensurepip
+
+
+class TestInstallPackageInstaller(unittest.TestCase):
+    """Tests for install_package() with installer parameter."""
+
+    @patch("labeille.runner._run_in_process_group")
+    def test_pip_backend(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        install_package(
+            Path("/venv/bin/python"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.PIP,
+        )
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/venv/bin/pip", cmd)
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    @patch("labeille.runner._run_in_process_group")
+    def test_uv_backend(self, mock_run: MagicMock, _mock_uv: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        install_package(
+            Path("/venv/bin/python"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.UV,
+        )
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/usr/bin/uv", cmd)
+        self.assertIn("--python", cmd)
+
+    @patch("labeille.runner._run_in_process_group")
+    def test_default_is_pip(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        install_package(
+            Path("/venv/bin/python"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+        )
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/venv/bin/pip", cmd)
+
+
+class TestGetInstalledPackagesInstaller(unittest.TestCase):
+    """Tests for get_installed_packages() with installer parameter."""
+
+    @patch("labeille.runner.subprocess.run")
+    def test_pip_backend(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='[{"name": "requests", "version": "2.31.0"}]',
+        )
+        result = get_installed_packages(Path("/venv/bin/python"), {}, InstallerBackend.PIP)
+        self.assertEqual(result, {"requests": "2.31.0"})
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("-m", cmd)
+        self.assertIn("pip", cmd)
+
+    @patch("labeille.runner.detect_uv", return_value="/usr/bin/uv")
+    @patch("labeille.runner.subprocess.run")
+    def test_uv_backend(self, mock_run: MagicMock, _mock_uv: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='[{"name": "requests", "version": "2.31.0"}]',
+        )
+        result = get_installed_packages(Path("/venv/bin/python"), {}, InstallerBackend.UV)
+        self.assertEqual(result, {"requests": "2.31.0"})
+        cmd = mock_run.call_args[0][0]
+        self.assertEqual(cmd[0], "/usr/bin/uv")
+
+    @patch("labeille.runner.subprocess.run")
+    def test_default_is_pip(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='[{"name": "foo", "version": "1.0"}]',
+        )
+        result = get_installed_packages(Path("/venv/bin/python"), {})
+        self.assertEqual(result, {"foo": "1.0"})
+
+
+class TestInstallWithFallback(unittest.TestCase):
+    """Tests for install_with_fallback()."""
+
+    @patch("labeille.runner.install_package")
+    def test_pip_success(self, mock_install: MagicMock) -> None:
+        mock_install.return_value = MagicMock(returncode=0)
+        proc, backend = install_with_fallback(
+            Path("/usr/bin/python3"),
+            Path("/tmp/venv"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.PIP,
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(backend, InstallerBackend.PIP)
+
+    @patch("labeille.runner.install_package")
+    def test_pip_failure_no_fallback(self, mock_install: MagicMock) -> None:
+        mock_install.return_value = MagicMock(returncode=1)
+        proc, backend = install_with_fallback(
+            Path("/usr/bin/python3"),
+            Path("/tmp/venv"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.PIP,
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertEqual(backend, InstallerBackend.PIP)
+
+    @patch("labeille.runner.install_package")
+    def test_uv_success(self, mock_install: MagicMock) -> None:
+        mock_install.return_value = MagicMock(returncode=0)
+        proc, backend = install_with_fallback(
+            Path("/usr/bin/python3"),
+            Path("/tmp/venv"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.UV,
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(backend, InstallerBackend.UV)
+
+    @patch("labeille.runner.create_venv")
+    @patch("labeille.runner.shutil.rmtree")
+    @patch("labeille.runner.install_package")
+    def test_uv_failure_falls_back_to_pip(
+        self,
+        mock_install: MagicMock,
+        mock_rmtree: MagicMock,
+        mock_create_venv: MagicMock,
+    ) -> None:
+        # First call (uv) fails, second call (pip) succeeds.
+        mock_install.side_effect = [
+            MagicMock(returncode=1, stderr="uv error"),
+            MagicMock(returncode=0),
+        ]
+        proc, backend = install_with_fallback(
+            Path("/usr/bin/python3"),
+            Path("/tmp/venv"),
+            "pip install -e .",
+            Path("/repo"),
+            {},
+            600,
+            InstallerBackend.UV,
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(backend, InstallerBackend.PIP)
+        mock_rmtree.assert_called_once()
+        mock_create_venv.assert_called_once_with(
+            Path("/usr/bin/python3"),
+            Path("/tmp/venv"),
+            InstallerBackend.PIP,
+        )
+
+
+class TestPackageResultInstaller(unittest.TestCase):
+    """Tests for installer_backend field on PackageResult."""
+
+    def test_default_empty(self) -> None:
+        r = PackageResult(package="test")
+        self.assertEqual(r.installer_backend, "")
+
+    def test_set_value(self) -> None:
+        r = PackageResult(package="test", installer_backend="uv")
+        self.assertEqual(r.installer_backend, "uv")
+
+
+class TestRunnerConfigInstaller(unittest.TestCase):
+    """Tests for installer field on RunnerConfig."""
+
+    def test_default_auto(self) -> None:
+        config = RunnerConfig(
+            target_python=Path("/usr/bin/python3"),
+            registry_dir=Path("/tmp/registry"),
+            results_dir=Path("/tmp/results"),
+            run_id="test",
+        )
+        self.assertEqual(config.installer, "auto")
+
+    def test_set_value(self) -> None:
+        config = RunnerConfig(
+            target_python=Path("/usr/bin/python3"),
+            registry_dir=Path("/tmp/registry"),
+            results_dir=Path("/tmp/results"),
+            run_id="test",
+            installer="uv",
+        )
+        self.assertEqual(config.installer, "uv")
+
+
+class TestInstallerBackendEnum(unittest.TestCase):
+    """Tests for InstallerBackend enum."""
+
+    def test_values(self) -> None:
+        self.assertEqual(InstallerBackend.PIP.value, "pip")
+        self.assertEqual(InstallerBackend.UV.value, "uv")
+
+    def test_members(self) -> None:
+        self.assertIn("PIP", InstallerBackend.__members__)
+        self.assertIn("UV", InstallerBackend.__members__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `InstallerBackend` enum (PIP/UV) with `detect_uv()`, `resolve_installer()`, and `_rewrite_install_command()` for transparent backend switching
- `install_with_fallback()` automatically falls back from uv to pip when uv install fails (deletes and recreates venv with pip)
- `--installer` CLI option (auto/uv/pip) on `run`, `bench run`, and `bisect` commands; `installer_backend` recorded in `PackageResult` and run metadata

## Test plan
- [x] All 1708 tests pass
- [x] ruff format and check pass
- [x] mypy strict mode passes
- [x] 35 new tests in `tests/test_installer.py` covering detect_uv, resolve_installer, _rewrite_install_command, create_venv, install_package, get_installed_packages, install_with_fallback, PackageResult, RunnerConfig, InstallerBackend
- [x] Updated bisect tests for install_with_fallback integration

Closes #104

Generated with [Claude Code](https://claude.com/claude-code)