### PR TITLE
Add documentation for benchmarking, free-threaded testing, compat, and workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Registry schema and data structures.
 
 ### Documentation
+- Standalone guides for resolve-run workflow, benchmarking, free-threaded testing, and compatibility analysis (doc/workflow.md, doc/benchmarking.md, doc/free-threaded.md, doc/compat.md).
+- README sections for benchmarking, free-threaded testing, and compatibility analysis features with command examples and links to standalone guides.
+- Updated README Status and Project Structure sections to reflect bench, ft, and compat features.
 - Added Anthropic support acknowledgment section to README.md.
 - Added security warnings to README.md, runner.py module docstring, and CLAUDE.md.
 - Added Gemini acknowledgment to CREDITS.md.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ extensions.
 
 ## Status
 
-**Early development (alpha).** Both the `resolve` and `run` subcommands are
-implemented. The tool can resolve PyPI packages to source repositories, classify
-them by extension type, and run their test suites against a JIT-enabled Python
-build. Crash detection, signature extraction, and JSONL result recording are
-functional. The registry format and CLI interface may change.
+**Early development (alpha).** Core features are implemented and functional:
+`resolve` and `run` for discovering packages and running test suites, `bench`
+for multi-condition performance comparison, `ft` for free-threaded CPython
+compatibility testing, and `compat` for C extension build compatibility surveys.
+The registry format and CLI interface may change.
 
 ## Security Considerations
 
@@ -323,6 +323,90 @@ labeille registry validate
 labeille registry remove-field old_field --apply --lenient
 ```
 
+## Benchmarking
+
+Compare test suite performance across conditions — JIT vs no-JIT, different
+interpreters, with/without coverage:
+
+```bash
+# Compare JIT-enabled vs disabled
+labeille bench run \
+    --condition "jit:target_python=/opt/cpython/python,env.PYTHON_JIT=1" \
+    --condition "nojit:target_python=/opt/cpython/python,env.PYTHON_JIT=0" \
+    --registry-dir registry --work-dir ~/bench-work --top 30
+
+# Or use a YAML profile for repeated benchmarks
+labeille bench run --profile jit-overhead.yaml --registry-dir registry
+
+# View results and compare conditions
+labeille bench show results/bench_*
+labeille bench compare results/bench_*
+
+# Track performance over time
+labeille bench track init jit-perf
+labeille bench track add jit-perf results/bench_*
+labeille bench track trend jit-perf
+```
+
+Key features: multi-condition comparison via YAML profiles or inline definitions,
+statistical analysis with confidence intervals, per-test timing capture, anomaly
+detection, longitudinal tracking with regression alerts, resource constraints
+(memory limits, CPU affinity), cache dropping for cold-start benchmarks, and
+export to CSV/Markdown.
+
+For the complete guide see **[doc/benchmarking.md](doc/benchmarking.md)**.
+
+## Free-Threaded Testing
+
+Test packages against free-threaded CPython builds to detect crashes, deadlocks,
+and race conditions:
+
+```bash
+# Run each package 10 times with PYTHON_GIL=0
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work --top 50
+
+# Compare with GIL-enabled behavior to isolate free-threading issues
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work --compare-with-gil --top 50
+
+# View results and analyze flakiness
+labeille ft show results/ft_*
+labeille ft flaky results/ft_* --package urllib3
+```
+
+Key features: multiple iterations per package to catch intermittent races,
+deadlock detection via output stall monitoring, GIL comparison mode, C extension
+GIL compatibility probing (`Py_mod_gil`), TSAN race condition detection, and
+failure categories (compatible, GIL fallback, intermittent, crash, deadlock).
+
+For the complete guide see **[doc/free-threaded.md](doc/free-threaded.md)**.
+
+## Compatibility Analysis
+
+Survey C extension packages for build compatibility against any Python version:
+
+```bash
+# Survey all C extensions in the registry against Python 3.15
+labeille compat survey --target-python ~/cpython-315/python \
+    --registry-dir registry --extensions-only --workers 4
+
+# Or survey specific packages from sdist or source
+labeille compat survey --target-python ~/cpython-315/python \
+    --packages numpy,scipy,pandas --from source
+
+# View results, diff two surveys
+labeille compat show compat-results/compat_*
+labeille compat diff compat-results/compat_314 compat-results/compat_315
+```
+
+Key features: three build modes (sdist, git source, `--no-binary :all:`), 40+
+built-in error classification patterns (removed C API, Cython, PyO3, struct
+changes, meson, cmake), custom pattern support via YAML, import probing after
+build, parallel execution, and markdown export.
+
+For the complete guide see **[doc/compat.md](doc/compat.md)**.
+
 ## Registry Format
 
 ### Package file (`registry/packages/{name}.yaml`)
@@ -379,7 +463,7 @@ Result statuses: `pass`, `fail`, `crash`, `timeout`, `install_error`,
 ```
 labeille/
 ├── src/labeille/        # Main package
-│   ├── cli.py           # Click CLI with resolve, run, bisect, scan-deps, registry, and analyze subcommands
+│   ├── cli.py           # Click CLI entry point (resolve, run, bisect, scan-deps, registry, analyze)
 │   ├── resolve.py       # Resolve PyPI packages to source repositories
 │   ├── runner.py        # Run test suites and capture results
 │   ├── bisect.py        # Automated crash bisection across git history
@@ -388,6 +472,22 @@ labeille/
 │   ├── registry_ops.py  # Batch operations (add/remove/rename/set/validate)
 │   ├── analyze.py       # Data loading and analysis functions
 │   ├── analyze_cli.py   # Analysis CLI (registry, run, compare, history, package)
+│   ├── bench_cli.py     # Benchmarking CLI (run, show, compare, track, export)
+│   ├── bench/           # Benchmarking subsystem
+│   │   ├── runner.py    # Benchmark execution engine
+│   │   ├── config.py    # Profile loading and condition resolution
+│   │   ├── compare.py   # Statistical comparison
+│   │   ├── tracking.py  # Longitudinal tracking series
+│   │   ├── trends.py    # Trend analysis and regression detection
+│   │   └── ...          # stats, anomaly, constraints, cache, system, export
+│   ├── ft_cli.py        # Free-threaded testing CLI (run, show, flaky, compat, compare)
+│   ├── ft/              # Free-threaded testing subsystem
+│   │   ├── runner.py    # Free-threading test execution
+│   │   ├── results.py   # Failure categories and result structures
+│   │   ├── compat.py    # Extension GIL compatibility detection
+│   │   └── ...          # analysis, compare, display, export
+│   ├── compat_cli.py    # Compatibility survey CLI (survey, show, diff, patterns)
+│   ├── compat.py        # C extension compatibility survey and error classification
 │   ├── formatting.py    # Shared text formatting (tables, histograms, sparklines)
 │   ├── summary.py       # Run summary formatting
 │   ├── yaml_lines.py    # Line-level YAML manipulation
@@ -397,6 +497,10 @@ labeille/
 │   ├── crash.py         # Crash detection and signature extraction
 │   └── logging.py       # Structured logging setup
 ├── doc/                 # Documentation
+│   ├── workflow.md      # Resolve-run workflow guide
+│   ├── benchmarking.md  # Benchmarking guide
+│   ├── free-threaded.md # Free-threaded testing guide
+│   ├── compat.md        # Compatibility analysis guide
 │   └── enrichment.md    # Package enrichment guide
 ├── tests/               # Unit and integration tests
 ├── registry/            # Package test configurations

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -1,0 +1,501 @@
+# Benchmarking
+
+## What is benchmarking in labeille?
+
+labeille's benchmarking system measures **whole test suite execution time** across
+different conditions — JIT vs no-JIT, different interpreters, with/without coverage,
+varying resource constraints. It is not a microbenchmark tool: it runs the same test
+suites you use with `labeille run`, collects wall/user/sys time and peak RSS for each
+iteration, and produces statistical comparisons.
+
+This answers questions like:
+- How much overhead does the JIT add to test suite execution?
+- Is a new CPython build faster or slower than the previous one?
+- Which packages show the most JIT overhead?
+- Are there performance regressions over time?
+
+
+## Quick Start
+
+### Inline conditions (simplest)
+
+Compare JIT-enabled vs JIT-disabled with two inline conditions:
+
+```bash
+labeille bench run \
+    --condition "jit:target_python=/opt/cpython-jit/python,env.PYTHON_JIT=1" \
+    --condition "nojit:target_python=/opt/cpython-jit/python,env.PYTHON_JIT=0" \
+    --registry-dir registry \
+    --work-dir ~/bench-work \
+    --packages requests,click,flask
+```
+
+### Quick mode
+
+For a fast sanity check — 3 iterations, no warmup, top 20 packages:
+
+```bash
+labeille bench run --quick \
+    --condition "jit:target_python=/opt/cpython-jit/python,env.PYTHON_JIT=1" \
+    --condition "nojit:target_python=/opt/cpython-jit/python,env.PYTHON_JIT=0" \
+    --registry-dir registry --work-dir ~/bench-work
+```
+
+### YAML profile (recommended for repeated use)
+
+```bash
+labeille bench run --profile jit-overhead.yaml \
+    --registry-dir registry --work-dir ~/bench-work
+```
+
+### View and compare results
+
+```bash
+# Display results
+labeille bench show results/bench_20260303_140000
+
+# Compare conditions within a run
+labeille bench compare results/bench_20260303_140000
+
+# Compare across runs
+labeille bench compare results/bench_run1 results/bench_run2
+```
+
+
+## Concepts
+
+### Conditions
+
+A **condition** is a named configuration that defines how to run tests. Each benchmark
+compares one or more conditions. A condition can specify:
+
+- `target_python` — path to the Python interpreter
+- `env` — environment variables (e.g., `PYTHON_JIT=1`)
+- `extra_deps` — additional packages to install
+- `test_command_prefix` — prepend to test commands (e.g., `coverage run -m`)
+- `test_command_suffix` — append to test commands
+- `test_command_override` — replace test commands entirely
+- `install_command` — override install commands
+- `constraints` — resource limits (memory, CPU affinity, CPU time)
+
+### Iterations and warmup
+
+Each package's test suite runs multiple times per condition:
+
+- **Warmup iterations** (default: 1) — not included in statistics, allows caches and
+  JIT compilation to stabilize
+- **Measured iterations** (default: 5, minimum: 3) — collected for statistical analysis
+
+More iterations improve statistical confidence but increase total runtime linearly.
+
+### Execution strategies
+
+When comparing multiple conditions:
+
+- **Alternating** (default for multi-condition): runs condition A then B for package 1,
+  then A then B for package 2, etc. Reduces systematic bias from time-varying factors
+  (thermal throttling, background load).
+- **Block**: runs all iterations of condition A for all packages, then all of condition B.
+  Faster but more susceptible to systematic bias.
+- **Interleaved** (`--interleave`): interleaves packages across iterations. Useful when
+  you want to distribute cache/memory effects across the run.
+
+
+## YAML Profile Format
+
+A profile defines conditions and shared settings in a YAML file:
+
+```yaml
+name: JIT overhead measurement
+description: Compare JIT-enabled vs JIT-disabled CPython
+
+iterations: 7
+warmup: 2
+timeout: 600
+
+conditions:
+  jit:
+    target_python: /opt/cpython-jit/python
+    env:
+      PYTHON_JIT: "1"
+
+  nojit:
+    target_python: /opt/cpython-jit/python
+    env:
+      PYTHON_JIT: "0"
+
+# Shared settings applied to all conditions unless overridden
+default_env:
+  ASAN_OPTIONS: "detect_leaks=0"
+
+default_extra_deps:
+  - pytest-timeout
+
+# Optional: package filtering
+packages:
+  - requests
+  - click
+  - flask
+
+# Optional: resource constraints applied to all conditions
+default_constraints:
+  cpu_affinity: "0,1"
+  memory_limit_mb: 4096
+```
+
+### Inline condition syntax
+
+The `--condition` flag uses the format `name:key=value,key=value`:
+
+```bash
+--condition "jit:target_python=/opt/python,env.PYTHON_JIT=1"
+--condition "nojit:target_python=/opt/python,env.PYTHON_JIT=0"
+```
+
+Supported keys: `target_python`, `env.KEY`, `extra_deps`, `test_command_prefix`,
+`test_command_suffix`, `test_command_override`, `install_command`.
+
+
+## Running Benchmarks
+
+### System stability
+
+For reliable results, ensure the system is quiet:
+
+```bash
+# Check stability before starting (warns if load is high)
+labeille bench run --check-stability --profile profile.yaml ...
+
+# Wait for system to stabilize before starting
+labeille bench run --wait-for-stability --profile profile.yaml ...
+```
+
+### Package selection
+
+Same options as `labeille run`:
+
+```bash
+--packages requests,click    # Specific packages
+--top 50                     # Top N by downloads
+--registry-dir registry      # Required
+```
+
+### Persistent directories
+
+Reuse repos and venvs across benchmark runs:
+
+```bash
+--work-dir ~/bench-work      # Sets both repos-dir and venvs-dir
+--repos-dir ~/repos           # Or set individually
+--venvs-dir ~/venvs
+```
+
+### Resource constraints
+
+Control resource usage per iteration:
+
+```bash
+# Memory limit (ulimit -v)
+labeille bench run --memory-limit 4096 ...
+
+# CPU affinity (taskset) — pin to specific cores
+labeille bench run --cpu-affinity "0,1" ...
+
+# CPU time limit (ulimit -t)
+labeille bench run --cpu-time-limit 300 ...
+```
+
+Constraints can also be set per-condition in a YAML profile.
+
+### Per-test timing
+
+Capture individual test timings via `pytest --durations=0`:
+
+```bash
+labeille bench run --per-test-timing --profile profile.yaml ...
+```
+
+This enables `--per-test` in `bench show` and `bench compare` to identify which
+specific tests contribute most to overhead.
+
+### Cache dropping
+
+For cold-start benchmarks, drop filesystem caches between iterations:
+
+```bash
+# First: set up the cache-drop helper (requires sudo configuration)
+labeille bench setup-cache-drop
+
+# Then run with cache dropping
+labeille bench run --drop-caches --profile profile.yaml ...
+
+# Or compare warm vs cold automatically
+labeille bench run --warm-vs-cold --profile profile.yaml ...
+```
+
+
+## Viewing Results
+
+### bench show
+
+Display results from a benchmark run:
+
+```bash
+labeille bench show results/bench_20260303_140000
+```
+
+Shows system profile, conditions defined, and a per-package table with median
+wall time, IQR, coefficient of variation, and status for each condition.
+
+### Anomaly detection
+
+Flag measurement anomalies — high variance, bimodal distributions, outliers:
+
+```bash
+labeille bench show results/bench_20260303_140000 --anomalies
+```
+
+Anomaly types: `high_cv` (coefficient of variation > threshold), `bimodal`
+(suspected multimodal distribution), `outlier_heavy` (many outlier iterations),
+`status_mixed` (some iterations pass, some fail), `trend` (monotonic drift).
+
+### Per-test timing
+
+Show individual test timings for a specific package:
+
+```bash
+labeille bench show results/bench_20260303_140000 --per-test requests
+```
+
+
+## Comparing Results
+
+### Within a single run (multi-condition)
+
+Compare conditions defined in the same benchmark:
+
+```bash
+labeille bench compare results/bench_20260303_140000
+```
+
+Shows overhead percentage, confidence intervals, and statistical significance
+(Welch's t-test) for each package.
+
+### Across separate runs
+
+Compare results from different benchmark executions:
+
+```bash
+labeille bench compare results/bench_run1 results/bench_run2
+```
+
+### Per-test comparison
+
+Identify which tests contribute most to overhead:
+
+```bash
+labeille bench compare results/bench_20260303_140000 --per-test requests
+```
+
+### Choosing a metric
+
+```bash
+--metric wall    # Wall clock time (default)
+--metric cpu     # User + sys CPU time
+--metric rss     # Peak resident set size
+```
+
+
+## Longitudinal Tracking
+
+Track benchmark performance over time with tracking series.
+
+### Creating a series
+
+```bash
+labeille bench track init jit-perf --description "JIT performance over CPython commits"
+```
+
+### Adding runs to a series
+
+```bash
+labeille bench track add jit-perf results/bench_20260303_140000 \
+    --notes "CPython main @ abc1234" \
+    --commit sha=abc1234,branch=main
+```
+
+### Viewing series history
+
+```bash
+labeille bench track show jit-perf          # All runs
+labeille bench track show jit-perf --last 5 # Last 5 runs
+```
+
+### Pinning a baseline
+
+Pin a specific run as the reference point for trend analysis:
+
+```bash
+labeille bench track pin jit-perf bench_20260301_100000
+labeille bench track unpin jit-perf   # Remove pin
+```
+
+### Trend analysis
+
+Detect performance trends and regressions across the series:
+
+```bash
+labeille bench track trend jit-perf
+labeille bench track trend jit-perf --condition jit --format markdown
+```
+
+Classifies each package as: `stable`, `improving`, `regressing`, or `volatile`.
+
+Thresholds are configurable:
+- `--regression-threshold 0.02` — per-run change threshold (fraction)
+- `--trend-threshold 0.05` — overall slope threshold for classification
+
+### Regression alerts
+
+Check for new regressions compared to the baseline and previous run:
+
+```bash
+labeille bench track alert jit-perf
+```
+
+### Listing all series
+
+```bash
+labeille bench track list
+```
+
+
+## Exporting Results
+
+### CSV (raw data)
+
+One row per package per condition per iteration — for pandas, R, or spreadsheets:
+
+```bash
+labeille bench export results/bench_20260303_140000 --format csv
+labeille bench export results/bench_20260303_140000 --format csv -o data.csv
+```
+
+### CSV summary
+
+One row per package per condition with aggregated statistics:
+
+```bash
+labeille bench export results/bench_20260303_140000 --format csv-summary
+```
+
+### Markdown
+
+Summary table suitable for GitHub issues and reports:
+
+```bash
+labeille bench export results/bench_20260303_140000 --format markdown
+```
+
+
+## Output Files
+
+A benchmark run produces:
+
+```
+results/bench_20260303_140000/
+├── bench_meta.json       # System profile, Python profile, conditions, timing
+└── bench_results.jsonl   # One JSON line per package with per-condition data
+```
+
+`bench_meta.json` contains:
+- System characterization (CPU, RAM, OS, kernel)
+- Python profile for each condition (version, JIT status, GIL, build flags)
+- Condition definitions as resolved
+- Execution timestamps
+
+`bench_results.jsonl` contains per-package:
+- Per-condition iteration timings (wall, user, sys, RSS)
+- Descriptive statistics (mean, median, std, percentiles, IQR, CV)
+- Outlier flags
+- Per-test timings (if `--per-test-timing` was used)
+
+
+## System Profiling
+
+Print system characterization for documentation and reproducibility:
+
+```bash
+labeille bench system
+labeille bench system --target-python /opt/cpython/python
+labeille bench system --json
+```
+
+
+## Examples
+
+### JIT overhead measurement
+
+```bash
+# Create a profile
+cat > jit-profile.yaml << 'EOF'
+name: JIT overhead
+iterations: 7
+warmup: 2
+conditions:
+  jit:
+    target_python: /opt/cpython-jit/python
+    env: { PYTHON_JIT: "1" }
+  nojit:
+    target_python: /opt/cpython-jit/python
+    env: { PYTHON_JIT: "0" }
+EOF
+
+# Run the benchmark
+labeille bench run --profile jit-profile.yaml \
+    --registry-dir registry --work-dir ~/bench-work --top 30
+
+# View results
+labeille bench show results/bench_*
+
+# Compare conditions
+labeille bench compare results/bench_*
+```
+
+### Tracking JIT performance over time
+
+```bash
+# Initialize a series
+labeille bench track init jit-tracking -d "Track JIT overhead across CPython commits"
+
+# After each CPython build, run and add:
+labeille bench run --profile jit-profile.yaml --registry-dir registry --work-dir ~/bench
+labeille bench track add jit-tracking results/bench_* --commit sha=$(git -C ~/cpython rev-parse HEAD)
+
+# Check for regressions
+labeille bench track trend jit-tracking
+labeille bench track alert jit-tracking
+```
+
+
+## Troubleshooting
+
+### High variance in measurements
+
+- Close other applications and background processes
+- Use `--check-stability` or `--wait-for-stability`
+- Pin CPU cores with `--cpu-affinity` to avoid migration
+- Check for thermal throttling (sustained heavy loads)
+- Increase `--iterations` for better statistical confidence
+
+### Mixed pass/fail across iterations
+
+Flaky tests pollute timing data. Use `--anomalies` with `bench show` to identify
+packages with `status_mixed` anomalies. Consider adding `--test-command-suffix "-k
+'not flaky_test'"` to exclude known flaky tests.
+
+### OOM kills
+
+- ASAN-enabled builds use ~2-3x memory; increase `--memory-limit` or use a non-ASAN build
+- Reduce `--workers` if running other processes
+- Check `oom_detected` field in results for confirmation

--- a/doc/compat.md
+++ b/doc/compat.md
@@ -1,0 +1,352 @@
+# C Extension Compatibility Analysis
+
+## What is compat?
+
+`labeille compat` surveys C extension packages for build compatibility against any
+Python version. It builds each package, captures the full build output, and classifies
+failures into fine-grained categories using 40+ built-in error patterns.
+
+This answers questions like:
+- How many packages build successfully on Python 3.15?
+- Which removed C APIs are blocking the most packages?
+- Did a new CPython release fix or break anything compared to the last one?
+- What are the main categories of build failures?
+
+
+## Quick Start
+
+### Registry-based survey
+
+```bash
+# Survey all C extension packages in the registry
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --registry-dir registry \
+    --extensions-only
+
+# Survey top 50 by downloads
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --registry-dir registry \
+    --top 50
+```
+
+### Ad-hoc package list
+
+```bash
+# Inline package list
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --packages numpy,scipy,pandas
+
+# From a file (one per line)
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --packages-file packages.txt
+```
+
+### View and compare results
+
+```bash
+# Display results
+labeille compat show results/compat_20260303
+
+# Compare two surveys (e.g., Python 3.14 vs 3.15)
+labeille compat diff results/compat_314 results/compat_315
+```
+
+
+## Concepts
+
+### Build modes
+
+| Mode | Flag | What it does |
+|------|------|-------------|
+| **sdist** (default) | `--from sdist` | Downloads sdist from PyPI, builds with `pip install --no-binary <pkg> <pkg>` |
+| **source** | `--from source` | Clones git repo, builds with the registry's `install_command` |
+| **no-binary-all** | `--no-binary-all` | Builds everything from source including dependencies: `pip install --no-binary :all: <pkg>` |
+
+**sdist** is the most common mode — it tests what PyPI users experience when
+installing from source distributions. **source** tests the latest git HEAD.
+**no-binary-all** is the strictest, forcing all transitive dependencies to build
+from source too (much slower, more likely to time out).
+
+### Error classification
+
+Build output is matched against 40+ regular expression patterns organized into
+categories and subcategories. When a build fails, all matching patterns are
+recorded. The **primary category** is the first match (most specific patterns
+are listed first).
+
+### Error categories
+
+| Category | Description | Since |
+|----------|-------------|-------|
+| `python_header` | Python.h not found (dev headers missing) | — |
+| `removed_c_api` | Functions/macros removed in recent Python versions | 3.12+ |
+| `changed_struct` | Direct struct member access (use accessor macros instead) | 3.12+ |
+| `cython_incompatible` | Cython version too old for target Python | — |
+| `pyo3_incompatible` | PyO3/Maturin doesn't support target Python | — |
+| `numpy_c_api` | NumPy C API/ABI version mismatch | — |
+| `missing_system_lib` | Missing system headers or libraries | — |
+| `setuptools_distutils` | distutils removed, pkg_resources missing | 3.12+ |
+| `build_backend` | PEP 517 backend errors, Meson, CMake | — |
+| `compiler_error` | Generic C/C++ compilation or linker errors | — |
+| `import_failure` | Undefined symbols or ABI mismatch at import time | — |
+
+Each category has multiple subcategories. For example, `removed_c_api` includes:
+`PyUnicode_READY`, `Py_UNICODE`, `PyUnicode_AS_UNICODE`, `tp_print`,
+`PyEval_CallObject`, and more.
+
+### Import probing
+
+After a successful build, labeille imports the package to detect runtime issues
+that don't surface during compilation (e.g., undefined symbols from ABI mismatches).
+Import failures are classified as `import_fail` or `import_crash`.
+
+### Crash detection
+
+If the build or import process crashes (segfault, abort), labeille detects it
+using the same crash detection module as `labeille run`.
+
+
+## Running Surveys
+
+### Package sources
+
+Packages can come from three sources, which are merged:
+
+```bash
+--registry-dir registry      # All packages in the registry
+--packages numpy,scipy       # Inline list
+--packages-file packages.txt # One per line
+```
+
+Filter to C extension packages only (default for registry-based):
+
+```bash
+--extensions-only   # Only packages with extension_type=extensions (default)
+--all-types         # Include pure Python packages too
+```
+
+### Build modes
+
+```bash
+--from sdist              # Build from PyPI sdist (default)
+--from source             # Clone and build from git repo
+--no-binary-all           # Force compile everything including deps
+```
+
+For source mode, you can specify a persistent repo directory:
+
+```bash
+--repos-dir ~/compat-repos   # Reuse repo clones
+```
+
+### Custom error patterns
+
+Extend or override the built-in patterns with a YAML file:
+
+```bash
+labeille compat survey --extra-patterns my-patterns.yaml ...
+```
+
+### Parallel execution
+
+```bash
+--workers 4    # Run 4 package builds in parallel
+```
+
+### Other options
+
+| Option | Description |
+|--------|-------------|
+| `--target-python PATH` | Python interpreter to build against (required) |
+| `--output-dir PATH` | Output directory (default: `compat-results`) |
+| `--timeout SECONDS` | Build timeout per package (default: 600) |
+| `--workers N` | Parallel builds (default: 1) |
+| `--installer {auto,uv,pip}` | Package installer backend (default: auto) |
+| `--export-markdown` | Also export results as a markdown file |
+| `-v, --verbose` | Detailed output |
+| `-q, --quiet` | Only show errors |
+
+
+## Viewing Results
+
+### compat show
+
+Display a saved survey:
+
+```bash
+labeille compat show results/compat_20260303
+
+# Filter by status
+labeille compat show results/compat_20260303 --status build_fail
+
+# Filter by failure category
+labeille compat show results/compat_20260303 --category removed_c_api
+
+# Markdown format for sharing
+labeille compat show results/compat_20260303 --format markdown
+```
+
+### Listing patterns
+
+See all available error classification patterns:
+
+```bash
+labeille compat patterns
+
+# Filter by category
+labeille compat patterns --category removed_c_api
+
+# Include custom patterns
+labeille compat patterns --extra-patterns my-patterns.yaml
+```
+
+
+## Comparing Surveys
+
+Compare two surveys to track compatibility changes:
+
+```bash
+labeille compat diff results/compat_314 results/compat_315
+```
+
+Shows:
+- **Regressions**: packages that went from `build_ok` to a failure
+- **Fixes**: packages that went from a failure to `build_ok`
+- **Category changes**: packages whose failure category changed
+
+Use case: run surveys against Python 3.14 and 3.15, then diff to see what the
+new version broke or fixed.
+
+
+## Custom Error Patterns
+
+### YAML format
+
+```yaml
+patterns:
+  - category: my_project
+    subcategory: special_api
+    since: "3.15"
+    pattern: "error.*MySpecialAPI"
+    description: "MySpecialAPI removed in 3.15"
+
+  - category: removed_c_api
+    subcategory: PyFrameObject_fields
+    since: "3.15"
+    pattern: "error.*PyFrameObject.*f_lineno"
+    description: "Direct PyFrameObject field access removed"
+```
+
+### Overriding built-in patterns
+
+If a custom pattern has the same `category` and `subcategory` as a built-in
+pattern, the custom version takes precedence. This lets you refine built-in
+patterns without modifying labeille's source code.
+
+
+## Output Files
+
+A survey produces:
+
+```
+compat-results/compat_20260303_140000/
+├── compat_meta.json      # Survey metadata (target Python, mode, timing)
+├── compat_results.jsonl  # One JSON line per package with status and matches
+└── build_logs/           # Full stdout/stderr for failed builds
+    ├── numpy_stdout.txt
+    ├── numpy_stderr.txt
+    └── ...
+```
+
+`compat_results.jsonl` contains per-package:
+- Build status (`build_ok`, `build_fail`, `import_fail`, `import_crash`,
+  `no_sdist`, `timeout`, `skip`)
+- Exit code and duration
+- Error matches (category, subcategory, matched line, line number)
+- Primary category and subcategory
+- Crash signature (if applicable)
+
+
+## Examples
+
+### Python 3.15 compatibility survey
+
+```bash
+# Survey all C extension packages in the registry
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --registry-dir registry \
+    --extensions-only \
+    --workers 4 \
+    --export-markdown
+
+# View the results
+labeille compat show compat-results/compat_*
+
+# Check which removed APIs are causing the most failures
+labeille compat show compat-results/compat_* --category removed_c_api
+```
+
+### Cross-version tracking
+
+```bash
+# Survey against 3.14
+labeille compat survey \
+    --target-python ~/cpython-314/python \
+    --packages-file c-ext-packages.txt \
+    --output-dir compat-314
+
+# Survey against 3.15
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --packages-file c-ext-packages.txt \
+    --output-dir compat-315
+
+# Diff: what changed?
+labeille compat diff compat-314/compat_* compat-315/compat_*
+```
+
+### Source mode for unreleased code
+
+Test the latest git HEAD of packages against the target Python:
+
+```bash
+labeille compat survey \
+    --target-python ~/cpython-315/python \
+    --registry-dir registry \
+    --from source \
+    --repos-dir ~/compat-repos \
+    --extensions-only \
+    --workers 2
+```
+
+
+## Troubleshooting
+
+### All packages fail with python_header
+
+The target Python's development headers are not installed or not in the expected
+location. Verify:
+```bash
+ls $(~/cpython-315/python -c "import sysconfig; print(sysconfig.get_path('include'))")/Python.h
+```
+
+### sdist not available
+
+Some packages only distribute wheels on PyPI. Use `--from source` to clone and
+build from the git repository instead.
+
+### Timeouts on large builds
+
+Packages like numpy, scipy, and tensorflow can take 10+ minutes to build from
+source. Increase `--timeout` accordingly, or exclude them from the survey.
+
+### Many unclassified failures
+
+If many packages show `unclassified/unknown`, the build errors don't match any
+built-in patterns. Check the build logs in `build_logs/` and consider adding
+custom patterns via `--extra-patterns`.

--- a/doc/free-threaded.md
+++ b/doc/free-threaded.md
@@ -1,0 +1,419 @@
+# Free-Threaded Testing
+
+## What is free-threaded testing?
+
+Free-threaded CPython (PEP 703) removes the Global Interpreter Lock (GIL), enabling
+true parallelism but introducing new failure modes: data races, deadlocks, and crashes
+in code that relied on the GIL for thread safety.
+
+`labeille ft` tests packages against free-threaded CPython builds by running each
+package's test suite multiple times with `PYTHON_GIL=0`. Multiple iterations catch
+intermittent failures — race conditions don't reproduce deterministically.
+
+Each package is classified into a compatibility category: fully compatible, compatible
+with GIL fallback, intermittent failures, incompatible, crash, or deadlock.
+
+
+## Prerequisites
+
+- A **free-threaded CPython build** (`./configure --disable-gil`)
+- Optional: a **TSAN build** for race condition detection
+  (`./configure --disable-gil --with-thread-sanitizer`)
+- Packages enriched in the registry (see [workflow.md](workflow.md))
+
+
+## Quick Start
+
+### Basic survey
+
+```bash
+# Run each package 10 times with PYTHON_GIL=0
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --top 50
+
+# View results
+labeille ft show results/ft_*
+```
+
+### Quick coverage scan
+
+Stop after the first passing iteration per package:
+
+```bash
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --stop-on-first-pass --top 100
+```
+
+### Thorough analysis with GIL comparison
+
+```bash
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --compare-with-gil --iterations 10 --top 50
+```
+
+### TSAN race detection
+
+```bash
+labeille ft run --target-python ~/cpython-tsan/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --tsan --iterations 5 --top 30
+```
+
+
+## Concepts
+
+### Failure categories
+
+Each package is classified based on its behavior across all iterations:
+
+| Category | Description |
+|----------|-------------|
+| `compatible` | All iterations pass — fully compatible with free-threading |
+| `compatible_gil_fallback` | Passes, but the GIL is re-enabled at runtime (C extension without `Py_mod_gil`) |
+| `intermittent` | Some iterations pass, some fail — likely race conditions |
+| `incompatible` | All iterations fail consistently (not a race, just broken) |
+| `crash` | Segfault, abort, or assertion failure under free-threading |
+| `deadlock` | Test suite stalls with no output (detected via stall threshold) |
+| `tsan_warnings` | TSAN detects data races (may still pass functionally) |
+| `install_failure` | Could not install the package |
+| `import_failure` | Package installs but fails to import |
+| `unknown` | Uncategorizable result |
+
+### Iterations and reliability
+
+Free-threading bugs are often non-deterministic. A single run may pass even if the
+code has race conditions. The default of 10 iterations provides reasonable detection
+probability:
+
+- A race that manifests ~50% of the time will be caught with >99.9% probability
+  in 10 runs
+- A race that manifests ~10% of the time will be caught with ~65% probability
+
+Increase `--iterations` for rare races, or use `--stop-on-first-pass` for quick
+coverage scans where you only need to know if it *can* pass.
+
+### Deadlock detection
+
+`--stall-threshold SECONDS` (default: 60) monitors test suite output. If no output
+is produced for the threshold duration, the iteration is classified as a deadlock
+and the process is killed.
+
+Increase the threshold for packages with naturally slow tests (heavy computation,
+network waits).
+
+### GIL comparison mode
+
+`--compare-with-gil` runs each package twice:
+1. With `PYTHON_GIL=0` (free-threaded)
+2. With `PYTHON_GIL=1` (GIL enabled)
+
+This isolates free-threading-specific failures: if a package fails with both
+GIL=0 and GIL=1, the failure is unrelated to free-threading (e.g., a pre-existing
+test bug). Only failures unique to GIL=0 are true free-threading issues.
+
+### Extension GIL compatibility
+
+When `--detect-extensions` is enabled (default), labeille probes each package's
+C extensions for free-threading compatibility:
+
+- Checks if extensions declare `Py_mod_gil` (the opt-in for free-threading)
+- Monitors `sys._is_gil_enabled()` at runtime to detect GIL fallback
+- Reports which packages trigger GIL re-enablement due to incompatible extensions
+
+
+## Running Tests
+
+### Package selection
+
+```bash
+--packages requests,click    # Specific packages
+--top 50                     # Top N by downloads
+--registry-dir registry      # Required
+```
+
+### Iteration control
+
+```bash
+--iterations 10              # Measured iterations per package (default: 10)
+--stop-on-first-pass         # Stop after first passing iteration
+```
+
+### Timeouts and stalls
+
+```bash
+--timeout 600                # Per-iteration timeout in seconds (default: 600)
+--stall-threshold 60         # Seconds without output before deadlock (default: 60)
+```
+
+### Extra dependencies and overrides
+
+```bash
+--extra-deps "trustme,uvicorn"         # Inject deps into every venv
+--test-command-suffix "--tb=short"     # Append to test commands
+--test-command-override "python -m pytest tests/" # Replace all test commands
+```
+
+### Environment variables
+
+```bash
+--env PYTHONMALLOC=debug     # Extra env vars (repeatable)
+--env PYTHONTRACEMALLOC=5
+```
+
+`PYTHON_GIL=0` is set automatically — you don't need to specify it.
+
+### Persistent directories
+
+```bash
+--repos-dir ~/repos          # Reuse repo clones
+--venvs-dir ~/venvs          # Reuse venvs
+--results-dir results        # Output directory (default: results)
+```
+
+### Full options
+
+| Option | Description |
+|--------|-------------|
+| `--target-python PATH` | Free-threaded Python build (required) |
+| `--iterations N` | Iterations per package (default: 10) |
+| `--timeout SECONDS` | Per-iteration timeout (default: 600) |
+| `--stall-threshold SECONDS` | Deadlock detection threshold (default: 60) |
+| `--packages CSV` | Comma-separated package filter |
+| `--top N` | Top N packages by downloads |
+| `--compare-with-gil` | Also run with GIL enabled for comparison |
+| `--stop-on-first-pass` | Stop after first passing iteration |
+| `--detect-extensions` | Check extension GIL compatibility (default: on) |
+| `--tsan` | Parse TSAN warnings from stderr |
+| `--check-stability` | Check system stability before starting |
+| `--extra-deps CSV` | Extra dependencies for every venv |
+| `--test-command-suffix STR` | Append to test commands |
+| `--test-command-override STR` | Override all test commands |
+| `--env KEY=VALUE` | Extra environment variables (repeatable) |
+| `--registry-dir PATH` | Registry directory (default: `registry`) |
+| `--repos-dir PATH` | Persistent repos (default: `repos`) |
+| `--venvs-dir PATH` | Persistent venvs (default: `venvs`) |
+| `--results-dir PATH` | Output directory (default: `results`) |
+| `-v, --verbose` | Detailed output |
+
+
+## Viewing Results
+
+### ft show
+
+Display a summary of free-threading test results:
+
+```bash
+labeille ft show results/ft_20260303_140000
+labeille ft show results/ft_20260303_140000 --sort pass_rate
+labeille ft show results/ft_20260303_140000 --limit 20
+```
+
+Shows: system and Python info, compatibility summary (counts per category),
+and a per-package table with category, pass rate, and iteration details.
+
+Sorting options: `category` (default), `pass_rate`, `name`.
+
+### Flakiness analysis
+
+Investigate intermittent failures in detail:
+
+```bash
+# Overview of all flaky packages
+labeille ft flaky results/ft_20260303_140000
+
+# Deep dive on one package
+labeille ft flaky results/ft_20260303_140000 --package urllib3
+```
+
+Shows which tests fail intermittently, failure patterns across iterations, and
+crash signature consistency.
+
+### Extension compatibility
+
+Check which packages have C extensions and their GIL compatibility status:
+
+```bash
+labeille ft compat results/ft_20260303_140000
+labeille ft compat results/ft_20260303_140000 --extensions-only
+```
+
+Reports `Py_mod_gil` declarations, GIL fallback status, and whether extensions
+are free-threading-safe.
+
+
+## Comparing Runs
+
+Track free-threading compatibility across CPython releases:
+
+```bash
+labeille ft compare results/ft_314a1 results/ft_314b2
+```
+
+Shows:
+- Category transitions (e.g., `crash` -> `compatible`)
+- Pass rate changes
+- New issues and resolved issues
+
+Use case: run the same packages against CPython 3.14a1 and 3.14b2 to track
+which packages gain or lose free-threading compatibility.
+
+
+## Reports and Exports
+
+### Comprehensive report
+
+Generate a full compatibility report for sharing:
+
+```bash
+labeille ft report results/ft_20260303_140000
+labeille ft report results/ft_20260303_140000 --format markdown -o report.md
+labeille ft report results/ft_20260303_140000 --format text
+```
+
+### Export for analysis
+
+```bash
+# CSV — one row per package
+labeille ft export results/ft_20260303_140000 --format csv -o results.csv
+
+# JSON — structured data
+labeille ft export results/ft_20260303_140000 --format json -o results.json
+```
+
+
+## Output Files
+
+A free-threading run produces:
+
+```
+results/ft_20260303_140000/
+├── ft_meta.json          # Run metadata (target Python, config, system info)
+└── ft_results.jsonl      # One JSON line per package with all iterations
+```
+
+`ft_results.jsonl` contains per-package:
+- Failure category classification
+- Per-iteration outcomes (pass/fail/crash/deadlock, exit code, duration)
+- Pass rate and iteration count
+- Extension GIL compatibility info (if `--detect-extensions`)
+- TSAN warnings (if `--tsan`)
+- GIL-enabled comparison results (if `--compare-with-gil`)
+
+
+## Examples
+
+### Ecosystem-wide survey
+
+```bash
+# Quick scan of top 100 packages
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --stop-on-first-pass --top 100
+
+# View summary
+labeille ft show results/ft_*
+
+# Export report for the free-threading compatibility tracker
+labeille ft report results/ft_* --format markdown -o ft-compat-report.md
+```
+
+### Package deep-dive
+
+```bash
+# Run many iterations for a specific package
+labeille ft run --target-python ~/cpython-ft/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --packages urllib3 --iterations 50
+
+# Analyze flakiness
+labeille ft flaky results/ft_* --package urllib3
+```
+
+### Version-to-version tracking
+
+```bash
+# Run against 3.14a1
+labeille ft run --target-python ~/cpython-314a1/python \
+    --registry-dir registry --work-dir ~/ft-work --top 50 \
+    --results-dir results/ft_314a1
+
+# Run against 3.14b2
+labeille ft run --target-python ~/cpython-314b2/python \
+    --registry-dir registry --work-dir ~/ft-work --top 50 \
+    --results-dir results/ft_314b2
+
+# Compare
+labeille ft compare results/ft_314a1 results/ft_314b2
+```
+
+### TSAN race detection
+
+```bash
+# Use a TSAN-instrumented build
+labeille ft run --target-python ~/cpython-tsan/python \
+    --registry-dir registry --work-dir ~/ft-work \
+    --tsan --iterations 5 --top 30
+
+# Check for packages with tsan_warnings category
+labeille ft show results/ft_* --sort category
+```
+
+
+## Interpreting Results
+
+### Compatible packages
+
+Packages classified as `compatible` pass all iterations with `PYTHON_GIL=0`. They
+are safe to use with free-threaded CPython.
+
+`compatible_gil_fallback` means the package works, but the GIL is re-enabled at
+runtime because a C extension doesn't declare `Py_mod_gil`. The package is
+functionally compatible but doesn't benefit from true parallelism.
+
+### Investigating intermittent failures
+
+`intermittent` packages have race conditions. Use `ft flaky --package NAME` to see:
+- Which specific tests fail and how often
+- Whether failures are concentrated in specific tests or spread across the suite
+- Whether crash signatures are consistent (same race) or varied (multiple races)
+
+### Investigating crashes
+
+`crash` packages segfault or abort under free-threading. Reproduce with:
+
+```bash
+PYTHON_GIL=0 ~/cpython-ft/python -m pytest tests/
+```
+
+If the crash doesn't reproduce, increase iterations — it may be intermittent.
+
+### Investigating deadlocks
+
+`deadlock` packages stall without producing output. Reproduce manually and attach
+a debugger to inspect thread states. Common causes: lock ordering inversions,
+missing lock releases on exception paths, busy-wait loops on GIL-protected state.
+
+
+## Troubleshooting
+
+### All packages show install_failure
+
+The free-threaded Python build may not be properly configured. Verify:
+```bash
+~/cpython-ft/python -c "import sys; print(sys._is_gil_enabled())"
+```
+Should print `False` if the GIL is disabled by default.
+
+### Too many false deadlocks
+
+Increase `--stall-threshold` for packages with slow tests. The default 60 seconds
+may be too short for heavy computation or network-dependent tests.
+
+### TSAN not detecting anything
+
+TSAN requires a TSAN-instrumented CPython build (`--with-thread-sanitizer`). The
+`--tsan` flag only tells labeille to parse TSAN output — it doesn't enable TSAN
+instrumentation in CPython itself.

--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -1,0 +1,312 @@
+# The Resolve-Run Workflow
+
+## Overview
+
+labeille works in two phases: **resolve** discovers packages and builds a registry,
+then **run** executes their test suites against a JIT-enabled CPython build and
+detects crashes. Between these phases, packages need to be **enriched** with
+specific installation and test instructions.
+
+```
+labeille resolve  →  enrich registry  →  labeille run  →  analyze results
+     │                     │                   │                  │
+ Fetch PyPI           Fill in YAML         Clone, build,     Crashes, timing,
+ metadata,            install/test         test, detect      comparisons
+ find repos           commands             crashes
+```
+
+The registry is the bridge: resolve creates it, enrichment fills it in, and run
+consumes it. Each phase can be run independently and repeatedly.
+
+
+## Phase 1: Resolve
+
+### What resolve does
+
+`labeille resolve` fetches PyPI metadata for each package and extracts:
+
+1. **Source repository URL** — from PyPI metadata fields (project_urls, home_page, etc.)
+2. **Extension type** — `pure`, `extensions`, or `unknown`, determined from wheel tag analysis
+3. **PyPI URL** — direct link to the package page
+
+It writes two things:
+- `registry/index.yaml` — a sorted list of all tracked packages with download counts
+- `registry/packages/{name}.yaml` — per-package YAML with the discovered metadata and
+  empty fields for enrichment
+
+### Package sources
+
+You can feed packages to resolve from multiple sources:
+
+```bash
+# Positional arguments
+labeille resolve requests click flask
+
+# From a file (one package name per line)
+labeille resolve --from-file packages.txt
+
+# From a JSON file with download counts (e.g. from BigQuery)
+labeille resolve --from-json top-pypi.json --top 500
+
+# Combine sources — all are merged
+labeille resolve requests --from-file extras.txt --from-json top-pypi.json --top 100
+```
+
+### Non-destructive updates
+
+Resolve never overwrites package files that have been manually enriched
+(`enriched: true`). Re-running resolve on an existing registry safely adds new
+packages without touching ones you've already configured.
+
+### Resolve options
+
+| Option | Description |
+|--------|-------------|
+| `PACKAGES` | Package names (positional, multiple) |
+| `--from-file FILE` | File with one package name per line |
+| `--from-json FILE` | JSON file with download counts |
+| `--top N` | Top N packages by downloads (requires `--from-json`) |
+| `--registry-dir PATH` | Output registry directory (default: `registry`) |
+| `--workers N` | Parallel PyPI API requests (default: 1) |
+| `--timeout SECONDS` | PyPI API request timeout (default: 10) |
+| `--dry-run` | Show what would be done without writing files |
+| `-v, --verbose` | Detailed output |
+| `-q, --quiet` | Only show errors |
+| `--log-file PATH` | Log file path (default: `labeille-resolve.log`) |
+
+
+## Phase 2: Run
+
+### What run does
+
+`labeille run` reads the registry and, for each enriched package:
+
+1. Clones the source repository (shallow by default)
+2. Creates a virtual environment with the target Python
+3. Installs the package using its `install_command`
+4. Runs the test suite using its `test_command`
+5. Detects crashes from exit codes, signals, and stderr patterns
+6. Records results as JSONL with full metadata
+
+The target Python has `PYTHON_JIT=1` and `PYTHONFAULTHANDLER=1` set automatically
+to enable the JIT and get crash tracebacks.
+
+### Basic usage
+
+```bash
+# Run all enriched packages
+labeille run --target-python ~/cpython/python --registry-dir registry
+
+# Run specific packages
+labeille run --target-python ~/cpython/python --packages requests,click,flask
+
+# Run top 50 by downloads, 4 workers
+labeille run --target-python ~/cpython/python --top 50 --workers 4
+
+# Test a specific git revision
+labeille run --target-python ~/cpython/python --packages=urllib3@abc1234 --no-shallow
+```
+
+### Package filtering
+
+| Option | Description |
+|--------|-------------|
+| `--packages CSV` | Comma-separated filter (supports `name@revision` syntax) |
+| `--top N` | Top N packages by download count |
+| `--skip-extensions` | Skip C extension packages (test pure Python only) |
+| `--force-run` | Override `skip` and `skip_versions` flags |
+| `--skip-completed` | Resume: skip already-tested packages |
+
+### Result statuses
+
+| Status | Meaning |
+|--------|---------|
+| `pass` | Test suite exited 0 (all tests passed) |
+| `fail` | Test suite exited 1 (some tests failed — normal) |
+| `crash` | Segfault, abort, or assertion failure detected |
+| `timeout` | Test suite exceeded the time limit |
+| `install_error` | Package installation failed |
+| `clone_error` | Git clone failed |
+| `error` | Other unexpected error |
+
+### Crash detection
+
+labeille detects crashes from:
+- **Exit codes**: negative exit codes (signals), exit code 134 (SIGABRT), 139 (SIGSEGV)
+- **Stderr patterns**: ASAN reports, Python fatal errors, assertion failures
+- **Signal names**: extracted from the exit code for crash signature
+
+Each crash gets a signature (signal + stderr context) for deduplication and
+comparison across runs.
+
+### Parallel execution
+
+`--workers N` runs N packages in parallel. Each worker handles one package
+end-to-end. Memory scales linearly with worker count. For ASAN-enabled builds,
+2-3 workers is the practical limit due to ~2-3x memory overhead per process.
+
+### Persistent directories
+
+By default, repos and venvs are created in temporary directories and cleaned up
+after each package. For faster repeated runs:
+
+```bash
+# Reuse repos and venvs across runs
+labeille run --target-python ~/cpython/python --work-dir ~/labeille-work
+
+# Or set them individually
+labeille run --target-python ~/cpython/python \
+    --repos-dir ~/repos --venvs-dir ~/venvs
+
+# Force reinstall when install commands change
+labeille run --target-python ~/cpython/python --work-dir ~/work --refresh-venvs
+```
+
+### Resuming interrupted runs
+
+```bash
+# Start a named run
+labeille run --target-python ~/cpython/python --run-id my-batch
+
+# Resume after interruption (skips already-tested packages)
+labeille run --target-python ~/cpython/python --run-id my-batch --skip-completed
+```
+
+### Runtime overrides
+
+Override registry settings without editing YAML files:
+
+```bash
+# Inject extra dependencies into every venv
+labeille run --target-python ~/cpython/python --extra-deps "trustme,uvicorn"
+
+# Override all test commands
+labeille run --target-python ~/cpython/python --test-command-override "python -m pytest -x"
+
+# Append flags to test commands
+labeille run --target-python ~/cpython/python --test-command-suffix "--tb=long -v"
+
+# Use a fork's repo
+labeille run --target-python ~/cpython/python --repo-override "requests=https://github.com/me/requests"
+```
+
+### Run options
+
+| Option | Description |
+|--------|-------------|
+| `--target-python PATH` | Python interpreter to test with (required) |
+| `--registry-dir PATH` | Registry directory (default: `registry`) |
+| `--results-dir PATH` | Output directory (default: `results`) |
+| `--packages CSV` | Comma-separated filter (supports `name@revision`) |
+| `--top N` | Top N packages by download count |
+| `--workers N` | Parallel package execution (default: 1) |
+| `--timeout SECONDS` | Per-package timeout (default: 600) |
+| `--skip-extensions` | Skip C extension packages |
+| `--skip-completed` | Resume: skip already-tested packages |
+| `--force-run` | Override skip and skip_versions flags |
+| `--stop-after-crash N` | Stop after N crashes found |
+| `--run-id ID` | Custom run identifier (default: timestamp) |
+| `--work-dir PATH` | Base directory for repos and venvs |
+| `--repos-dir PATH` | Persistent repo clones |
+| `--venvs-dir PATH` | Persistent venvs |
+| `--keep-work-dirs` | Don't clean up temporary directories |
+| `--refresh-venvs` | Delete and recreate existing venvs |
+| `--extra-deps CSV` | Inject additional packages into every venv |
+| `--test-command-override STR` | Replace all test commands |
+| `--test-command-suffix STR` | Append flags to test commands |
+| `--repo-override PKG=URL` | Override repo URL (repeatable) |
+| `--clone-depth N` | Git clone depth |
+| `--no-shallow` | Full clone (needed for old revisions) |
+| `--installer {auto,uv,pip}` | Package installer backend (default: auto) |
+| `--env KEY=VALUE` | Extra environment variables (repeatable) |
+| `--dry-run` | Don't actually execute tests |
+| `-v, --verbose` | Show all details |
+| `-q, --quiet` | Only show crashes |
+
+
+## The Registry Bridge
+
+The registry connects resolve and run:
+
+1. **Resolve creates it** — writes skeleton YAML with repo URL and extension type
+2. **Enrichment fills it in** — adds install_command, test_command, dependencies
+3. **Run consumes it** — reads the commands and executes them
+
+This separation means you resolve once and run many times against different
+Python builds. See [enrichment.md](enrichment.md) for the complete enrichment guide.
+
+
+## Complete Workflow Example
+
+```bash
+# 1. Build a registry from the top 100 PyPI packages
+labeille resolve --from-json top-pypi.json --top 100 --registry-dir registry
+
+# 2. Enrich packages (see doc/enrichment.md)
+#    Fill in install_command, test_command, etc. for each package
+
+# 3. Run tests against a JIT-enabled CPython build
+labeille run --target-python ~/jit_cpython/python \
+    --registry-dir registry \
+    --results-dir results \
+    --work-dir ~/labeille-work \
+    --workers 4
+
+# 4. Analyze results
+labeille analyze run                            # Summary
+labeille analyze run -q                         # Crashes only
+labeille analyze package requests               # Deep dive on one package
+
+# 5. Compare with a previous run
+labeille analyze compare run_001 run_002
+```
+
+
+## Investigation Workflow
+
+When a crash is found:
+
+```bash
+# 1. Reproduce the crash
+labeille run --target-python ~/jit_cpython/python --packages=urllib3 \
+    --work-dir ~/investigate
+
+# 2. Check if HEAD still crashes
+labeille run --target-python ~/jit_cpython/python --packages=urllib3
+
+# 3. Test at the specific revision where the crash was found
+labeille run --target-python ~/jit_cpython/python \
+    --packages=urllib3@abc1234 --no-shallow
+
+# 4. Bisect across the package's git history
+labeille bisect --target-python ~/jit_cpython/python \
+    --package urllib3 --good v2.0.0 --bad HEAD
+```
+
+If the package code didn't change between runs but the crash appeared, the
+regression is almost certainly on the CPython/JIT side.
+
+
+## Results
+
+Each run creates a directory under `results/{run_id}/`:
+
+- **`run_meta.json`** — Run metadata: Python version, JIT status, hostname, timing
+- **`results.jsonl`** — One JSON line per package with status, exit code, signal,
+  crash signature, timing, and installed dependency versions
+- **`crashes/`** — Full stderr captures for crashed packages
+- **`run.log`** — Detailed debug log
+
+Use `labeille analyze` commands to examine results, or process the JSONL directly.
+
+
+## What's Next
+
+Once you have the basic workflow running, labeille offers specialized testing modes:
+
+- **[Benchmarking](benchmarking.md)** — Compare test suite performance across conditions
+  (JIT vs no-JIT, different interpreters, with/without coverage)
+- **[Free-threaded testing](free-threaded.md)** — Test packages against free-threaded
+  CPython builds to detect crashes, deadlocks, and race conditions
+- **[Compatibility analysis](compat.md)** — Survey C extension packages for build
+  compatibility against any Python version


### PR DESCRIPTION
## Summary

- Create four standalone documentation guides in `doc/`:
  - `workflow.md` (312 lines) — resolve → enrich → run pipeline with options tables and worked examples
  - `benchmarking.md` (501 lines) — multi-condition benchmarking, YAML profiles, longitudinal tracking, anomaly detection, exports
  - `free-threaded.md` (419 lines) — free-threaded CPython testing, failure categories, deadlock detection, GIL comparison, TSAN
  - `compat.md` (352 lines) — C extension compatibility surveys, 40+ error patterns, build modes, custom patterns
- Add README sections for benchmarking, free-threaded testing, and compatibility analysis with command examples and links to guides
- Update README Status and Project Structure sections

## Test plan

- [x] All 4 doc files created and valid markdown
- [x] All cross-references between docs are valid relative links
- [x] README links to all standalone guides
- [x] Project Structure reflects bench/, ft/, compat.py, and new docs
- [x] CHANGELOG entry added

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)