### PR TITLE
feat: update registry skip reasons from compat analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - New crash summary statistics in compare output showing repo unchanged/changed/unknown counts.
 
 ### Enhanced
+- Updated 63 registry packages with accurate skip reasons from compat analysis: cleared vague 3.15 skip_versions, added specific failure categories (Meson, CMake, removed APIs), reclassified non-3.15 issues as skip with precise reasons, and unskipped 5 packages that now build on 3.15.
 - `BenchRunner._run_iteration()` applies resource constraints via command wrapping before execution.
 - `BenchRunner.run()` now checks for root execution and refuses unless `--run-dangerously-as-root` is passed.
 - macOS support for system profiling: CPU info from `sysctl`, memory from `vm_stat`, OS from `sw_vers`, disk type from `diskutil`. All existing Linux code paths preserved unchanged.
@@ -111,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Renamed `Issues` URL key to `Bug Tracker` in project metadata for PyPI display consistency.
 
 ### Fixed
+- `update_index_from_packages()` no longer crashes when `skip_versions` is `None`.
 - Bench runner `install_package` now receives a complete environment (starting from `os.environ`) instead of bare condition env vars, fixing install failures when build backends need `PATH` to find tools like `git`.
 - `run_meta.json` now stores actual CLI argument strings (`sys.argv[1:]`) instead of parameter names, making runs reproducible from metadata.
 - `build_reproduce_command` uses `export PATH` for venv activation instead of fragile `.venv/bin/` prefix string replacement.

--- a/registry/index.yaml
+++ b/registry/index.yaml
@@ -1,4 +1,4 @@
-last_updated: '2026-03-02T07:58:07'
+last_updated: '2026-03-03T02:56:11'
 packages:
 - name: boto3
   download_count: 1577565199
@@ -322,8 +322,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: python-dotenv
   download_count: 334327298
   extension_type: pure
@@ -477,9 +476,8 @@ packages:
   download_count: 284122904
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: pyasn1-modules
   download_count: 283880829
   extension_type: pure
@@ -1045,7 +1043,7 @@ packages:
   download_count: 134896232
   extension_type: extensions
   enriched: true
-  skip: true
+  skip: false
   skip_versions_keys: []
 - name: textual
   download_count: 134773724
@@ -1196,7 +1194,7 @@ packages:
   download_count: 122233058
   extension_type: extensions
   enriched: true
-  skip: true
+  skip: false
   skip_versions_keys: []
 - name: jaraco-context
   download_count: 122112425
@@ -1460,7 +1458,7 @@ packages:
   download_count: 95792495
   extension_type: extensions
   enriched: true
-  skip: true
+  skip: false
   skip_versions_keys: []
 - name: jsonpatch
   download_count: 95721283
@@ -1607,7 +1605,7 @@ packages:
   download_count: 86974692
   extension_type: extensions
   enriched: true
-  skip: true
+  skip: false
   skip_versions_keys: []
 - name: asttokens
   download_count: 86671185
@@ -1884,7 +1882,7 @@ packages:
   download_count: 69782107
   extension_type: extensions
   enriched: true
-  skip: true
+  skip: false
   skip_versions_keys: []
 - name: typer-slim
   download_count: 69700655
@@ -2080,8 +2078,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: pygithub
   download_count: 60446942
   extension_type: pure
@@ -2429,9 +2426,8 @@ packages:
   download_count: 50616819
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: google-cloud-tasks
   download_count: 50513280
   extension_type: pure
@@ -2480,8 +2476,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: nbconvert
   download_count: 49293646
   extension_type: pure
@@ -2511,15 +2506,13 @@ packages:
   extension_type: pure
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: argon2-cffi-bindings
   download_count: 48707685
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: xlrd
   download_count: 48510263
   extension_type: pure
@@ -2676,22 +2669,19 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: confluent-kafka
   download_count: 45316318
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: asyncpg
   download_count: 45270644
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: pyperclip
   download_count: 45070816
   extension_type: pure
@@ -2828,8 +2818,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: nvidia-cusparse-cu12
   download_count: 42367846
   extension_type: extensions
@@ -3233,9 +3222,8 @@ packages:
   download_count: 35461155
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: langgraph
   download_count: 35458331
   extension_type: pure
@@ -3272,8 +3260,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: appdirs
   download_count: 34856629
   extension_type: pure
@@ -3396,9 +3383,8 @@ packages:
   download_count: 33426514
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: zeep
   download_count: 33408628
   extension_type: pure
@@ -3839,9 +3825,8 @@ packages:
   download_count: 27965186
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: checkov
   download_count: 27805563
   extension_type: pure
@@ -4514,9 +4499,8 @@ packages:
   download_count: 21922730
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: pyiceberg
   download_count: 21889779
   extension_type: extensions
@@ -4748,8 +4732,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: sphinxcontrib-jsmath
   download_count: 20239804
   extension_type: pure
@@ -4847,8 +4830,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: lazy-loader
   download_count: 19617221
   extension_type: pure
@@ -5083,8 +5065,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: userpath
   download_count: 18134533
   extension_type: pure
@@ -5198,8 +5179,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: looker-sdk
   download_count: 17390407
   extension_type: pure
@@ -5217,8 +5197,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: py-key-value-shared
   download_count: 17317113
   extension_type: pure
@@ -5488,8 +5467,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: sqlalchemy-spanner
   download_count: 16056574
   extension_type: pure
@@ -5531,8 +5509,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: srsly
   download_count: 15852018
   extension_type: extensions
@@ -5622,8 +5599,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: azure-storage-file-share
   download_count: 15445718
   extension_type: pure
@@ -5690,9 +5666,8 @@ packages:
   download_count: 15040403
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: python-socketio
   download_count: 15032489
   extension_type: pure
@@ -5755,15 +5730,13 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: clickhouse-connect
   download_count: 14915207
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: rich-argparse
   download_count: 14901873
   extension_type: pure
@@ -6273,9 +6246,8 @@ packages:
   download_count: 12810503
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: genson
   download_count: 12798350
   extension_type: pure
@@ -6305,8 +6277,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: face
   download_count: 12618224
   extension_type: pure
@@ -6516,8 +6487,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: weasel
   download_count: 11926713
   extension_type: pure
@@ -6864,8 +6834,7 @@ packages:
   extension_type: pure
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: oldest-supported-numpy
   download_count: 11041965
   extension_type: pure
@@ -7395,9 +7364,8 @@ packages:
   download_count: 9546516
   extension_type: extensions
   enriched: true
-  skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip: true
+  skip_versions_keys: []
 - name: huey
   download_count: 9543713
   extension_type: pure
@@ -7525,8 +7493,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: msgraph-core
   download_count: 9227248
   extension_type: pure
@@ -8686,8 +8653,7 @@ packages:
   extension_type: extensions
   enriched: true
   skip: false
-  skip_versions_keys:
-  - '3.15'
+  skip_versions_keys: []
 - name: boto
   download_count: 7131787
   extension_type: pure

--- a/registry/packages/aiohttp.yaml
+++ b/registry/packages/aiohttp.yaml
@@ -13,9 +13,7 @@ uses_xdist: false
 timeout: 1800
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': C extension source files not generated (Cython build step fails on editable
-    install for 3.15).
+skip_versions: null
 notes: aiohttp async HTTP framework. C extensions via Cython. Functional tests excluded
   (need running server). 30min timeout.
 enriched: true

--- a/registry/packages/aiokafka.yaml
+++ b/registry/packages/aiokafka.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Depends on gssapi (C extension build failure on 3.15)"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/aioresponses.yaml
+++ b/registry/packages/aioresponses.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Depends on yarl (C extension, import failure on 3.15)"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/amazon-ion.yaml
+++ b/registry/packages/amazon-ion.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build depends on ionc (build failure on 3.15)"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/apache-beam.yaml
+++ b/registry/packages/apache-beam.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': C extension build
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (meson cannot find python3.15 sysconfig)."
 notes: Repo found by improved URL detection. C extension build
 enriched: true
 clone_depth: null

--- a/registry/packages/argon2-cffi-bindings.yaml
+++ b/registry/packages/argon2-cffi-bindings.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Needs argon2 C headers (system C library)"
+skip_versions: null
 notes: "Uses setuptools-scm (needs git tags)"
 enriched: true
 clone_depth: 50

--- a/registry/packages/argon2-cffi.yaml
+++ b/registry/packages/argon2-cffi.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Depends on argon2-cffi-bindings (C extension build failure on 3.15)"
+skip_versions: null
 notes: "Uses setuptools-scm (needs git tags)"
 enriched: true
 clone_depth: 50

--- a/registry/packages/asyncpg.yaml
+++ b/registry/packages/asyncpg.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build fails on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/awscrt.yaml
+++ b/registry/packages/awscrt.yaml
@@ -9,10 +9,9 @@ test_command: python -m unittest discover test -v
 test_framework: unittest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip: true
+skip_reason: CMake must be installed to build from source (not a 3.15-specific issue).
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/backports-datetime-fromisoformat.yaml
+++ b/registry/packages/backports-datetime-fromisoformat.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15"
+  '3.15': Uses private C API _PyUnicode_CheckConsistency, undeclared in 3.15.
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/backports-zoneinfo.yaml
+++ b/registry/packages/backports-zoneinfo.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15 (also unnecessary, zoneinfo is stdlib)"
+  '3.15': Uses removed internal symbol _PyLong_One (undeclared in 3.15).
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/biopython.yaml
+++ b/registry/packages/biopython.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': C extension build fails on 3.15
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15."
 notes: 'Re-enriched: C extension build fails on 3.15'
 enriched: true
 clone_depth: null

--- a/registry/packages/bitarray.yaml
+++ b/registry/packages/bitarray.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': C extension (bitarray/_bitarray.c)
+skip_versions: null
 notes: 'Re-enriched: C extension (bitarray/_bitarray.c)'
 enriched: true
 clone_depth: null

--- a/registry/packages/blis.yaml
+++ b/registry/packages/blis.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "Cython extension, build fails on 3.15"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (numpy build dep fails)."
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/bottleneck.yaml
+++ b/registry/packages/bottleneck.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension (Cython) build failure on 3.15"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (numpy build dep fails)."
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/brotli.yaml
+++ b/registry/packages/brotli.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': C extension (brotli/_brotli.c)
+skip_versions: null
 notes: 'Re-enriched: C extension (brotli/_brotli.c)'
 enriched: true
 clone_depth: null

--- a/registry/packages/clickhouse-connect.yaml
+++ b/registry/packages/clickhouse-connect.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension, build fails on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/confluent-kafka.yaml
+++ b/registry/packages/confluent-kafka.yaml
@@ -9,10 +9,9 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "Needs librdkafka C library"
+skip: true
+skip_reason: Requires librdkafka C library (not a 3.15-specific issue).
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/contourpy.yaml
+++ b/registry/packages/contourpy.yaml
@@ -10,7 +10,7 @@ test_framework: pytest
 uses_xdist: false
 timeout: null
 skip: true
-skip_reason: C++ extension requiring meson build system.
+skip_reason: "Meson build system: 'Python dependency not found' on 3.15 (meson cannot find python3.15 sysconfig)."
 notes: Contour plotting library.
 enriched: true
 clone_depth: null

--- a/registry/packages/curl-cffi.yaml
+++ b/registry/packages/curl-cffi.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Needs curl development headers (system C library)"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/ddtrace.yaml
+++ b/registry/packages/ddtrace.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "Complex tracing library with C extensions"
+  '3.15': setup.py requires pkg_resources (removed from setuptools).
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/duckdb.yaml
+++ b/registry/packages/duckdb.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C++ extension, complex build system, fails on 3.15"
+  '3.15': CMake FindPython fails with Python 3.15 (pybind11 cannot locate 3.15 interpreter).
 notes: "Uses setuptools-scm (needs git tags). addopts cleared (refs: pytest-cov)"
 enriched: true
 clone_depth: 50

--- a/registry/packages/fastar.yaml
+++ b/registry/packages/fastar.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "Editable install fails on 3.15"
+  '3.15': Depends on PyO3/maturin which does not support Python 3.15 yet.
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/fastparquet.yaml
+++ b/registry/packages/fastparquet.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension, build fails on 3.15"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (numpy build dep fails)."
 notes: "Uses setuptools-scm (needs git tags)"
 enriched: true
 clone_depth: 50

--- a/registry/packages/gevent.yaml
+++ b/registry/packages/gevent.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "libev/libuv C extensions"
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/geventhttpclient.yaml
+++ b/registry/packages/geventhttpclient.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "Depends on gevent"
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/h3.yaml
+++ b/registry/packages/h3.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15"
+  '3.15': CMake FindPython fails with Python 3.15.
 notes: "addopts cleared (refs: pytest-cov)"
 enriched: true
 clone_depth: null

--- a/registry/packages/hiredis.yaml
+++ b/registry/packages/hiredis.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15"
+  '3.15': setup.py uses SourceFileLoader.load_module(), removed in Python 3.15.
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/httptools.yaml
+++ b/registry/packages/httptools.yaml
@@ -9,8 +9,8 @@ test_command: python -m pytest tests/
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: true
-skip_reason: C extension build requires vendored llhttp headers missing from editable
+skip: false
+skip_reason: null
   install.
 notes: HTTP parser based on llhttp (C extension).
 enriched: true

--- a/registry/packages/jpype1.yaml
+++ b/registry/packages/jpype1.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension (CMake) build failure on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/kiwisolver.yaml
+++ b/registry/packages/kiwisolver.yaml
@@ -9,8 +9,8 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: true
-skip_reason: C++ extension built with Cython.
+skip: false
+skip_reason: null
 notes: Cassowary constraint solver.
 enriched: true
 clone_depth: null

--- a/registry/packages/levenshtein.yaml
+++ b/registry/packages/levenshtein.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension (CMake) build failure on 3.15"
+  '3.15': CMake FindPython fails with Python 3.15.
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/lightgbm.yaml
+++ b/registry/packages/lightgbm.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C++ gradient boosting library"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (numpy/scipy build dep fails)."
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/llvmlite.yaml
+++ b/registry/packages/llvmlite.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "LLVM bindings, complex build"
+  '3.15': distutils spawn() API change in Python 3.15 (dry_run keyword removed).
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/lxml.yaml
+++ b/registry/packages/lxml.yaml
@@ -10,7 +10,7 @@ test_framework: pytest
 uses_xdist: false
 timeout: null
 skip: true
-skip_reason: Complex C extension requiring libxml2 and libxslt development headers.
+skip_reason: Requires libxml2 and libxslt development headers (not a 3.15-specific issue).
   Build from source is fragile and version-sensitive.
 notes: XML/HTML processing library wrapping libxml2/libxslt C libraries.
 enriched: true

--- a/registry/packages/maxminddb.yaml
+++ b/registry/packages/maxminddb.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip_versions: null
 notes: "Uses setuptools-scm (needs git tags)"
 enriched: true
 clone_depth: 50

--- a/registry/packages/memray.yaml
+++ b/registry/packages/memray.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension memory profiler, complex build"
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/ml-dtypes.yaml
+++ b/registry/packages/ml-dtypes.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15."
 notes: "xdist disabled for JIT testing"
 enriched: true
 clone_depth: null

--- a/registry/packages/multiprocess.yaml
+++ b/registry/packages/multiprocess.yaml
@@ -11,9 +11,7 @@ uses_xdist: false
 timeout: 600
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': Version-specific directory structure (py3.15/), tests use __main__.py runner
-    not pytest.
+skip_versions: null
 notes: Fork of multiprocessing using dill. Has C extensions. Tests may spawn subprocesses.
 enriched: true
 clone_depth: null

--- a/registry/packages/mysql-connector-python.yaml
+++ b/registry/packages/mysql-connector-python.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': C extension build
+skip_versions: null
 notes: 'Re-enriched: C extension build'
 enriched: true
 clone_depth: null

--- a/registry/packages/mysqlclient.yaml
+++ b/registry/packages/mysqlclient.yaml
@@ -9,10 +9,9 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': C extension build (MySQL client)
+skip: true
+skip_reason: Requires MySQL/MariaDB client library (not a 3.15-specific issue).
+skip_versions: null
 notes: Repo found by improved URL detection. C extension build (MySQL client)
 enriched: true
 clone_depth: null

--- a/registry/packages/numpy.yaml
+++ b/registry/packages/numpy.yaml
@@ -15,7 +15,7 @@ timeout: 1800
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': Meson build system broken on 3.15 alpha (pip/meson-python requirement parsing error).
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (meson cannot find python3.15 sysconfig)."
 notes: Build deps (meson-python, meson, cython, ninja) installed explicitly for --no-build-isolation.
   Very large test suite. May fail to build on early 3.15 alphas.
 enriched: true

--- a/registry/packages/onnx.yaml
+++ b/registry/packages/onnx.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "Complex protobuf-based build"
+  '3.15': "Meson build system: 'Python dependency not found' on 3.15 (numpy build dep fails)."
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/optree.yaml
+++ b/registry/packages/optree.yaml
@@ -12,7 +12,7 @@ timeout: null
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': "C extension build failure on 3.15"
+  '3.15': CMake FindPython fails with Python 3.15.
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/oracledb.yaml
+++ b/registry/packages/oracledb.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/pillow.yaml
+++ b/registry/packages/pillow.yaml
@@ -9,10 +9,9 @@ test_command: python -m pytest Tests/
 test_framework: pytest
 uses_xdist: false
 timeout: 1200
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': C extension editable build fails on 3.15 debug build.
+skip: true
+skip_reason: Requires libjpeg/zlib development headers to build from source (not a 3.15-specific issue).
+skip_versions: null
 notes: Image processing library (PIL fork). Uses setuptools build backend. C extensions
   for image format support. Tests in Tests/ directory (capital T). Requires system
   libraries (libjpeg, zlib, etc.) for full format support. Timeout 20min for large

--- a/registry/packages/psycopg-binary.yaml
+++ b/registry/packages/psycopg-binary.yaml
@@ -9,10 +9,9 @@ test_command: python -m pytest tests
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip: true
+skip_reason: Binary-only distribution on PyPI, no source available for sdist build.
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/pybase64.yaml
+++ b/registry/packages/pybase64.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/pycares.yaml
+++ b/registry/packages/pycares.yaml
@@ -9,10 +9,9 @@ test_command: python -m unittest discover tests -v
 test_framework: unittest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip: true
+skip_reason: Requires CMake >= 3.5 to build (not a 3.15-specific issue).
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/pycryptodomex.yaml
+++ b/registry/packages/pycryptodomex.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': C extension build
+skip_versions: null
 notes: 'Re-enriched: C extension build'
 enriched: true
 clone_depth: null

--- a/registry/packages/pypdfium2.yaml
+++ b/registry/packages/pypdfium2.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/registry/packages/pyzmq.yaml
+++ b/registry/packages/pyzmq.yaml
@@ -12,7 +12,7 @@ timeout: 600
 skip: false
 skip_reason: null
 skip_versions:
-  '3.15': C extension (Cython) editable build fails on 3.15.
+  '3.15': CMake FindPython fails with Python 3.15 (missing Python Development.Module).
 notes: ZeroMQ Python bindings. C extension (Cython). Some socket tests may need running
   zmq.
 enriched: true

--- a/registry/packages/rapidfuzz.yaml
+++ b/registry/packages/rapidfuzz.yaml
@@ -9,8 +9,8 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: true
-skip_reason: C++ extension using scikit-build-core.
+skip: false
+skip_reason: null
 notes: Fuzzy string matching.
 enriched: true
 clone_depth: null

--- a/registry/packages/ray.yaml
+++ b/registry/packages/ray.yaml
@@ -9,10 +9,9 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "Complex build with Cython and Bazel components"
+skip: true
+skip_reason: Binary-only distribution on PyPI (no source distribution available for 3.15).
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/ruamel-yaml-clib.yaml
+++ b/registry/packages/ruamel-yaml-clib.yaml
@@ -9,8 +9,8 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: true
-skip_reason: C extension companion to ruamel-yaml. No separate test suite.
+skip: false
+skip_reason: null
 notes: C extension for ruamel.yaml performance. No independent tests.
 enriched: true
 clone_depth: null

--- a/registry/packages/scikit-learn.yaml
+++ b/registry/packages/scikit-learn.yaml
@@ -10,7 +10,7 @@ test_framework: pytest
 uses_xdist: false
 timeout: null
 skip: true
-skip_reason: Requires Cython and OpenMP. Complex meson build.
+skip_reason: "Meson build system: 'Python dependency not found' on 3.15. Also requires Cython and OpenMP."
 notes: Machine learning library.
 enriched: true
 clone_depth: null

--- a/registry/packages/scipy.yaml
+++ b/registry/packages/scipy.yaml
@@ -10,7 +10,7 @@ test_framework: pytest
 uses_xdist: false
 timeout: null
 skip: true
-skip_reason: Requires Fortran compiler and complex C/C++ build chain.
+skip_reason: "Meson build system: 'Python dependency not found' on 3.15. Also requires Fortran compiler."
 notes: Scientific computing library.
 enriched: true
 clone_depth: null

--- a/registry/packages/sentencepiece.yaml
+++ b/registry/packages/sentencepiece.yaml
@@ -9,10 +9,9 @@ test_command: null
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': C extension build
+skip: true
+skip_reason: build_bundled.sh requires protobuf compiler (not a 3.15-specific issue).
+skip_versions: null
 notes: 'Re-enriched: C extension build'
 enriched: true
 clone_depth: null

--- a/registry/packages/time-machine.yaml
+++ b/registry/packages/time-machine.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension for time mocking"
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/tritonclient.yaml
+++ b/registry/packages/tritonclient.yaml
@@ -9,10 +9,9 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': C extension
+skip: true
+skip_reason: Placeholder package on PyPI; hosted on NVIDIA Python Package Index.
+skip_versions: null
 notes: Repo found by improved URL detection. C extension
 enriched: true
 clone_depth: null

--- a/registry/packages/uvloop.yaml
+++ b/registry/packages/uvloop.yaml
@@ -9,8 +9,8 @@ test_command: python -m pytest tests/
 test_framework: pytest
 uses_xdist: false
 timeout: 600
-skip: true
-skip_reason: Cython/setuptools build fails (pkg_resources not found during metadata generation).
+skip: false
+skip_reason: null
 notes: Fast event loop based on libuv (C extension). Cython-based.
 enriched: true
 clone_depth: null

--- a/registry/packages/xgboost.yaml
+++ b/registry/packages/xgboost.yaml
@@ -9,10 +9,9 @@ test_command: ''
 test_framework: pytest
 uses_xdist: false
 timeout: null
-skip: false
-skip_reason: null
-skip_versions:
-  '3.15': "C++ gradient boosting library"
+skip: true
+skip_reason: Requires CMake to build from source (not a 3.15-specific issue).
+skip_versions: null
 notes: "Auto-triaged: extension with 3.15 build blocker"
 enriched: true
 clone_depth: null

--- a/registry/packages/zopfli.yaml
+++ b/registry/packages/zopfli.yaml
@@ -11,8 +11,7 @@ uses_xdist: false
 timeout: null
 skip: false
 skip_reason: null
-skip_versions:
-  '3.15': "C extension build failure on 3.15"
+skip_versions: null
 notes: "Auto-enriched"
 enriched: true
 clone_depth: null

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -279,4 +279,6 @@ def update_index_from_packages(
             entry.extension_type = pkg.extension_type
             entry.enriched = pkg.enriched
             entry.skip = pkg.skip
-            entry.skip_versions_keys = sorted(pkg.skip_versions.keys())
+            entry.skip_versions_keys = (
+                sorted(pkg.skip_versions.keys()) if pkg.skip_versions else []
+            )


### PR DESCRIPTION
## Summary
- Replace vague "C extension build failure on 3.15" skip reasons across 63 registry packages with specific failure categories identified through live compat analysis (Meson Python dep not found, CMake FindPython fails, removed internal symbols, setup.py uses removed APIs).
- Clear `skip_versions` for 20+ packages that actually build OK on 3.15 (aiohttp, asyncpg, bitarray, brotli, gevent, jpype1, time-machine, etc.) and unskip 5 packages now building (httptools, kiwisolver, rapidfuzz, ruamel-yaml-clib, uvloop).
- Fix `update_index_from_packages()` crash when `skip_versions` is `None`.

## Test plan
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy passes (46 source files, no issues)
- [x] All 1797 tests pass (6 skipped)

Closes #110

Generated with [Claude Code](https://claude.com/claude-code)