### PR TITLE
feat: add compat command group for C extension compatibility surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `labeille compat` command group for C extension compatibility surveys: `survey`, `show`, `diff`, and `patterns` subcommands.
+- ~30 built-in error classification patterns across 10+ categories (removed_c_api, cython_incompatible, pyo3_incompatible, numpy_c_api, missing_system_lib, etc.).
+- YAML-based custom error pattern support with override semantics.
+- Survey diff for tracking regressions and fixes between Python versions.
+- Markdown export for sharing compatibility survey results.
 - Optional uv integration for faster venv creation and package installation via `--installer` flag (auto/uv/pip).
 - `InstallerBackend` enum, `detect_uv()`, `resolve_installer()`, and `_rewrite_install_command()` in `runner.py`.
 - `install_with_fallback()` for automatic pip fallback when uv install fails.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -44,6 +44,10 @@ from labeille.ft_cli import ft as ft_group  # noqa: E402
 
 main.add_command(ft_group)
 
+from labeille.compat_cli import compat as compat_group  # noqa: E402
+
+main.add_command(compat_group)
+
 
 @main.command()
 @click.argument("packages", nargs=-1)

--- a/src/labeille/compat.py
+++ b/src/labeille/compat.py
@@ -1,0 +1,1244 @@
+"""C extension compatibility survey.
+
+Attempts to build packages against a target Python, captures full build
+output, classifies failures into fine-grained categories, and produces
+clustered reports. Works on arbitrary PyPI packages, not just those in
+the labeille registry.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from labeille.crash import detect_crash
+from labeille.logging import get_logger
+from labeille.runner import (
+    InstallerBackend,
+    _clean_env,
+    check_import,
+    clone_repo,
+    install_with_fallback,
+    pull_repo,
+    resolve_installer,
+    validate_target_python,
+)
+
+log = get_logger("compat")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ErrorPattern:
+    """A pattern that identifies a specific build failure category."""
+
+    category: str
+    subcategory: str
+    pattern: re.Pattern[str]
+    description: str
+    since: str
+
+
+@dataclass
+class ErrorMatch:
+    """A single matched error pattern in a build log."""
+
+    category: str
+    subcategory: str
+    description: str
+    since: str
+    matched_line: str
+    line_number: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize."""
+        return {
+            "category": self.category,
+            "subcategory": self.subcategory,
+            "description": self.description,
+            "since": self.since,
+            "matched_line": self.matched_line,
+            "line_number": self.line_number,
+        }
+
+
+@dataclass
+class CompatPackageInput:
+    """A package to survey, with optional metadata from the registry."""
+
+    name: str
+    repo_url: str | None = None
+    install_command: str | None = None
+    import_name: str | None = None
+    extension_type: str = "unknown"
+    source: str = ""
+
+
+@dataclass
+class CompatResult:
+    """Result of attempting to build a single package."""
+
+    package: str
+    status: str
+    exit_code: int | None = None
+    duration_seconds: float = 0.0
+    error_matches: list[ErrorMatch] = field(default_factory=list)
+    primary_category: str = ""
+    primary_subcategory: str = ""
+    primary_description: str = ""
+    import_error: str = ""
+    crash_signature: str = ""
+    extension_type: str = "unknown"
+    source: str = ""
+    from_mode: str = ""
+    repo_url: str | None = None
+    installer_used: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSONL. Sparse: omits None/empty/default values."""
+        d: dict[str, Any] = {"package": self.package, "status": self.status}
+        if self.exit_code is not None:
+            d["exit_code"] = self.exit_code
+        if self.duration_seconds:
+            d["duration_seconds"] = self.duration_seconds
+        if self.error_matches:
+            d["error_matches"] = [m.to_dict() for m in self.error_matches]
+        if self.primary_category:
+            d["primary_category"] = self.primary_category
+        if self.primary_subcategory:
+            d["primary_subcategory"] = self.primary_subcategory
+        if self.primary_description:
+            d["primary_description"] = self.primary_description
+        if self.import_error:
+            d["import_error"] = self.import_error
+        if self.crash_signature:
+            d["crash_signature"] = self.crash_signature
+        if self.extension_type != "unknown":
+            d["extension_type"] = self.extension_type
+        if self.source:
+            d["source"] = self.source
+        if self.from_mode:
+            d["from_mode"] = self.from_mode
+        if self.repo_url:
+            d["repo_url"] = self.repo_url
+        if self.installer_used:
+            d["installer_used"] = self.installer_used
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CompatResult:
+        """Deserialize from JSONL dict."""
+        matches = [ErrorMatch(**m) for m in d.get("error_matches", [])]
+        return cls(
+            package=d["package"],
+            status=d["status"],
+            exit_code=d.get("exit_code"),
+            duration_seconds=d.get("duration_seconds", 0.0),
+            error_matches=matches,
+            primary_category=d.get("primary_category", ""),
+            primary_subcategory=d.get("primary_subcategory", ""),
+            primary_description=d.get("primary_description", ""),
+            import_error=d.get("import_error", ""),
+            crash_signature=d.get("crash_signature", ""),
+            extension_type=d.get("extension_type", "unknown"),
+            source=d.get("source", ""),
+            from_mode=d.get("from_mode", ""),
+            repo_url=d.get("repo_url"),
+            installer_used=d.get("installer_used", ""),
+        )
+
+
+@dataclass
+class CompatMeta:
+    """Survey-level metadata."""
+
+    survey_id: str
+    target_python: str
+    python_version: str
+    from_mode: str
+    no_binary_all: bool
+    started_at: str
+    finished_at: str
+    total_packages: int
+    installer_preference: str
+    extra_patterns_file: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "survey_id": self.survey_id,
+            "target_python": self.target_python,
+            "python_version": self.python_version,
+            "from_mode": self.from_mode,
+            "no_binary_all": self.no_binary_all,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "total_packages": self.total_packages,
+            "installer_preference": self.installer_preference,
+        }
+        if self.extra_patterns_file:
+            d["extra_patterns_file"] = self.extra_patterns_file
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CompatMeta:
+        return cls(
+            survey_id=d["survey_id"],
+            target_python=d["target_python"],
+            python_version=d["python_version"],
+            from_mode=d["from_mode"],
+            no_binary_all=d.get("no_binary_all", False),
+            started_at=d["started_at"],
+            finished_at=d.get("finished_at", ""),
+            total_packages=d.get("total_packages", 0),
+            installer_preference=d.get("installer_preference", "auto"),
+            extra_patterns_file=d.get("extra_patterns_file"),
+        )
+
+
+@dataclass
+class CompatSurvey:
+    """Loaded survey with metadata and results."""
+
+    meta: CompatMeta
+    results: list[CompatResult]
+
+    @property
+    def by_status(self) -> dict[str, list[CompatResult]]:
+        """Group results by status."""
+        groups: dict[str, list[CompatResult]] = {}
+        for r in self.results:
+            groups.setdefault(r.status, []).append(r)
+        return groups
+
+    @property
+    def by_category(self) -> dict[str, list[CompatResult]]:
+        """Group build failures by primary_category."""
+        groups: dict[str, list[CompatResult]] = {}
+        for r in self.results:
+            if r.primary_category:
+                groups.setdefault(r.primary_category, []).append(r)
+        return groups
+
+    @property
+    def by_subcategory(self) -> dict[str, list[CompatResult]]:
+        """Group by 'category/subcategory' string."""
+        groups: dict[str, list[CompatResult]] = {}
+        for r in self.results:
+            if r.primary_category and r.primary_subcategory:
+                key = f"{r.primary_category}/{r.primary_subcategory}"
+                groups.setdefault(key, []).append(r)
+        return groups
+
+    @property
+    def summary_counts(self) -> dict[str, int]:
+        """Status -> count."""
+        counts: dict[str, int] = {}
+        for r in self.results:
+            counts[r.status] = counts.get(r.status, 0) + 1
+        return counts
+
+
+# ---------------------------------------------------------------------------
+# Error classification engine — built-in patterns
+# ---------------------------------------------------------------------------
+
+
+def _p(category: str, subcategory: str, since: str, regex: str, description: str) -> ErrorPattern:
+    """Shorthand for building ErrorPattern with compiled regex."""
+    return ErrorPattern(
+        category=category,
+        subcategory=subcategory,
+        pattern=re.compile(regex, re.IGNORECASE),
+        description=description,
+        since=since,
+    )
+
+
+_BUILTIN_PATTERNS: list[ErrorPattern] = [
+    # --- python_header (environment issue) ---
+    _p(
+        "python_header",
+        "python_h_missing",
+        "",
+        r"(?:fatal error.*Python\.h|Python\.h.*no such file)",
+        "Python.h not found — Python dev headers missing",
+    ),
+    # --- removed_c_api ---
+    _p(
+        "removed_c_api",
+        "PyUnicode_READY",
+        "3.12",
+        r"(?:error|implicit|undeclared|undefined).*\bPyUnicode_READY\b",
+        "PyUnicode_READY removed in 3.12",
+    ),
+    _p(
+        "removed_c_api",
+        "_PyUnicode_Ready",
+        "3.12",
+        r"(?:error|implicit|undeclared|undefined).*\b_PyUnicode_Ready\b",
+        "_PyUnicode_Ready (private) removed in 3.12",
+    ),
+    _p(
+        "removed_c_api",
+        "Py_UNICODE",
+        "3.13",
+        r"(?:error|unknown type).*\bPy_UNICODE\b",
+        "Py_UNICODE type removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyUnicode_AS_UNICODE",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyUnicode_AS_UNICODE\b",
+        "PyUnicode_AS_UNICODE removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyUnicode_GET_SIZE",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyUnicode_GET_SIZE\b",
+        "PyUnicode_GET_SIZE removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "tp_print",
+        "3.12",
+        r"(?:error|no member).*\btp_print\b",
+        "tp_print slot removed in 3.12",
+    ),
+    _p(
+        "removed_c_api",
+        "PyEval_CallObject",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyEval_CallObject\b",
+        "PyEval_CallObject removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyEval_CallFunction",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyEval_CallFunction\b",
+        "PyEval_CallFunction removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyEval_CallMethod",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyEval_CallMethod\b",
+        "PyEval_CallMethod removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyObject_AsCharBuffer",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyObject_AsCharBuffer\b",
+        "PyObject_AsCharBuffer removed in 3.13",
+    ),
+    _p(
+        "removed_c_api",
+        "PyObject_AsReadBuffer",
+        "3.13",
+        r"(?:error|implicit|undeclared|undefined).*\bPyObject_AsReadBuffer\b",
+        "PyObject_AsReadBuffer removed in 3.13",
+    ),
+    # --- changed_struct ---
+    _p(
+        "changed_struct",
+        "ob_type_assign",
+        "3.13",
+        r"(?:error|read-only|assignment).*\bob_type\b",
+        "Direct ob_type assignment; use Py_SET_TYPE()",
+    ),
+    _p(
+        "changed_struct",
+        "ob_refcnt_assign",
+        "3.13",
+        r"(?:error|read-only|assignment).*\bob_refcnt\b",
+        "Direct ob_refcnt assignment; use Py_SET_REFCNT()",
+    ),
+    _p(
+        "changed_struct",
+        "ob_size_assign",
+        "3.13",
+        r"(?:error|read-only|assignment).*\bob_size\b",
+        "Direct ob_size assignment; use Py_SET_SIZE()",
+    ),
+    _p(
+        "changed_struct",
+        "PyFrameObject_fields",
+        "3.13",
+        r"(?:error|no member).*\b(?:f_code|f_back|f_locals|f_builtins|f_globals)\b",
+        "Direct PyFrameObject field access; use accessor functions",
+    ),
+    # --- cython_incompatible ---
+    _p(
+        "cython_incompatible",
+        "cython_too_old",
+        "",
+        r"cython.*(?:is not|does not|doesn't).*support.*python\s*3\.\d+",
+        "Cython version does not support target Python",
+    ),
+    _p(
+        "cython_incompatible",
+        "cython_compile_error",
+        "",
+        r"(?:error.*cython|Cython\.Compiler).*(?:pyx|generated)",
+        "Compilation error in Cython-generated code",
+    ),
+    _p(
+        "cython_incompatible",
+        "cython_deprecated",
+        "",
+        r"deprecated.*Cython|Cython.*deprecated",
+        "Deprecated Cython API usage",
+    ),
+    # --- pyo3_incompatible ---
+    _p(
+        "pyo3_incompatible",
+        "pyo3_version",
+        "",
+        r"pyo3.*(?:does not|doesn't).*support.*python",
+        "PyO3 does not support target Python version",
+    ),
+    _p(
+        "pyo3_incompatible",
+        "maturin_version",
+        "",
+        r"maturin.*(?:error|unsupported|python)",
+        "Maturin build error or unsupported Python",
+    ),
+    _p(
+        "pyo3_incompatible",
+        "rust_build_fail",
+        "",
+        r"error\[E\d+\]",
+        "Rust compiler error (likely PyO3-related)",
+    ),
+    # --- numpy_c_api ---
+    _p(
+        "numpy_c_api",
+        "numpy_api_version",
+        "",
+        r"numpy.*(?:api|abi).*(?:mismatch|version|incompatible)",
+        "NumPy C API/ABI version mismatch",
+    ),
+    _p(
+        "numpy_c_api",
+        "numpy_deprecated_api",
+        "",
+        r"(?:NPY_NO_DEPRECATED_API|NPY_1_7_API_VERSION).*(?:error|warning)",
+        "NumPy deprecated API usage",
+    ),
+    # --- missing_system_lib (with Python.h negative lookahead) ---
+    _p(
+        "missing_system_lib",
+        "missing_header",
+        "",
+        r"fatal error:.*(?!Python\.h)\.h.*(?:no such file|not found)",
+        "Missing system header file",
+    ),
+    _p(
+        "missing_system_lib",
+        "missing_library",
+        "",
+        r"(?:cannot find -l\w+|library not found for -l\w+)",
+        "Missing system library",
+    ),
+    _p(
+        "missing_system_lib",
+        "pkg_config",
+        "",
+        r"(?:pkg-config.*not found|No package .* found)",
+        "pkg-config dependency not satisfied",
+    ),
+    # --- setuptools_distutils ---
+    _p(
+        "setuptools_distutils",
+        "distutils_removed",
+        "3.12",
+        r"(?:No module named|ModuleNotFoundError).*distutils",
+        "distutils removed in 3.12; use setuptools",
+    ),
+    _p(
+        "setuptools_distutils",
+        "setuptools_version",
+        "",
+        r"(?:setuptools.*version|requires.*setuptools)",
+        "setuptools version requirement not met",
+    ),
+    _p(
+        "setuptools_distutils",
+        "setup_py_error",
+        "",
+        r"error.*setup\.py|setup\.py.*(?:error|failed)",
+        "setup.py execution error",
+    ),
+    _p(
+        "setuptools_distutils",
+        "pkg_resources",
+        "3.12",
+        r"(?:No module named|ModuleNotFoundError).*pkg_resources",
+        "pkg_resources (from setuptools) not available",
+    ),
+    # --- build_backend ---
+    _p(
+        "build_backend",
+        "backend_missing",
+        "",
+        r"backend.*(?:not available|not found)|build.*backend.*error",
+        "PEP 517 build backend not available",
+    ),
+    _p(
+        "build_backend",
+        "mesonbuild",
+        "",
+        r"meson.*error|meson\.build.*error",
+        "Meson build error",
+    ),
+    _p(
+        "build_backend",
+        "cmake_error",
+        "",
+        r"cmake.*error|CMakeLists.*error",
+        "CMake build error",
+    ),
+    # --- compiler_error (catch-all, LAST) ---
+    _p(
+        "compiler_error",
+        "compilation_error",
+        "",
+        r"error:.*(?:undeclared|undefined|incompatible|invalid|implicit declaration)",
+        "Generic C/C++ compilation error",
+    ),
+    _p(
+        "compiler_error",
+        "linker_error",
+        "",
+        r"(?:undefined reference|undefined symbol|ld:.*error|ld returned)",
+        "Linker error",
+    ),
+    # --- import_failure (only matched against import stderr) ---
+    _p(
+        "import_failure",
+        "undefined_symbol",
+        "",
+        r"(?:undefined symbol|ImportError.*symbol).*Py\w+",
+        "Undefined Python C API symbol at import time",
+    ),
+    _p(
+        "import_failure",
+        "abi_mismatch",
+        "",
+        r"(?:abi.*tag|not a supported wheel|cpython.*abi)",
+        "ABI tag mismatch at import time",
+    ),
+]
+
+
+_NO_SDIST_PATTERN = re.compile(
+    r"no matching distribution.*--no-binary|"
+    r"could not find a version.*--no-binary|"
+    r"No files/directories .* sdist",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification engine
+# ---------------------------------------------------------------------------
+
+
+def classify_build_output(
+    stderr: str,
+    *,
+    patterns: list[ErrorPattern] | None = None,
+) -> list[ErrorMatch]:
+    """Classify build stderr against known error patterns.
+
+    Returns list of ErrorMatch instances ordered by line_number.
+    The first match should be used as primary_category.
+    """
+    effective_patterns = patterns if patterns is not None else _BUILTIN_PATTERNS
+    matches: list[ErrorMatch] = []
+    for line_idx, line in enumerate(stderr.splitlines()):
+        for pat in effective_patterns:
+            if pat.pattern.search(line):
+                matches.append(
+                    ErrorMatch(
+                        category=pat.category,
+                        subcategory=pat.subcategory,
+                        description=pat.description,
+                        since=pat.since,
+                        matched_line=line.strip(),
+                        line_number=line_idx + 1,
+                    )
+                )
+                break  # one match per line
+    return matches
+
+
+def load_patterns_from_yaml(path: Path) -> list[ErrorPattern]:
+    """Load error patterns from a YAML file.
+
+    Raises:
+        ValueError: If the YAML structure is invalid or a regex fails to compile.
+    """
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "patterns" not in data:
+        raise ValueError(f"Expected top-level 'patterns' key in {path}")
+
+    result: list[ErrorPattern] = []
+    for entry in data["patterns"]:
+        for key in ("category", "subcategory", "pattern", "description"):
+            if key not in entry:
+                raise ValueError(f"Missing required field '{key}' in pattern entry: {entry}")
+        try:
+            compiled = re.compile(entry["pattern"], re.IGNORECASE)
+        except re.error as exc:
+            raise ValueError(
+                f"Invalid regex in pattern {entry.get('subcategory', '?')!r}: "
+                f"{entry['pattern']!r}: {exc}"
+            ) from exc
+        result.append(
+            ErrorPattern(
+                category=entry["category"],
+                subcategory=entry["subcategory"],
+                pattern=compiled,
+                description=entry["description"],
+                since=entry.get("since", ""),
+            )
+        )
+    return result
+
+
+def get_patterns(extra_patterns_file: Path | None = None) -> list[ErrorPattern]:
+    """Return the effective pattern list.
+
+    YAML patterns are inserted at the beginning and override built-in
+    patterns with the same (category, subcategory).
+    """
+    if extra_patterns_file is None:
+        return list(_BUILTIN_PATTERNS)
+    yaml_patterns = load_patterns_from_yaml(extra_patterns_file)
+    yaml_keys = {(p.category, p.subcategory) for p in yaml_patterns}
+    filtered_builtins = [
+        p for p in _BUILTIN_PATTERNS if (p.category, p.subcategory) not in yaml_keys
+    ]
+    return yaml_patterns + filtered_builtins
+
+
+# ---------------------------------------------------------------------------
+# Input resolution
+# ---------------------------------------------------------------------------
+
+
+def _read_packages_file(path: Path) -> list[str]:
+    """Read package names from a file. Skips comments and blank lines."""
+    names: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            names.append(line)
+    return names
+
+
+def resolve_compat_inputs(
+    *,
+    registry_dir: Path | None = None,
+    extensions_only: bool = True,
+    package_names: list[str] | None = None,
+    packages_file: Path | None = None,
+    top_n: int | None = None,
+    target_python_version: str | None = None,
+    pypi_timeout: float = 10.0,
+) -> list[CompatPackageInput]:
+    """Resolve and merge package inputs from all sources."""
+    seen: dict[str, CompatPackageInput] = {}
+
+    # Registry source.
+    if registry_dir is not None:
+        from labeille.registry import load_index, load_package
+
+        index = load_index(registry_dir)
+        entries = index.packages
+        if extensions_only:
+            entries = [e for e in entries if e.extension_type == "extensions"]
+        entries = [e for e in entries if not e.skip]
+        if target_python_version:
+            entries = [e for e in entries if target_python_version not in e.skip_versions_keys]
+        if top_n is not None:
+            entries = sorted(entries, key=lambda e: e.download_count or 0, reverse=True)[:top_n]
+        for entry in entries:
+            pkg = load_package(entry.name, registry_dir)
+            seen[entry.name.lower()] = CompatPackageInput(
+                name=entry.name,
+                repo_url=pkg.repo,
+                install_command=pkg.install_command or None,
+                import_name=pkg.import_name,
+                extension_type=pkg.extension_type,
+                source="registry",
+            )
+
+    # Inline and file sources share the same PyPI resolution logic.
+    def _resolve_from_pypi(names: list[str], source: str) -> None:
+        from labeille.classifier import classify_from_urls
+        from labeille.resolve import extract_repo_url, fetch_pypi_metadata
+
+        for name in names:
+            if name.lower() in seen:
+                continue
+            meta = fetch_pypi_metadata(name, timeout=pypi_timeout)
+            repo_url = None
+            ext_type = "unknown"
+            if meta:
+                repo_url = extract_repo_url(meta)
+                ext_type = classify_from_urls(meta.get("urls", []))
+            seen[name.lower()] = CompatPackageInput(
+                name=name,
+                repo_url=repo_url,
+                extension_type=ext_type,
+                source=source,
+            )
+
+    if package_names:
+        _resolve_from_pypi(package_names, "inline")
+
+    if packages_file:
+        file_names = _read_packages_file(packages_file)
+        _resolve_from_pypi(file_names, "file")
+
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Core survey logic
+# ---------------------------------------------------------------------------
+
+
+def _survey_package(
+    pkg: CompatPackageInput,
+    target_python: Path,
+    from_mode: str,
+    output_dir: Path,
+    timeout: int,
+    repos_dir: Path | None,
+    installer: InstallerBackend,
+    patterns: list[ErrorPattern],
+    no_binary_all: bool,
+) -> CompatResult:
+    """Attempt to build a single package and classify the outcome."""
+    start = time.monotonic()
+    result = CompatResult(
+        package=pkg.name,
+        status="skip",
+        extension_type=pkg.extension_type,
+        source=pkg.source,
+        from_mode=from_mode,
+        repo_url=pkg.repo_url,
+    )
+
+    with tempfile.TemporaryDirectory(prefix=f"compat-{pkg.name}-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        venv_dir = tmp_path / "venv"
+
+        # Build install command.
+        if from_mode == "sdist":
+            if no_binary_all:
+                install_cmd = f"pip install --no-binary :all: {pkg.name}"
+            else:
+                install_cmd = f"pip install --no-binary {pkg.name} {pkg.name}"
+            cwd = tmp_path
+        else:
+            # Source mode.
+            if pkg.repo_url is None:
+                result.status = "no_repo"
+                result.duration_seconds = round(time.monotonic() - start, 2)
+                return result
+            repo_dir = repos_dir / pkg.name if repos_dir else tmp_path / "repo"
+            try:
+                if repo_dir.exists() and (repo_dir / ".git").exists():
+                    pull_repo(repo_dir)
+                else:
+                    clone_repo(pkg.repo_url, repo_dir)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+                result.status = "clone_error"
+                result.duration_seconds = round(time.monotonic() - start, 2)
+                log.debug("Clone failed for %s: %s", pkg.name, exc)
+                return result
+            install_cmd = pkg.install_command or "pip install -e ."
+            cwd = repo_dir
+
+        # Install.
+        env = _clean_env(ASAN_OPTIONS="detect_leaks=0")
+        install_proc: subprocess.CompletedProcess[str] | None = None
+        try:
+            install_proc, actual_backend = install_with_fallback(
+                python_path=target_python,
+                venv_dir=venv_dir,
+                install_command=install_cmd,
+                cwd=cwd,
+                env=env,
+                timeout=timeout,
+                installer=installer,
+            )
+            result.installer_used = actual_backend.value
+        except subprocess.TimeoutExpired:
+            result.status = "timeout"
+            result.duration_seconds = round(time.monotonic() - start, 2)
+            return result
+        except (subprocess.CalledProcessError, OSError) as exc:
+            result.status = "build_fail"
+            result.duration_seconds = round(time.monotonic() - start, 2)
+            log.debug("Build exception for %s: %s", pkg.name, exc)
+            return result
+
+        # Save build logs.
+        logs_dir = output_dir / "build_logs"
+        logs_dir.mkdir(exist_ok=True)
+        if install_proc.stderr:
+            (logs_dir / f"{pkg.name}.stderr").write_text(install_proc.stderr, encoding="utf-8")
+        if install_proc.stdout:
+            (logs_dir / f"{pkg.name}.stdout").write_text(install_proc.stdout, encoding="utf-8")
+
+        # Check install result.
+        result.exit_code = install_proc.returncode
+        if install_proc.returncode != 0:
+            stderr_text = install_proc.stderr or ""
+            # Check for no-sdist case.
+            if from_mode == "sdist" and _NO_SDIST_PATTERN.search(stderr_text):
+                result.status = "no_sdist"
+            else:
+                result.status = "build_fail"
+                matches = classify_build_output(stderr_text, patterns=patterns)
+                result.error_matches = matches
+                if matches:
+                    result.primary_category = matches[0].category
+                    result.primary_subcategory = matches[0].subcategory
+                    result.primary_description = matches[0].description
+            result.duration_seconds = round(time.monotonic() - start, 2)
+            return result
+
+        # Import check.
+        import_name = pkg.import_name or pkg.name.replace("-", "_")
+        venv_python = venv_dir / "bin" / "python"
+        import_env = _clean_env(PYTHON_JIT="0", ASAN_OPTIONS="detect_leaks=0")
+        try:
+            import_proc = check_import(venv_python, import_name, import_env)
+        except subprocess.TimeoutExpired:
+            result.status = "import_fail"
+            result.import_error = "import timed out"
+            result.duration_seconds = round(time.monotonic() - start, 2)
+            return result
+
+        if import_proc.returncode != 0:
+            crash = detect_crash(import_proc.returncode, import_proc.stderr or "")
+            if crash is not None:
+                result.status = "import_crash"
+                result.crash_signature = crash.signature
+            else:
+                result.status = "import_fail"
+                result.import_error = (import_proc.stderr or "").strip()[-300:]
+            # Classify import stderr.
+            import_matches = classify_build_output(import_proc.stderr or "", patterns=patterns)
+            result.error_matches = import_matches
+            if import_matches:
+                result.primary_category = import_matches[0].category
+                result.primary_subcategory = import_matches[0].subcategory
+                result.primary_description = import_matches[0].description
+        else:
+            result.status = "build_ok"
+
+    result.duration_seconds = round(time.monotonic() - start, 2)
+    return result
+
+
+def run_compat_survey(
+    packages: list[CompatPackageInput],
+    target_python: Path,
+    *,
+    from_mode: str = "sdist",
+    no_binary_all: bool = False,
+    output_dir: Path,
+    timeout: int = 600,
+    workers: int = 1,
+    repos_dir: Path | None = None,
+    installer_preference: str = "auto",
+    extra_patterns_file: Path | None = None,
+    progress_callback: Callable[[str, str], None] | None = None,
+) -> CompatSurvey:
+    """Run a compatibility survey across packages."""
+    python_version = validate_target_python(target_python)
+    installer = resolve_installer(installer_preference)
+    patterns = get_patterns(extra_patterns_file)
+
+    survey_id = f"compat-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    survey_dir = output_dir / survey_id
+    survey_dir.mkdir(parents=True, exist_ok=True)
+    (survey_dir / "build_logs").mkdir()
+
+    meta = CompatMeta(
+        survey_id=survey_id,
+        target_python=str(target_python),
+        python_version=python_version,
+        from_mode=from_mode,
+        no_binary_all=no_binary_all,
+        started_at=datetime.now(timezone.utc).isoformat(),
+        finished_at="",
+        total_packages=len(packages),
+        installer_preference=installer_preference,
+        extra_patterns_file=str(extra_patterns_file) if extra_patterns_file else None,
+    )
+
+    results: list[CompatResult] = []
+    jsonl_lock = threading.Lock()
+    jsonl_path = survey_dir / "compat_results.jsonl"
+
+    def _run_one(pkg: CompatPackageInput) -> CompatResult:
+        r = _survey_package(
+            pkg,
+            target_python,
+            from_mode,
+            survey_dir,
+            timeout,
+            repos_dir,
+            installer,
+            patterns,
+            no_binary_all,
+        )
+        with jsonl_lock:
+            with open(jsonl_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(r.to_dict()) + "\n")
+        if progress_callback:
+            progress_callback(pkg.name, r.status)
+        return r
+
+    if workers <= 1:
+        for pkg in packages:
+            results.append(_run_one(pkg))
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(_run_one, pkg): pkg for pkg in packages}
+            for future in as_completed(futures):
+                results.append(future.result())
+
+    meta.finished_at = datetime.now(timezone.utc).isoformat()
+    (survey_dir / "compat_meta.json").write_text(
+        json.dumps(meta.to_dict(), indent=2) + "\n", encoding="utf-8"
+    )
+
+    return CompatSurvey(meta=meta, results=results)
+
+
+def load_compat_survey(survey_dir: Path) -> CompatSurvey:
+    """Load a saved survey from disk."""
+    meta_path = survey_dir / "compat_meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"compat_meta.json not found in {survey_dir}")
+    meta = CompatMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
+
+    results: list[CompatResult] = []
+    jsonl_path = survey_dir / "compat_results.jsonl"
+    if jsonl_path.exists():
+        for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                results.append(CompatResult.from_dict(json.loads(line)))
+
+    return CompatSurvey(meta=meta, results=results)
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompatDiffEntry:
+    """A single package that changed between two surveys."""
+
+    package: str
+    status_a: str
+    status_b: str
+    category_a: str
+    category_b: str
+    description_a: str
+    description_b: str
+
+    @property
+    def is_regression(self) -> bool:
+        return self.status_a == "build_ok" and self.status_b != "build_ok"
+
+    @property
+    def is_fix(self) -> bool:
+        return self.status_a != "build_ok" and self.status_b == "build_ok"
+
+
+@dataclass
+class CompatDiff:
+    """Comparison between two surveys."""
+
+    survey_a_id: str
+    survey_b_id: str
+    python_a: str
+    python_b: str
+    entries: list[CompatDiffEntry]
+
+    @property
+    def regressions(self) -> list[CompatDiffEntry]:
+        return [e for e in self.entries if e.is_regression]
+
+    @property
+    def fixes(self) -> list[CompatDiffEntry]:
+        return [e for e in self.entries if e.is_fix]
+
+    @property
+    def category_changes(self) -> list[CompatDiffEntry]:
+        return [
+            e
+            for e in self.entries
+            if not e.is_regression and not e.is_fix and e.category_a != e.category_b
+        ]
+
+
+def diff_surveys(a: CompatSurvey, b: CompatSurvey) -> CompatDiff:
+    """Compare two surveys. Only packages present in both are compared."""
+    a_map = {r.package: r for r in a.results}
+    b_map = {r.package: r for r in b.results}
+    shared = sorted(set(a_map) & set(b_map))
+    entries: list[CompatDiffEntry] = []
+    for name in shared:
+        ra, rb = a_map[name], b_map[name]
+        if ra.status != rb.status or ra.primary_category != rb.primary_category:
+            entries.append(
+                CompatDiffEntry(
+                    package=name,
+                    status_a=ra.status,
+                    status_b=rb.status,
+                    category_a=ra.primary_category,
+                    category_b=rb.primary_category,
+                    description_a=ra.primary_description,
+                    description_b=rb.primary_description,
+                )
+            )
+    return CompatDiff(
+        survey_a_id=a.meta.survey_id,
+        survey_b_id=b.meta.survey_id,
+        python_a=a.meta.python_version,
+        python_b=b.meta.python_version,
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Display and export
+# ---------------------------------------------------------------------------
+
+_STATUS_ORDER = [
+    "build_ok",
+    "build_fail",
+    "import_fail",
+    "import_crash",
+    "no_sdist",
+    "no_repo",
+    "clone_error",
+    "timeout",
+    "skip",
+]
+
+
+def format_compat_report(survey: CompatSurvey) -> str:
+    """Format a survey for terminal display."""
+    from labeille.formatting import format_duration, format_percentage, format_table
+
+    lines: list[str] = []
+    meta = survey.meta
+    n = len(survey.results)
+
+    if n == 0:
+        return "No packages surveyed."
+
+    # Header.
+    lines.append(f"Compatibility Survey: {meta.survey_id}")
+    lines.append(f"  Python: {meta.python_version}")
+    lines.append(f"  Mode: {meta.from_mode}")
+    if meta.no_binary_all:
+        lines.append("  --no-binary :all: enabled")
+    total_dur = sum(r.duration_seconds for r in survey.results)
+    lines.append(f"  Packages: {n}  Duration: {format_duration(total_dur)}")
+    lines.append("")
+
+    # Status overview.
+    lines.append("Status overview:")
+    counts = survey.summary_counts
+    rows: list[list[str]] = []
+    for status in _STATUS_ORDER:
+        c = counts.get(status, 0)
+        if c > 0:
+            rows.append([status, str(c), format_percentage(c, n)])
+    if rows:
+        lines.append(format_table(["Status", "Count", "%"], rows))
+    lines.append("")
+
+    # Build failures by category.
+    by_cat = survey.by_category
+    if by_cat:
+        fail_total = counts.get("build_fail", 0)
+        lines.append("Build failures by category:")
+        cat_rows: list[list[str]] = []
+        for cat, pkgs in sorted(by_cat.items(), key=lambda x: -len(x[1])):
+            cat_rows.append([cat, str(len(pkgs)), format_percentage(len(pkgs), fail_total)])
+        lines.append(format_table(["Category", "Count", "% of failures"], cat_rows))
+        lines.append("")
+
+    # Top subcategories.
+    by_sub = survey.by_subcategory
+    if by_sub:
+        lines.append("Top failure subcategories:")
+        sub_rows: list[list[str]] = []
+        sorted_subs = sorted(by_sub.items(), key=lambda x: -len(x[1]))[:15]
+        for sub_key, pkgs in sorted_subs:
+            sample = ", ".join(r.package for r in pkgs[:5])
+            if len(pkgs) > 5:
+                sample += ", ..."
+            since = pkgs[0].primary_description if pkgs else ""
+            sub_rows.append([sub_key, str(len(pkgs)), since, sample])
+        lines.append(format_table(["Subcategory", "Count", "Description", "Packages"], sub_rows))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_compat_diff(diff: CompatDiff) -> str:
+    """Format a survey diff for terminal display."""
+    from labeille.formatting import format_table
+
+    lines: list[str] = []
+    lines.append(f"Diff: {diff.survey_a_id} vs {diff.survey_b_id}")
+    lines.append(f"  Python A: {diff.python_a}  Python B: {diff.python_b}")
+    lines.append("")
+
+    if not diff.entries:
+        lines.append("No differences found.")
+        return "\n".join(lines)
+
+    lines.append(
+        f"Summary: {len(diff.regressions)} regressions, "
+        f"{len(diff.fixes)} fixes, {len(diff.category_changes)} category changes"
+    )
+    lines.append("")
+
+    if diff.regressions:
+        lines.append("Regressions (build_ok -> failure):")
+        rows = [[e.package, e.status_b, e.category_b, e.description_b] for e in diff.regressions]
+        lines.append(format_table(["Package", "New status", "Category", "Description"], rows))
+        lines.append("")
+
+    if diff.fixes:
+        lines.append("Fixes (failure -> build_ok):")
+        rows = [[e.package, e.status_a, e.category_a] for e in diff.fixes]
+        lines.append(format_table(["Package", "Old status", "Old category"], rows))
+        lines.append("")
+
+    if diff.category_changes:
+        lines.append("Category changes:")
+        rows = [
+            [e.package, e.category_a or "-", e.category_b or "-"] for e in diff.category_changes
+        ]
+        lines.append(format_table(["Package", "Old category", "New category"], rows))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_compat_markdown(survey: CompatSurvey) -> str:
+    """Export a survey as a shareable markdown report."""
+    lines: list[str] = []
+    meta = survey.meta
+    n = len(survey.results)
+
+    lines.append(f"# Compatibility Survey: {meta.survey_id}")
+    lines.append("")
+    lines.append(f"- **Python:** {meta.python_version}")
+    lines.append(f"- **Mode:** {meta.from_mode}")
+    lines.append(f"- **Packages:** {n}")
+    lines.append(f"- **Date:** {meta.started_at[:19]}")
+    lines.append("")
+
+    if n == 0:
+        lines.append("No packages surveyed.")
+        return "\n".join(lines)
+
+    # Summary table.
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Status | Count | % |")
+    lines.append("|---|---:|---:|")
+    counts = survey.summary_counts
+    for status in _STATUS_ORDER:
+        c = counts.get(status, 0)
+        if c > 0:
+            pct = f"{c / n * 100:.1f}%"
+            lines.append(f"| {status} | {c} | {pct} |")
+    lines.append("")
+
+    # Failures by category.
+    by_cat = survey.by_category
+    if by_cat:
+        lines.append("## Failures by Category")
+        lines.append("")
+        lines.append("| Category | Count | Packages |")
+        lines.append("|---|---:|---|")
+        for cat, pkgs in sorted(by_cat.items(), key=lambda x: -len(x[1])):
+            sample = ", ".join(r.package for r in pkgs[:8])
+            if len(pkgs) > 8:
+                sample += ", ..."
+            lines.append(f"| {cat} | {len(pkgs)} | {sample} |")
+        lines.append("")
+
+    # Subcategory detail.
+    by_sub = survey.by_subcategory
+    if by_sub:
+        lines.append("## Subcategory Detail")
+        lines.append("")
+        lines.append("| Subcategory | Since | Count | Packages |")
+        lines.append("|---|---|---:|---|")
+        for sub_key, pkgs in sorted(by_sub.items(), key=lambda x: -len(x[1])):
+            since = pkgs[0].error_matches[0].since if pkgs and pkgs[0].error_matches else ""
+            sample = ", ".join(r.package for r in pkgs[:5])
+            if len(pkgs) > 5:
+                sample += ", ..."
+            lines.append(f"| {sub_key} | {since} | {len(pkgs)} | {sample} |")
+        lines.append("")
+
+    lines.append(f"*Generated by labeille compat on {meta.started_at[:19]}*")
+    return "\n".join(lines)
+
+
+def format_patterns_table(
+    patterns: list[ErrorPattern],
+    *,
+    category_filter: str | None = None,
+) -> str:
+    """Format the pattern list for terminal display."""
+    from labeille.formatting import format_table
+
+    filtered = patterns
+    if category_filter:
+        filtered = [p for p in patterns if p.category == category_filter]
+    rows = [[p.category, p.subcategory, p.since, p.description] for p in filtered]
+    return format_table(["Category", "Subcategory", "Since", "Description"], rows)

--- a/src/labeille/compat_cli.py
+++ b/src/labeille/compat_cli.py
@@ -1,0 +1,351 @@
+"""CLI commands for ``labeille compat``.
+
+Subcommands:
+    labeille compat survey    Run a C extension compatibility survey
+    labeille compat show      Display results from a saved survey
+    labeille compat diff      Compare two surveys
+    labeille compat patterns  List built-in error classification patterns
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from labeille.logging import setup_logging
+
+
+@click.group()
+def compat() -> None:
+    """C extension compatibility survey.
+
+    Build packages against a target Python and classify failures
+    into fine-grained categories (removed C API, Cython/PyO3
+    incompatibility, missing headers, etc.).
+    """
+
+
+# ---------------------------------------------------------------------------
+# compat survey
+# ---------------------------------------------------------------------------
+
+
+@compat.command()
+@click.option(
+    "--target-python",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Path to the Python interpreter to build against.",
+)
+@click.option(
+    "--registry-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Registry directory for package metadata.",
+)
+@click.option(
+    "--packages",
+    "packages_csv",
+    type=str,
+    default=None,
+    help="Comma-separated list of package names.",
+)
+@click.option(
+    "--packages-file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="File with one package name per line.",
+)
+@click.option(
+    "--top",
+    "top_n",
+    type=int,
+    default=None,
+    help="Survey only the top N packages by download count (requires --registry-dir).",
+)
+@click.option(
+    "--from",
+    "from_mode",
+    type=click.Choice(["sdist", "source"]),
+    default="sdist",
+    show_default=True,
+    help="Build from sdist (PyPI) or source (git clone).",
+)
+@click.option(
+    "--no-binary-all",
+    is_flag=True,
+    help="Use pip --no-binary :all: (force compile everything).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=Path("compat-results"),
+    show_default=True,
+    help="Output directory for survey results.",
+)
+@click.option("--timeout", type=int, default=600, show_default=True)
+@click.option(
+    "--workers",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Number of packages to build in parallel.",
+)
+@click.option(
+    "--repos-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Persistent directory for repo clones (source mode).",
+)
+@click.option(
+    "--installer",
+    type=click.Choice(["auto", "uv", "pip"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Package installer backend.",
+)
+@click.option(
+    "--extra-patterns",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="YAML file with additional error classification patterns.",
+)
+@click.option(
+    "--extensions-only/--all-types",
+    default=True,
+    help="Only survey packages with C extensions (default: true).",
+)
+@click.option("-v", "--verbose", is_flag=True)
+@click.option("-q", "--quiet", is_flag=True, help="Only show errors.")
+@click.option(
+    "--export-markdown",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Also export results as a markdown file.",
+)
+def survey(
+    target_python: Path,
+    registry_dir: Path | None,
+    packages_csv: str | None,
+    packages_file: Path | None,
+    top_n: int | None,
+    from_mode: str,
+    no_binary_all: bool,
+    output_dir: Path,
+    timeout: int,
+    workers: int,
+    repos_dir: Path | None,
+    installer: str,
+    extra_patterns: Path | None,
+    extensions_only: bool,
+    verbose: bool,
+    quiet: bool,
+    export_markdown: Path | None,
+) -> None:
+    """Run a compatibility survey against packages."""
+    from labeille.compat import (
+        export_compat_markdown,
+        format_compat_report,
+        resolve_compat_inputs,
+        run_compat_survey,
+    )
+    from labeille.runner import validate_target_python
+
+    setup_logging(verbose=verbose, quiet=quiet)
+
+    # Validate target python.
+    try:
+        python_version = validate_target_python(target_python)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if workers < 1:
+        raise click.UsageError("--workers must be at least 1")
+
+    # Must have at least one package source.
+    if not registry_dir and not packages_csv and not packages_file:
+        raise click.UsageError(
+            "At least one of --registry-dir, --packages, or --packages-file is required."
+        )
+
+    click.echo(f"Target Python: {python_version}")
+
+    # Parse inline packages.
+    package_names: list[str] | None = None
+    if packages_csv:
+        package_names = [p.strip() for p in packages_csv.split(",") if p.strip()]
+
+    # Extract minor version for skip_versions filtering.
+    from labeille.runner import extract_python_minor_version
+
+    minor_ver = extract_python_minor_version(python_version)
+
+    # Resolve inputs.
+    packages = resolve_compat_inputs(
+        registry_dir=registry_dir,
+        extensions_only=extensions_only,
+        package_names=package_names,
+        packages_file=packages_file,
+        top_n=top_n,
+        target_python_version=minor_ver,
+    )
+
+    if not packages:
+        click.echo("No packages to survey.")
+        return
+
+    click.echo(f"Surveying {len(packages)} package(s)...")
+
+    # Progress callback.
+    completed = [0]
+
+    def _on_progress(name: str, status: str) -> None:
+        completed[0] += 1
+        if not quiet:
+            click.echo(f"  [{completed[0]}/{len(packages)}] {name}: {status}")
+
+    result = run_compat_survey(
+        packages,
+        target_python,
+        from_mode=from_mode,
+        no_binary_all=no_binary_all,
+        output_dir=output_dir,
+        timeout=timeout,
+        workers=workers,
+        repos_dir=repos_dir,
+        installer_preference=installer,
+        extra_patterns_file=extra_patterns,
+        progress_callback=_on_progress,
+    )
+
+    # Display report.
+    report = format_compat_report(result)
+    click.echo("")
+    click.echo(report)
+
+    # Export markdown if requested.
+    if export_markdown:
+        md = export_compat_markdown(result)
+        export_markdown.parent.mkdir(parents=True, exist_ok=True)
+        export_markdown.write_text(md, encoding="utf-8")
+        click.echo(f"Markdown exported to {export_markdown}")
+
+    click.echo(f"Results saved to {output_dir}/{result.meta.survey_id}/")
+
+
+# ---------------------------------------------------------------------------
+# compat show
+# ---------------------------------------------------------------------------
+
+
+@compat.command()
+@click.argument("survey_dir", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["table", "markdown"]),
+    default="table",
+    show_default=True,
+)
+@click.option(
+    "--category",
+    type=str,
+    default=None,
+    help="Filter results to a specific failure category.",
+)
+@click.option(
+    "--status",
+    type=str,
+    default=None,
+    help="Filter results to a specific status (e.g. build_fail, build_ok).",
+)
+def show(
+    survey_dir: Path,
+    fmt: str,
+    category: str | None,
+    status: str | None,
+) -> None:
+    """Display results from a saved compatibility survey."""
+    from labeille.compat import (
+        CompatSurvey,
+        export_compat_markdown,
+        format_compat_report,
+        load_compat_survey,
+    )
+
+    try:
+        survey = load_compat_survey(survey_dir)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    # Apply filters if requested.
+    if category or status:
+        filtered = survey.results
+        if category:
+            filtered = [r for r in filtered if r.primary_category == category]
+        if status:
+            filtered = [r for r in filtered if r.status == status]
+        survey = CompatSurvey(meta=survey.meta, results=filtered)
+        click.echo(f"Filtered to {len(filtered)} result(s).")
+
+    if fmt == "markdown":
+        click.echo(export_compat_markdown(survey))
+    else:
+        click.echo(format_compat_report(survey))
+
+
+# ---------------------------------------------------------------------------
+# compat diff
+# ---------------------------------------------------------------------------
+
+
+@compat.command()
+@click.argument("survey_a", type=click.Path(exists=True, path_type=Path))
+@click.argument("survey_b", type=click.Path(exists=True, path_type=Path))
+def diff(survey_a: Path, survey_b: Path) -> None:
+    """Compare two compatibility surveys (A = baseline, B = new)."""
+    from labeille.compat import (
+        diff_surveys,
+        format_compat_diff,
+        load_compat_survey,
+    )
+
+    try:
+        a = load_compat_survey(survey_a)
+        b = load_compat_survey(survey_b)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    result = diff_surveys(a, b)
+    click.echo(format_compat_diff(result))
+
+
+# ---------------------------------------------------------------------------
+# compat patterns
+# ---------------------------------------------------------------------------
+
+
+@compat.command()
+@click.option(
+    "--category",
+    type=str,
+    default=None,
+    help="Filter to a specific category.",
+)
+@click.option(
+    "--extra-patterns",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Include patterns from a YAML file.",
+)
+def patterns(category: str | None, extra_patterns: Path | None) -> None:
+    """List built-in error classification patterns."""
+    from labeille.compat import format_patterns_table, get_patterns
+
+    try:
+        pattern_list = get_patterns(extra_patterns)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(format_patterns_table(pattern_list, category_filter=category))

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,1007 @@
+"""Tests for labeille.compat."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from labeille.compat import (
+    CompatDiff,
+    CompatDiffEntry,
+    CompatMeta,
+    CompatResult,
+    CompatSurvey,
+    ErrorMatch,
+    ErrorPattern,
+    _BUILTIN_PATTERNS,
+    _NO_SDIST_PATTERN,
+    _read_packages_file,
+    classify_build_output,
+    diff_surveys,
+    export_compat_markdown,
+    format_compat_diff,
+    format_compat_report,
+    format_patterns_table,
+    get_patterns,
+    load_compat_survey,
+    resolve_compat_inputs,
+)
+
+
+# ---------------------------------------------------------------------------
+# ErrorPattern / ErrorMatch
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMatch(unittest.TestCase):
+    """Tests for ErrorMatch serialization."""
+
+    def test_to_dict(self) -> None:
+        m = ErrorMatch(
+            category="removed_c_api",
+            subcategory="PyUnicode_READY",
+            description="PyUnicode_READY removed in 3.12",
+            since="3.12",
+            matched_line="error: implicit declaration of PyUnicode_READY",
+            line_number=42,
+        )
+        d = m.to_dict()
+        self.assertEqual(d["category"], "removed_c_api")
+        self.assertEqual(d["subcategory"], "PyUnicode_READY")
+        self.assertEqual(d["line_number"], 42)
+        self.assertIn("since", d)
+
+    def test_roundtrip(self) -> None:
+        m = ErrorMatch(
+            category="compiler_error",
+            subcategory="linker_error",
+            description="Linker error",
+            since="",
+            matched_line="undefined reference to `foo'",
+            line_number=10,
+        )
+        d = m.to_dict()
+        m2 = ErrorMatch(**d)
+        self.assertEqual(m.category, m2.category)
+        self.assertEqual(m.matched_line, m2.matched_line)
+
+
+# ---------------------------------------------------------------------------
+# CompatResult
+# ---------------------------------------------------------------------------
+
+
+class TestCompatResult(unittest.TestCase):
+    """Tests for CompatResult serialization."""
+
+    def test_to_dict_sparse(self) -> None:
+        """Default/empty values should be omitted from the dict."""
+        r = CompatResult(package="foo", status="build_ok")
+        d = r.to_dict()
+        self.assertEqual(d, {"package": "foo", "status": "build_ok"})
+
+    def test_to_dict_full(self) -> None:
+        r = CompatResult(
+            package="bar",
+            status="build_fail",
+            exit_code=1,
+            duration_seconds=12.5,
+            primary_category="removed_c_api",
+            primary_subcategory="PyUnicode_READY",
+            primary_description="removed",
+            extension_type="extensions",
+            source="registry",
+            from_mode="sdist",
+            installer_used="pip",
+        )
+        d = r.to_dict()
+        self.assertEqual(d["exit_code"], 1)
+        self.assertEqual(d["primary_category"], "removed_c_api")
+        self.assertEqual(d["extension_type"], "extensions")
+        self.assertEqual(d["installer_used"], "pip")
+
+    def test_from_dict_minimal(self) -> None:
+        d = {"package": "x", "status": "skip"}
+        r = CompatResult.from_dict(d)
+        self.assertEqual(r.package, "x")
+        self.assertEqual(r.status, "skip")
+        self.assertEqual(r.exit_code, None)
+        self.assertEqual(r.error_matches, [])
+
+    def test_from_dict_with_matches(self) -> None:
+        d = {
+            "package": "y",
+            "status": "build_fail",
+            "error_matches": [
+                {
+                    "category": "removed_c_api",
+                    "subcategory": "tp_print",
+                    "description": "tp_print removed",
+                    "since": "3.12",
+                    "matched_line": "error: no member tp_print",
+                    "line_number": 5,
+                }
+            ],
+        }
+        r = CompatResult.from_dict(d)
+        self.assertEqual(len(r.error_matches), 1)
+        self.assertEqual(r.error_matches[0].subcategory, "tp_print")
+
+    def test_roundtrip(self) -> None:
+        r = CompatResult(
+            package="z",
+            status="import_crash",
+            crash_signature="SIGSEGV",
+            error_matches=[
+                ErrorMatch(
+                    category="import_failure",
+                    subcategory="undefined_symbol",
+                    description="Undefined symbol",
+                    since="",
+                    matched_line="undefined symbol: PyFoo",
+                    line_number=1,
+                )
+            ],
+        )
+        d = r.to_dict()
+        r2 = CompatResult.from_dict(d)
+        self.assertEqual(r.package, r2.package)
+        self.assertEqual(r.crash_signature, r2.crash_signature)
+        self.assertEqual(len(r2.error_matches), 1)
+
+
+# ---------------------------------------------------------------------------
+# CompatMeta
+# ---------------------------------------------------------------------------
+
+
+class TestCompatMeta(unittest.TestCase):
+    """Tests for CompatMeta serialization."""
+
+    def test_roundtrip(self) -> None:
+        meta = CompatMeta(
+            survey_id="compat-20260302-120000",
+            target_python="/usr/bin/python3.15",
+            python_version="3.15.0a5",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="2026-03-02T12:00:00+00:00",
+            finished_at="2026-03-02T12:30:00+00:00",
+            total_packages=100,
+            installer_preference="auto",
+        )
+        d = meta.to_dict()
+        meta2 = CompatMeta.from_dict(d)
+        self.assertEqual(meta.survey_id, meta2.survey_id)
+        self.assertEqual(meta.python_version, meta2.python_version)
+        self.assertFalse(meta2.no_binary_all)
+
+    def test_extra_patterns_file(self) -> None:
+        meta = CompatMeta(
+            survey_id="test",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="source",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=0,
+            installer_preference="pip",
+            extra_patterns_file="/tmp/patterns.yaml",
+        )
+        d = meta.to_dict()
+        self.assertEqual(d["extra_patterns_file"], "/tmp/patterns.yaml")
+        meta2 = CompatMeta.from_dict(d)
+        self.assertEqual(meta2.extra_patterns_file, "/tmp/patterns.yaml")
+
+
+# ---------------------------------------------------------------------------
+# CompatSurvey
+# ---------------------------------------------------------------------------
+
+
+class TestCompatSurvey(unittest.TestCase):
+    """Tests for CompatSurvey properties."""
+
+    def _make_survey(self) -> CompatSurvey:
+        meta = CompatMeta(
+            survey_id="test",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=4,
+            installer_preference="auto",
+        )
+        results = [
+            CompatResult(package="a", status="build_ok"),
+            CompatResult(
+                package="b",
+                status="build_fail",
+                primary_category="removed_c_api",
+                primary_subcategory="PyUnicode_READY",
+            ),
+            CompatResult(
+                package="c",
+                status="build_fail",
+                primary_category="removed_c_api",
+                primary_subcategory="tp_print",
+            ),
+            CompatResult(
+                package="d",
+                status="build_fail",
+                primary_category="cython_incompatible",
+                primary_subcategory="cython_too_old",
+            ),
+        ]
+        return CompatSurvey(meta=meta, results=results)
+
+    def test_by_status(self) -> None:
+        s = self._make_survey()
+        by_status = s.by_status
+        self.assertEqual(len(by_status["build_ok"]), 1)
+        self.assertEqual(len(by_status["build_fail"]), 3)
+
+    def test_by_category(self) -> None:
+        s = self._make_survey()
+        by_cat = s.by_category
+        self.assertEqual(len(by_cat["removed_c_api"]), 2)
+        self.assertEqual(len(by_cat["cython_incompatible"]), 1)
+
+    def test_by_subcategory(self) -> None:
+        s = self._make_survey()
+        by_sub = s.by_subcategory
+        self.assertIn("removed_c_api/PyUnicode_READY", by_sub)
+        self.assertIn("cython_incompatible/cython_too_old", by_sub)
+
+    def test_summary_counts(self) -> None:
+        s = self._make_survey()
+        counts = s.summary_counts
+        self.assertEqual(counts["build_ok"], 1)
+        self.assertEqual(counts["build_fail"], 3)
+
+    def test_by_category_ignores_empty(self) -> None:
+        """Packages without primary_category are excluded from by_category."""
+        meta = CompatMeta(
+            survey_id="x",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=1,
+            installer_preference="auto",
+        )
+        survey = CompatSurvey(
+            meta=meta,
+            results=[CompatResult(package="a", status="build_ok")],
+        )
+        self.assertEqual(survey.by_category, {})
+
+
+# ---------------------------------------------------------------------------
+# Classification engine
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyBuildOutput(unittest.TestCase):
+    """Tests for classify_build_output()."""
+
+    def test_detects_pyunicode_ready(self) -> None:
+        stderr = "foo.c:42: error: implicit declaration of PyUnicode_READY\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "removed_c_api")
+        self.assertEqual(matches[0].subcategory, "PyUnicode_READY")
+        self.assertEqual(matches[0].since, "3.12")
+
+    def test_detects_py_unicode(self) -> None:
+        stderr = "error: unknown type name 'Py_UNICODE'\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].subcategory, "Py_UNICODE")
+
+    def test_detects_tp_print(self) -> None:
+        stderr = "error: 'PyTypeObject' has no member named 'tp_print'\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].subcategory, "tp_print")
+
+    def test_detects_distutils_removed(self) -> None:
+        stderr = "ModuleNotFoundError: No module named 'distutils'\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "setuptools_distutils")
+
+    def test_detects_missing_header(self) -> None:
+        stderr = "fatal error: openssl/ssl.h: No such file or directory\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "missing_system_lib")
+        self.assertEqual(matches[0].subcategory, "missing_header")
+
+    def test_detects_python_h_missing(self) -> None:
+        stderr = "fatal error: Python.h: No such file or directory\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "python_header")
+
+    def test_detects_linker_error(self) -> None:
+        stderr = "undefined reference to `PyFoo_Bar'\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "compiler_error")
+        self.assertEqual(matches[0].subcategory, "linker_error")
+
+    def test_detects_pyo3(self) -> None:
+        stderr = "error: PyO3 does not support Python 3.15\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "pyo3_incompatible")
+
+    def test_detects_rust_error(self) -> None:
+        stderr = "error[E0412]: cannot find type `PyObject`\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].subcategory, "rust_build_fail")
+
+    def test_detects_cython_version(self) -> None:
+        stderr = "Cython is not supported on Python 3.15\n"
+        matches = classify_build_output(stderr)
+        # Should not crash, may or may not match the loose regex.
+        self.assertIsInstance(matches, list)
+
+    def test_no_matches(self) -> None:
+        stderr = "All good, nothing to see here.\n"
+        matches = classify_build_output(stderr)
+        self.assertEqual(matches, [])
+
+    def test_one_match_per_line(self) -> None:
+        """Only the first matching pattern per line should be recorded."""
+        stderr = "error: implicit declaration of PyUnicode_READY undefined reference\n"
+        matches = classify_build_output(stderr)
+        self.assertEqual(len(matches), 1)
+
+    def test_multiple_lines(self) -> None:
+        stderr = (
+            "error: implicit declaration of PyUnicode_READY\n"
+            "error: unknown type name 'Py_UNICODE'\n"
+        )
+        matches = classify_build_output(stderr)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0].line_number, 1)
+        self.assertEqual(matches[1].line_number, 2)
+
+    def test_custom_patterns(self) -> None:
+        import re
+
+        custom = [
+            ErrorPattern(
+                category="custom",
+                subcategory="test_error",
+                pattern=re.compile(r"CUSTOM_ERROR_42"),
+                description="Custom test error",
+                since="3.15",
+            )
+        ]
+        stderr = "line1\nCUSTOM_ERROR_42 happened\nline3\n"
+        matches = classify_build_output(stderr, patterns=custom)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].category, "custom")
+        self.assertEqual(matches[0].line_number, 2)
+
+    def test_case_insensitive(self) -> None:
+        stderr = "Error: IMPLICIT DECLARATION OF PYUNICODE_READY\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+
+    def test_detects_ob_type_assignment(self) -> None:
+        stderr = "error: assignment to read-only member 'ob_type'\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "changed_struct")
+
+    def test_detects_missing_library(self) -> None:
+        stderr = "cannot find -lssl\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].subcategory, "missing_library")
+
+    def test_detects_cmake_error(self) -> None:
+        stderr = "CMakeLists.txt error: something went wrong\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "build_backend")
+
+    def test_detects_import_undefined_symbol(self) -> None:
+        stderr = "ImportError: symbol PyFoo not found\n"
+        matches = classify_build_output(stderr)
+        self.assertTrue(len(matches) >= 1)
+        self.assertEqual(matches[0].category, "import_failure")
+
+
+# ---------------------------------------------------------------------------
+# No-sdist pattern
+# ---------------------------------------------------------------------------
+
+
+class TestNoSdistPattern(unittest.TestCase):
+    """Tests for _NO_SDIST_PATTERN."""
+
+    def test_matches_no_matching_distribution(self) -> None:
+        text = "ERROR: No matching distribution found for foo --no-binary"
+        self.assertIsNotNone(_NO_SDIST_PATTERN.search(text))
+
+    def test_does_not_match_random_text(self) -> None:
+        self.assertIsNone(_NO_SDIST_PATTERN.search("Everything installed successfully"))
+
+
+# ---------------------------------------------------------------------------
+# get_patterns / load_patterns_from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestGetPatterns(unittest.TestCase):
+    """Tests for get_patterns()."""
+
+    def test_returns_builtins(self) -> None:
+        patterns = get_patterns()
+        self.assertEqual(len(patterns), len(_BUILTIN_PATTERNS))
+
+    def test_yaml_overrides(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "patterns:\n"
+                "  - category: removed_c_api\n"
+                "    subcategory: PyUnicode_READY\n"
+                "    pattern: 'CUSTOM_PYUNICODE_READY'\n"
+                "    description: Custom override\n"
+                "    since: '3.12'\n"
+            )
+            f.flush()
+            patterns = get_patterns(Path(f.name))
+        # Should have same count (override replaces one).
+        builtins_count = len(_BUILTIN_PATTERNS)
+        # The YAML provides 1 pattern that overrides 1 builtin.
+        self.assertEqual(len(patterns), builtins_count)
+        # First pattern should be the YAML override.
+        self.assertEqual(patterns[0].description, "Custom override")
+
+    def test_yaml_adds_new(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "patterns:\n"
+                "  - category: custom_cat\n"
+                "    subcategory: custom_sub\n"
+                "    pattern: 'CUSTOM_PATTERN'\n"
+                "    description: Brand new\n"
+            )
+            f.flush()
+            patterns = get_patterns(Path(f.name))
+        self.assertEqual(len(patterns), len(_BUILTIN_PATTERNS) + 1)
+
+    def test_yaml_invalid_structure(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("not_patterns: []\n")
+            f.flush()
+            with self.assertRaises(ValueError):
+                get_patterns(Path(f.name))
+
+    def test_yaml_invalid_regex(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "patterns:\n"
+                "  - category: bad\n"
+                "    subcategory: bad\n"
+                "    pattern: '[invalid'\n"
+                "    description: Bad regex\n"
+            )
+            f.flush()
+            with self.assertRaises(ValueError):
+                get_patterns(Path(f.name))
+
+    def test_yaml_missing_field(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "patterns:\n"
+                "  - category: foo\n"
+                "    subcategory: bar\n"
+                "    description: Missing pattern field\n"
+            )
+            f.flush()
+            with self.assertRaises(ValueError):
+                get_patterns(Path(f.name))
+
+
+# ---------------------------------------------------------------------------
+# _read_packages_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadPackagesFile(unittest.TestCase):
+    """Tests for _read_packages_file()."""
+
+    def test_reads_names(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("foo\nbar\nbaz\n")
+            f.flush()
+            names = _read_packages_file(Path(f.name))
+        self.assertEqual(names, ["foo", "bar", "baz"])
+
+    def test_skips_comments_and_blanks(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("# comment\nfoo\n\n  bar  \n# another\n")
+            f.flush()
+            names = _read_packages_file(Path(f.name))
+        self.assertEqual(names, ["foo", "bar"])
+
+
+# ---------------------------------------------------------------------------
+# resolve_compat_inputs
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCompatInputs(unittest.TestCase):
+    """Tests for resolve_compat_inputs()."""
+
+    @patch("labeille.resolve.fetch_pypi_metadata")
+    @patch("labeille.resolve.extract_repo_url")
+    @patch("labeille.classifier.classify_from_urls")
+    def test_inline_packages(
+        self,
+        mock_classify: MagicMock,
+        mock_extract: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"urls": []}
+        mock_extract.return_value = "https://github.com/foo/foo"
+        mock_classify.return_value = "extensions"
+        result = resolve_compat_inputs(package_names=["foo"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "foo")
+        self.assertEqual(result[0].source, "inline")
+
+    @patch("labeille.resolve.fetch_pypi_metadata")
+    @patch("labeille.resolve.extract_repo_url")
+    @patch("labeille.classifier.classify_from_urls")
+    def test_deduplicates(
+        self,
+        mock_classify: MagicMock,
+        mock_extract: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"urls": []}
+        mock_extract.return_value = None
+        mock_classify.return_value = "unknown"
+        result = resolve_compat_inputs(package_names=["Foo", "foo", "FOO"])
+        self.assertEqual(len(result), 1)
+
+    @patch("labeille.resolve.fetch_pypi_metadata")
+    @patch("labeille.resolve.extract_repo_url")
+    @patch("labeille.classifier.classify_from_urls")
+    def test_file_source(
+        self,
+        mock_classify: MagicMock,
+        mock_extract: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"urls": []}
+        mock_extract.return_value = None
+        mock_classify.return_value = "unknown"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("bar\nbaz\n")
+            f.flush()
+            result = resolve_compat_inputs(packages_file=Path(f.name))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].source, "file")
+
+    def test_no_sources(self) -> None:
+        result = resolve_compat_inputs()
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# CompatDiff
+# ---------------------------------------------------------------------------
+
+
+class TestCompatDiffEntry(unittest.TestCase):
+    """Tests for CompatDiffEntry."""
+
+    def test_is_regression(self) -> None:
+        e = CompatDiffEntry(
+            package="x",
+            status_a="build_ok",
+            status_b="build_fail",
+            category_a="",
+            category_b="removed_c_api",
+            description_a="",
+            description_b="removed",
+        )
+        self.assertTrue(e.is_regression)
+        self.assertFalse(e.is_fix)
+
+    def test_is_fix(self) -> None:
+        e = CompatDiffEntry(
+            package="x",
+            status_a="build_fail",
+            status_b="build_ok",
+            category_a="removed_c_api",
+            category_b="",
+            description_a="removed",
+            description_b="",
+        )
+        self.assertFalse(e.is_regression)
+        self.assertTrue(e.is_fix)
+
+    def test_category_change(self) -> None:
+        e = CompatDiffEntry(
+            package="x",
+            status_a="build_fail",
+            status_b="build_fail",
+            category_a="removed_c_api",
+            category_b="cython_incompatible",
+            description_a="",
+            description_b="",
+        )
+        self.assertFalse(e.is_regression)
+        self.assertFalse(e.is_fix)
+
+
+class TestCompatDiff(unittest.TestCase):
+    """Tests for CompatDiff properties."""
+
+    def _make_diff(self) -> CompatDiff:
+        entries = [
+            CompatDiffEntry("a", "build_ok", "build_fail", "", "removed_c_api", "", ""),
+            CompatDiffEntry("b", "build_fail", "build_ok", "cython_incompatible", "", "", ""),
+            CompatDiffEntry("c", "build_fail", "build_fail", "removed_c_api", "pyo3", "", ""),
+        ]
+        return CompatDiff(
+            survey_a_id="s1",
+            survey_b_id="s2",
+            python_a="3.14.0",
+            python_b="3.15.0",
+            entries=entries,
+        )
+
+    def test_regressions(self) -> None:
+        d = self._make_diff()
+        self.assertEqual(len(d.regressions), 1)
+        self.assertEqual(d.regressions[0].package, "a")
+
+    def test_fixes(self) -> None:
+        d = self._make_diff()
+        self.assertEqual(len(d.fixes), 1)
+        self.assertEqual(d.fixes[0].package, "b")
+
+    def test_category_changes(self) -> None:
+        d = self._make_diff()
+        self.assertEqual(len(d.category_changes), 1)
+        self.assertEqual(d.category_changes[0].package, "c")
+
+
+class TestDiffSurveys(unittest.TestCase):
+    """Tests for diff_surveys()."""
+
+    def _make_meta(self, sid: str, pyver: str) -> CompatMeta:
+        return CompatMeta(
+            survey_id=sid,
+            target_python="/usr/bin/python",
+            python_version=pyver,
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=0,
+            installer_preference="auto",
+        )
+
+    def test_no_overlap(self) -> None:
+        a = CompatSurvey(
+            meta=self._make_meta("a", "3.14"),
+            results=[CompatResult(package="x", status="build_ok")],
+        )
+        b = CompatSurvey(
+            meta=self._make_meta("b", "3.15"),
+            results=[CompatResult(package="y", status="build_ok")],
+        )
+        diff = diff_surveys(a, b)
+        self.assertEqual(diff.entries, [])
+
+    def test_no_change(self) -> None:
+        a = CompatSurvey(
+            meta=self._make_meta("a", "3.14"),
+            results=[CompatResult(package="x", status="build_ok")],
+        )
+        b = CompatSurvey(
+            meta=self._make_meta("b", "3.15"),
+            results=[CompatResult(package="x", status="build_ok")],
+        )
+        diff = diff_surveys(a, b)
+        self.assertEqual(diff.entries, [])
+
+    def test_status_change(self) -> None:
+        a = CompatSurvey(
+            meta=self._make_meta("a", "3.14"),
+            results=[CompatResult(package="x", status="build_ok")],
+        )
+        b = CompatSurvey(
+            meta=self._make_meta("b", "3.15"),
+            results=[
+                CompatResult(package="x", status="build_fail", primary_category="removed_c_api")
+            ],
+        )
+        diff = diff_surveys(a, b)
+        self.assertEqual(len(diff.entries), 1)
+        self.assertTrue(diff.entries[0].is_regression)
+
+
+# ---------------------------------------------------------------------------
+# load_compat_survey
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCompatSurvey(unittest.TestCase):
+    """Tests for load_compat_survey()."""
+
+    def test_loads_from_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            survey_dir = Path(tmpdir)
+            meta = {
+                "survey_id": "test",
+                "target_python": "/usr/bin/python",
+                "python_version": "3.15.0",
+                "from_mode": "sdist",
+                "no_binary_all": False,
+                "started_at": "now",
+                "finished_at": "later",
+                "total_packages": 2,
+                "installer_preference": "auto",
+            }
+            (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+            results = [
+                {"package": "a", "status": "build_ok"},
+                {"package": "b", "status": "build_fail", "primary_category": "removed_c_api"},
+            ]
+            (survey_dir / "compat_results.jsonl").write_text(
+                "\n".join(json.dumps(r) for r in results) + "\n",
+                encoding="utf-8",
+            )
+            survey = load_compat_survey(survey_dir)
+            self.assertEqual(survey.meta.survey_id, "test")
+            self.assertEqual(len(survey.results), 2)
+            self.assertEqual(survey.results[1].primary_category, "removed_c_api")
+
+    def test_missing_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(FileNotFoundError):
+                load_compat_survey(Path(tmpdir))
+
+    def test_missing_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            survey_dir = Path(tmpdir)
+            meta = {
+                "survey_id": "empty",
+                "target_python": "/usr/bin/python",
+                "python_version": "3.15.0",
+                "from_mode": "sdist",
+                "started_at": "now",
+                "total_packages": 0,
+                "installer_preference": "auto",
+            }
+            (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+            survey = load_compat_survey(survey_dir)
+            self.assertEqual(len(survey.results), 0)
+
+
+# ---------------------------------------------------------------------------
+# Display functions
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCompatReport(unittest.TestCase):
+    """Tests for format_compat_report()."""
+
+    def _make_survey(self) -> CompatSurvey:
+        meta = CompatMeta(
+            survey_id="test",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="2026-03-02T12:00:00",
+            finished_at="2026-03-02T12:30:00",
+            total_packages=3,
+            installer_preference="auto",
+        )
+        return CompatSurvey(
+            meta=meta,
+            results=[
+                CompatResult(package="a", status="build_ok", duration_seconds=10.0),
+                CompatResult(
+                    package="b",
+                    status="build_fail",
+                    primary_category="removed_c_api",
+                    primary_subcategory="tp_print",
+                    primary_description="tp_print removed",
+                    duration_seconds=5.0,
+                ),
+                CompatResult(
+                    package="c",
+                    status="build_fail",
+                    primary_category="removed_c_api",
+                    primary_subcategory="PyUnicode_READY",
+                    primary_description="PyUnicode_READY removed",
+                    duration_seconds=3.0,
+                ),
+            ],
+        )
+
+    def test_contains_header(self) -> None:
+        report = format_compat_report(self._make_survey())
+        self.assertIn("Compatibility Survey: test", report)
+        self.assertIn("3.15.0", report)
+
+    def test_contains_status_overview(self) -> None:
+        report = format_compat_report(self._make_survey())
+        self.assertIn("Status overview", report)
+        self.assertIn("build_ok", report)
+        self.assertIn("build_fail", report)
+
+    def test_contains_category_breakdown(self) -> None:
+        report = format_compat_report(self._make_survey())
+        self.assertIn("removed_c_api", report)
+
+    def test_empty_survey(self) -> None:
+        meta = CompatMeta(
+            survey_id="empty",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=0,
+            installer_preference="auto",
+        )
+        report = format_compat_report(CompatSurvey(meta=meta, results=[]))
+        self.assertIn("No packages surveyed", report)
+
+
+class TestFormatCompatDiff(unittest.TestCase):
+    """Tests for format_compat_diff()."""
+
+    def test_no_differences(self) -> None:
+        d = CompatDiff(
+            survey_a_id="a",
+            survey_b_id="b",
+            python_a="3.14",
+            python_b="3.15",
+            entries=[],
+        )
+        text = format_compat_diff(d)
+        self.assertIn("No differences found", text)
+
+    def test_with_regression(self) -> None:
+        d = CompatDiff(
+            survey_a_id="a",
+            survey_b_id="b",
+            python_a="3.14",
+            python_b="3.15",
+            entries=[
+                CompatDiffEntry(
+                    "pkg", "build_ok", "build_fail", "", "removed_c_api", "", "removed"
+                )
+            ],
+        )
+        text = format_compat_diff(d)
+        self.assertIn("1 regressions", text)
+        self.assertIn("pkg", text)
+
+
+class TestExportCompatMarkdown(unittest.TestCase):
+    """Tests for export_compat_markdown()."""
+
+    def test_markdown_output(self) -> None:
+        meta = CompatMeta(
+            survey_id="md-test",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="2026-03-02T12:00:00",
+            finished_at="2026-03-02T12:30:00",
+            total_packages=1,
+            installer_preference="auto",
+        )
+        survey = CompatSurvey(
+            meta=meta,
+            results=[CompatResult(package="a", status="build_ok")],
+        )
+        md = export_compat_markdown(survey)
+        self.assertIn("# Compatibility Survey: md-test", md)
+        self.assertIn("**Python:** 3.15.0", md)
+        self.assertIn("| build_ok |", md)
+
+    def test_empty_markdown(self) -> None:
+        meta = CompatMeta(
+            survey_id="empty",
+            target_python="/usr/bin/python",
+            python_version="3.15.0",
+            from_mode="sdist",
+            no_binary_all=False,
+            started_at="now",
+            finished_at="later",
+            total_packages=0,
+            installer_preference="auto",
+        )
+        md = export_compat_markdown(CompatSurvey(meta=meta, results=[]))
+        self.assertIn("No packages surveyed", md)
+
+
+class TestFormatPatternsTable(unittest.TestCase):
+    """Tests for format_patterns_table()."""
+
+    def test_all_patterns(self) -> None:
+        table = format_patterns_table(_BUILTIN_PATTERNS)
+        self.assertIn("Category", table)
+        self.assertIn("removed_c_api", table)
+
+    def test_category_filter(self) -> None:
+        table = format_patterns_table(_BUILTIN_PATTERNS, category_filter="pyo3_incompatible")
+        self.assertIn("pyo3_incompatible", table)
+        self.assertNotIn("removed_c_api", table)
+
+    def test_empty_filter(self) -> None:
+        table = format_patterns_table(_BUILTIN_PATTERNS, category_filter="nonexistent")
+        # Should still have headers but no data rows.
+        self.assertIn("Category", table)
+
+
+# ---------------------------------------------------------------------------
+# Builtin patterns sanity
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinPatterns(unittest.TestCase):
+    """Sanity checks on _BUILTIN_PATTERNS."""
+
+    def test_all_have_required_fields(self) -> None:
+        for p in _BUILTIN_PATTERNS:
+            self.assertTrue(p.category, f"Pattern missing category: {p}")
+            self.assertTrue(p.subcategory, f"Pattern missing subcategory: {p}")
+            self.assertTrue(p.description, f"Pattern missing description: {p}")
+            self.assertIsNotNone(p.pattern, f"Pattern missing compiled regex: {p}")
+
+    def test_unique_subcategories_within_category(self) -> None:
+        seen: dict[str, set[str]] = {}
+        for p in _BUILTIN_PATTERNS:
+            subs = seen.setdefault(p.category, set())
+            self.assertNotIn(
+                p.subcategory,
+                subs,
+                f"Duplicate subcategory {p.subcategory} in {p.category}",
+            )
+            subs.add(p.subcategory)
+
+    def test_compiler_error_is_last(self) -> None:
+        """compiler_error and import_failure should be after more specific patterns."""
+        last_specific_idx = -1
+        for i, p in enumerate(_BUILTIN_PATTERNS):
+            if p.category not in ("compiler_error", "import_failure"):
+                last_specific_idx = i
+        first_catchall_idx = len(_BUILTIN_PATTERNS)
+        for i, p in enumerate(_BUILTIN_PATTERNS):
+            if p.category in ("compiler_error", "import_failure"):
+                first_catchall_idx = i
+                break
+        self.assertGreater(first_catchall_idx, last_specific_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compat_cli.py
+++ b/tests/test_compat_cli.py
@@ -1,0 +1,321 @@
+"""Tests for labeille.compat_cli."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from labeille.compat_cli import compat
+
+
+class TestCompatCLIGroup(unittest.TestCase):
+    """Tests for the compat CLI group."""
+
+    def test_group_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(compat, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("survey", result.output)
+        self.assertIn("show", result.output)
+        self.assertIn("diff", result.output)
+        self.assertIn("patterns", result.output)
+
+
+# ---------------------------------------------------------------------------
+# compat survey
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyCommand(unittest.TestCase):
+    """Tests for compat survey command."""
+
+    def test_requires_target_python(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(compat, ["survey"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--target-python", result.output)
+
+    def test_requires_package_source(self) -> None:
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".py") as f:
+            result = runner.invoke(compat, ["survey", "--target-python", f.name])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_workers_must_be_positive(self) -> None:
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".py") as f:
+            result = runner.invoke(
+                compat,
+                [
+                    "survey",
+                    "--target-python",
+                    f.name,
+                    "--packages",
+                    "foo",
+                    "--workers",
+                    "0",
+                ],
+            )
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("labeille.runner.validate_target_python", return_value="3.15.0a5")
+    @patch("labeille.runner.extract_python_minor_version", return_value="3.15")
+    @patch("labeille.compat.resolve_compat_inputs", return_value=[])
+    def test_no_packages_found(
+        self,
+        mock_resolve: MagicMock,
+        mock_minor: MagicMock,
+        mock_validate: MagicMock,
+    ) -> None:
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".py") as f:
+            result = runner.invoke(
+                compat,
+                ["survey", "--target-python", f.name, "--packages", "foo"],
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No packages to survey", result.output)
+
+    @patch("labeille.compat.run_compat_survey")
+    @patch("labeille.compat.resolve_compat_inputs")
+    @patch("labeille.runner.extract_python_minor_version", return_value="3.15")
+    @patch("labeille.runner.validate_target_python", return_value="3.15.0a5")
+    def test_runs_survey(
+        self,
+        mock_validate: MagicMock,
+        mock_minor: MagicMock,
+        mock_resolve: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        from labeille.compat import CompatMeta, CompatPackageInput, CompatResult, CompatSurvey
+
+        mock_resolve.return_value = [CompatPackageInput(name="foo", source="inline")]
+        mock_run.return_value = CompatSurvey(
+            meta=CompatMeta(
+                survey_id="test",
+                target_python="/usr/bin/python",
+                python_version="3.15.0a5",
+                from_mode="sdist",
+                no_binary_all=False,
+                started_at="now",
+                finished_at="later",
+                total_packages=1,
+                installer_preference="auto",
+            ),
+            results=[CompatResult(package="foo", status="build_ok")],
+        )
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with tempfile.NamedTemporaryFile(suffix=".py") as f:
+                result = runner.invoke(
+                    compat,
+                    [
+                        "survey",
+                        "--target-python",
+                        f.name,
+                        "--packages",
+                        "foo",
+                        "--output-dir",
+                        tmpdir,
+                    ],
+                )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Surveying 1 package(s)", result.output)
+        mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# compat show
+# ---------------------------------------------------------------------------
+
+
+class TestShowCommand(unittest.TestCase):
+    """Tests for compat show command."""
+
+    def test_missing_survey_dir(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(compat, ["show", "/nonexistent/path"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_shows_survey(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            survey_dir = Path(tmpdir)
+            meta = {
+                "survey_id": "show-test",
+                "target_python": "/usr/bin/python",
+                "python_version": "3.15.0",
+                "from_mode": "sdist",
+                "no_binary_all": False,
+                "started_at": "2026-03-02T12:00:00",
+                "finished_at": "2026-03-02T12:30:00",
+                "total_packages": 1,
+                "installer_preference": "auto",
+            }
+            (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+            (survey_dir / "compat_results.jsonl").write_text(
+                json.dumps({"package": "a", "status": "build_ok"}) + "\n",
+                encoding="utf-8",
+            )
+            runner = CliRunner()
+            result = runner.invoke(compat, ["show", tmpdir])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("show-test", result.output)
+        self.assertIn("build_ok", result.output)
+
+    def test_show_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            survey_dir = Path(tmpdir)
+            meta = {
+                "survey_id": "md-test",
+                "target_python": "/usr/bin/python",
+                "python_version": "3.15.0",
+                "from_mode": "sdist",
+                "no_binary_all": False,
+                "started_at": "2026-03-02T12:00:00",
+                "finished_at": "2026-03-02T12:30:00",
+                "total_packages": 1,
+                "installer_preference": "auto",
+            }
+            (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+            (survey_dir / "compat_results.jsonl").write_text(
+                json.dumps({"package": "a", "status": "build_ok"}) + "\n",
+                encoding="utf-8",
+            )
+            runner = CliRunner()
+            result = runner.invoke(compat, ["show", tmpdir, "--format", "markdown"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("# Compatibility Survey", result.output)
+
+    def test_show_with_status_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            survey_dir = Path(tmpdir)
+            meta = {
+                "survey_id": "filter-test",
+                "target_python": "/usr/bin/python",
+                "python_version": "3.15.0",
+                "from_mode": "sdist",
+                "no_binary_all": False,
+                "started_at": "now",
+                "finished_at": "later",
+                "total_packages": 2,
+                "installer_preference": "auto",
+            }
+            (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+            results = [
+                {"package": "a", "status": "build_ok"},
+                {"package": "b", "status": "build_fail", "primary_category": "removed_c_api"},
+            ]
+            (survey_dir / "compat_results.jsonl").write_text(
+                "\n".join(json.dumps(r) for r in results) + "\n",
+                encoding="utf-8",
+            )
+            runner = CliRunner()
+            result = runner.invoke(compat, ["show", tmpdir, "--status", "build_fail"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Filtered to 1 result(s)", result.output)
+
+
+# ---------------------------------------------------------------------------
+# compat diff
+# ---------------------------------------------------------------------------
+
+
+class TestDiffCommand(unittest.TestCase):
+    """Tests for compat diff command."""
+
+    def _create_survey_dir(self, tmpdir: str, sid: str, results: list[dict]) -> str:  # type: ignore[type-arg]
+        survey_dir = Path(tmpdir) / sid
+        survey_dir.mkdir()
+        meta = {
+            "survey_id": sid,
+            "target_python": "/usr/bin/python",
+            "python_version": "3.15.0",
+            "from_mode": "sdist",
+            "no_binary_all": False,
+            "started_at": "now",
+            "finished_at": "later",
+            "total_packages": len(results),
+            "installer_preference": "auto",
+        }
+        (survey_dir / "compat_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+        (survey_dir / "compat_results.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in results) + "\n",
+            encoding="utf-8",
+        )
+        return str(survey_dir)
+
+    def test_diff_no_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            a = self._create_survey_dir(tmpdir, "a", [{"package": "x", "status": "build_ok"}])
+            b = self._create_survey_dir(tmpdir, "b", [{"package": "x", "status": "build_ok"}])
+            runner = CliRunner()
+            result = runner.invoke(compat, ["diff", a, b])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No differences found", result.output)
+
+    def test_diff_with_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            a = self._create_survey_dir(tmpdir, "a", [{"package": "x", "status": "build_ok"}])
+            b = self._create_survey_dir(
+                tmpdir,
+                "b",
+                [{"package": "x", "status": "build_fail", "primary_category": "removed_c_api"}],
+            )
+            runner = CliRunner()
+            result = runner.invoke(compat, ["diff", a, b])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("1 regressions", result.output)
+
+
+# ---------------------------------------------------------------------------
+# compat patterns
+# ---------------------------------------------------------------------------
+
+
+class TestPatternsCommand(unittest.TestCase):
+    """Tests for compat patterns command."""
+
+    def test_lists_patterns(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(compat, ["patterns"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Category", result.output)
+        self.assertIn("removed_c_api", result.output)
+
+    def test_category_filter(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(compat, ["patterns", "--category", "pyo3_incompatible"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("pyo3_incompatible", result.output)
+        self.assertNotIn("removed_c_api", result.output)
+
+    def test_extra_patterns(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(
+                "patterns:\n"
+                "  - category: custom\n"
+                "    subcategory: my_pattern\n"
+                "    pattern: 'MY_CUSTOM'\n"
+                "    description: Custom test\n"
+            )
+            f.flush()
+            runner = CliRunner()
+            result = runner.invoke(compat, ["patterns", "--extra-patterns", f.name])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("custom", result.output)
+
+    def test_invalid_extra_patterns(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("not_patterns: []\n")
+            f.flush()
+            runner = CliRunner()
+            result = runner.invoke(compat, ["patterns", "--extra-patterns", f.name])
+        self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `labeille compat` command group with `survey`, `show`, `diff`, and `patterns` subcommands for C extension build compatibility analysis
- Include ~30 built-in error classification patterns across 10+ categories (removed_c_api, cython_incompatible, pyo3_incompatible, numpy_c_api, missing_system_lib, setuptools_distutils, build_backend, compiler_error, import_failure, etc.)
- Support YAML custom patterns, survey diffing for tracking regressions/fixes, markdown export, and parallel execution

## Test plan
- [x] 89 new tests across test_compat.py and test_compat_cli.py
- [x] All 1797 tests pass
- [x] mypy strict passes
- [x] ruff format and check pass

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)