### PR TITLE
feat: --trust-ft-wheels for labeille ft run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `--trust-ft-wheels` flag for `labeille ft run`: packages with free-threaded wheels (`cpXYt` ABI tag) for the target Python version are classified as `compatible_by_wheel` without running tests.
+- `--trust-ft-wheels-any-version` flag for `labeille ft run`: like `--trust-ft-wheels` but trusts free-threaded wheels built for any Python version. Implies `--trust-ft-wheels`.
+- `COMPATIBLE_BY_WHEEL` category in `FailureCategory` with `⊕` symbol and severity 0.
+- `has_ft_wheel()` function in `classifier.py` to detect free-threaded wheels in PyPI release metadata.
+- `ft_wheel_found` and `ft_wheel_version` fields on `FTPackageResult` for provenance tracking.
+- `trust_ft_wheels` and `trust_ft_wheels_any_version` fields on `FTRunConfig`, recorded in `ft_meta.json`.
+- FT wheel check reuses PyPI metadata for sdist version lookup when both `--trust-ft-wheels` and `--install-from sdist` are active.
 - `--install-from {source|sdist}` option for `labeille run` and `labeille ft run`: install packages from PyPI source distributions while running tests from cloned git repos.
 - Sdist version alignment: `fetch_latest_pypi_version()` queries PyPI, `checkout_matching_tag()` aligns the repo to the matching release tag.
 - Source directory shielding: `shield_source_dir()` temporarily renames flat-layout source dirs to prevent local imports from shadowing the sdist-installed package.

--- a/src/labeille/classifier.py
+++ b/src/labeille/classifier.py
@@ -84,3 +84,40 @@ def has_platform_wheel(filenames: list[str]) -> bool:
         True if any wheel is platform-specific.
     """
     return any(_PLATFORM_INDICATORS.search(f) for f in filenames)
+
+
+_FT_WHEEL_TAG_RE = re.compile(r"-cp(\d)(\d+)t-")
+
+
+def has_ft_wheel(
+    urls: list[dict[str, Any]],
+    *,
+    target_version: tuple[int, int] | None = None,
+) -> bool:
+    """Check whether any wheel in the release is a free-threaded build.
+
+    Looks for wheels with ``cpXYt`` in the python/ABI tag, indicating
+    a free-threaded CPython build.
+
+    Args:
+        urls: The ``urls`` array from the PyPI JSON API response.
+        target_version: Optional ``(major, minor)`` tuple. If provided,
+            only wheels matching this specific Python version are
+            considered. If None, any free-threaded wheel matches.
+
+    Returns:
+        True if a matching free-threaded wheel is found.
+    """
+    filenames = [u.get("filename", "") for u in urls if u.get("filename")]
+    wheel_filenames = [f for f in filenames if f.endswith(".whl")]
+
+    for filename in wheel_filenames:
+        m = _FT_WHEEL_TAG_RE.search(filename)
+        if m is not None:
+            if target_version is None:
+                return True
+            major = int(m.group(1))
+            minor = int(m.group(2))
+            if (major, minor) == target_version:
+                return True
+    return False

--- a/src/labeille/ft/analysis.py
+++ b/src/labeille/ft/analysis.py
@@ -347,6 +347,7 @@ def prioritize_triage(
     for r in results:
         if not include_compatible and r.category in (
             FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_BY_WHEEL,
             FailureCategory.COMPATIBLE_GIL_FALLBACK,
         ):
             continue

--- a/src/labeille/ft/display.py
+++ b/src/labeille/ft/display.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from labeille.ft.results import FailureCategory
+
 log = logging.getLogger("labeille")
 
 
@@ -60,6 +62,7 @@ def format_compatibility_summary(
     # Display categories in severity order.
     display_order = [
         ("compatible", "✓", "Compatible"),
+        ("compatible_by_wheel", "⊕", "Compatible (FT wheel)"),
         ("compatible_gil_fallback", "⚠", "Compatible (GIL fallback)"),
         ("tsan_warnings", "⚡", "TSAN warnings (tests pass)"),
         ("intermittent", "~", "Intermittent"),
@@ -153,6 +156,8 @@ def format_package_table(
 
         # Details column.
         details: list[str] = []
+        if r.category == FailureCategory.COMPATIBLE_BY_WHEEL:
+            details.append(f"FT wheel ({r.ft_wheel_version or '?'})")
         if r.failure_signatures:
             details.append(r.failure_signatures[0][:30])
         if r.flaky_tests:

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -174,6 +174,11 @@ def _report_header_md(meta: Any, summary: Any) -> list[str]:
     lines.append(f"**Iterations:** {config.get('iterations', '?')} per package")
     if config.get("install_from") == "sdist":
         lines.append("**Install source:** sdist")
+    if config.get("trust_ft_wheels"):
+        mode = (
+            "any version" if config.get("trust_ft_wheels_any_version") else "target version only"
+        )
+        lines.append(f"**FT wheel trust:** enabled ({mode})")
     lines.append(f"**Packages tested:** {summary.total_packages}")
     lines.append("")
 
@@ -193,6 +198,7 @@ def _report_summary_table_md(summary: Any) -> list[str]:
 
     display_order = [
         ("compatible", "Compatible"),
+        ("compatible_by_wheel", "Compatible (FT wheel)"),
         ("compatible_gil_fallback", "Compatible (GIL fallback)"),
         ("tsan_warnings", "TSAN warnings"),
         ("intermittent", "Intermittent"),

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -30,6 +30,7 @@ class FailureCategory(enum.Enum):
     """
 
     COMPATIBLE = "compatible"
+    COMPATIBLE_BY_WHEEL = "compatible_by_wheel"
     COMPATIBLE_GIL_FALLBACK = "compatible_gil_fallback"
     INTERMITTENT = "intermittent"
     INCOMPATIBLE = "incompatible"
@@ -45,6 +46,7 @@ class FailureCategory(enum.Enum):
         """True if the package at least works sometimes."""
         return self in (
             FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_BY_WHEEL,
             FailureCategory.COMPATIBLE_GIL_FALLBACK,
             FailureCategory.INTERMITTENT,
             FailureCategory.TSAN_WARNINGS,
@@ -55,6 +57,7 @@ class FailureCategory(enum.Enum):
         """Numeric severity for sorting (higher = worse)."""
         order = {
             FailureCategory.COMPATIBLE: 0,
+            FailureCategory.COMPATIBLE_BY_WHEEL: 0,
             FailureCategory.COMPATIBLE_GIL_FALLBACK: 1,
             FailureCategory.TSAN_WARNINGS: 2,
             FailureCategory.INTERMITTENT: 3,
@@ -72,6 +75,7 @@ class FailureCategory(enum.Enum):
         """Single-character symbol for compact display."""
         symbols = {
             FailureCategory.COMPATIBLE: "\u2713",
+            FailureCategory.COMPATIBLE_BY_WHEEL: "\u2295",
             FailureCategory.COMPATIBLE_GIL_FALLBACK: "\u26a0",
             FailureCategory.INTERMITTENT: "~",
             FailureCategory.INCOMPATIBLE: "\u2717",
@@ -180,6 +184,8 @@ class FTPackageResult:
     install_from: str = ""
     sdist_version: str | None = None
     sdist_tag_matched: bool | None = None
+    ft_wheel_found: bool | None = None
+    ft_wheel_version: str | None = None
 
     gil_enabled_pass_rate: float | None = None
     gil_enabled_iterations: list[IterationOutcome] | None = None
@@ -274,6 +280,8 @@ class FTPackageResult:
             "install_from": self.install_from,
             "sdist_version": self.sdist_version,
             "sdist_tag_matched": self.sdist_tag_matched,
+            "ft_wheel_found": self.ft_wheel_found,
+            "ft_wheel_version": self.ft_wheel_version,
             "iterations": [i.to_dict() for i in self.iterations],
         }
         if self.extension_compat is not None:
@@ -317,6 +325,8 @@ class FTPackageResult:
             install_from=data.get("install_from", ""),
             sdist_version=data.get("sdist_version"),
             sdist_tag_matched=data.get("sdist_tag_matched"),
+            ft_wheel_found=data.get("ft_wheel_found"),
+            ft_wheel_version=data.get("ft_wheel_version"),
             gil_enabled_pass_rate=data.get("gil_enabled_pass_rate"),
             gil_enabled_iterations=gil_iters,
         )
@@ -457,6 +467,7 @@ class FTRunSummary:
                 if r.category
                 in (
                     FailureCategory.COMPATIBLE,
+                    FailureCategory.COMPATIBLE_BY_WHEEL,
                     FailureCategory.TSAN_WARNINGS,
                 )
             )
@@ -469,6 +480,7 @@ class FTRunSummary:
                 if r.category
                 in (
                     FailureCategory.COMPATIBLE,
+                    FailureCategory.COMPATIBLE_BY_WHEEL,
                     FailureCategory.COMPATIBLE_GIL_FALLBACK,
                     FailureCategory.TSAN_WARNINGS,
                 )

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -20,15 +20,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from labeille.classifier import has_ft_wheel
 from labeille.crash import detect_crash
 from labeille.ft.compat import assess_extension_compat
 from labeille.ft.results import (
+    FailureCategory,
     FTPackageResult,
     FTRunMeta,
     IterationOutcome,
     append_ft_result,
     save_ft_run,
 )
+from labeille.resolve import fetch_pypi_metadata
 from labeille.runner import (
     _clean_env,
     build_sdist_install_commands,
@@ -43,6 +46,22 @@ from labeille.runner import (
 )
 
 log = logging.getLogger("labeille")
+
+_PYTHON_VERSION_RE = re.compile(r"(\d+)\.(\d+)")
+
+
+def _parse_python_version(version_str: str) -> tuple[int, int] | None:
+    """Extract (major, minor) from a Python version string.
+
+    Handles formats like ``"3.15.0a1"``, ``"3.14.0"``, ``"3.15"``.
+
+    Returns:
+        Tuple of ``(major, minor)``, or None if parsing fails.
+    """
+    m = _PYTHON_VERSION_RE.match(version_str)
+    if m is None:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
 
 
 @dataclass
@@ -71,6 +90,9 @@ class FTRunConfig:
     verbose: bool = False
     stderr_tail_bytes: int = 4096
     install_from: str = "source"
+    trust_ft_wheels: bool = False
+    trust_ft_wheels_any_version: bool = False
+    _target_python_version: tuple[int, int] | None = None
 
     def validate(self) -> list[str]:
         """Validate configuration. Returns list of error messages."""
@@ -85,6 +107,8 @@ class FTRunConfig:
             errors.append(f"Stall threshold must be >= 5, got {self.stall_threshold}")
         if self.compare_with_gil and self.iterations < 3:
             errors.append("GIL comparison mode needs at least 3 iterations for meaningful results")
+        if self.trust_ft_wheels_any_version and not self.trust_ft_wheels:
+            self.trust_ft_wheels = True
         return errors
 
 
@@ -465,6 +489,42 @@ def run_package_ft(
     """
     result = FTPackageResult(package=pkg.package)
 
+    # --- FT wheel trust check (before clone). ---
+    _cached_metadata: dict[str, Any] | None = None
+
+    if config.trust_ft_wheels:
+        ft_check_version: tuple[int, int] | None = (
+            None if config.trust_ft_wheels_any_version else config._target_python_version
+        )
+        _cached_metadata = fetch_pypi_metadata(pkg.package, timeout=10.0)
+        if _cached_metadata is not None:
+            urls = _cached_metadata.get("urls", [])
+            pypi_version: str | None = None
+            try:
+                pypi_version = _cached_metadata["info"]["version"]
+            except (KeyError, TypeError):
+                pass
+
+            if has_ft_wheel(urls, target_version=ft_check_version):
+                version_desc = (
+                    f" (Python {ft_check_version[0]}.{ft_check_version[1]})"
+                    if ft_check_version
+                    else " (any version)"
+                )
+                log.info(
+                    "Skipping %s: free-threaded wheel found for %s%s",
+                    pkg.package,
+                    pypi_version or "latest",
+                    version_desc,
+                )
+                result.category = FailureCategory.COMPATIBLE_BY_WHEEL
+                result.ft_wheel_found = True
+                result.ft_wheel_version = pypi_version
+                result.install_from = "skipped"
+                return result
+            else:
+                result.ft_wheel_found = False
+
     repo_dir = config.repos_dir / pkg.package
     venv_dir = config.venvs_dir / f"{pkg.package}-ft"
 
@@ -501,7 +561,14 @@ def run_package_ft(
 
     if config.install_from == "sdist":
         result.install_from = "sdist"
-        sdist_version = fetch_latest_pypi_version(pkg.package)
+        # Reuse cached metadata from FT wheel check if available.
+        if _cached_metadata is not None:
+            try:
+                sdist_version: str | None = _cached_metadata["info"]["version"]
+            except (KeyError, TypeError):
+                sdist_version = None
+        else:
+            sdist_version = fetch_latest_pypi_version(pkg.package)
         if sdist_version:
             log.info("PyPI latest version for %s: %s", pkg.package, sdist_version)
             commit_hash, matched_tag = checkout_matching_tag(repo_dir, pkg.package, sdist_version)
@@ -799,6 +866,9 @@ def run_ft(config: FTRunConfig) -> list[FTPackageResult]:
         env={"PYTHON_GIL": "0"},
     )
 
+    # Parse target Python version for FT wheel matching.
+    config._target_python_version = _parse_python_version(py_profile.version)
+
     if not py_profile.gil_disabled:
         log.warning(
             "Target Python at %s does not appear to be a "
@@ -851,6 +921,8 @@ def run_ft(config: FTRunConfig) -> list[FTPackageResult]:
             "test_command_suffix": config.test_command_suffix,
             "test_command_override": config.test_command_override,
             "install_from": config.install_from,
+            "trust_ft_wheels": config.trust_ft_wheels,
+            "trust_ft_wheels_any_version": config.trust_ft_wheels_any_version,
         },
         cli_args=sys.argv[1:],
         packages_total=len(packages),

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -101,6 +101,26 @@ def ft() -> None:
         "from the cloned repo."
     ),
 )
+@click.option(
+    "--trust-ft-wheels",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip packages that publish free-threaded wheels for the target "
+        "Python version. These packages are classified as "
+        "'compatible_by_wheel' without running any tests."
+    ),
+)
+@click.option(
+    "--trust-ft-wheels-any-version",
+    is_flag=True,
+    default=False,
+    help=(
+        "Like --trust-ft-wheels, but trusts free-threaded wheels built "
+        "for any Python version, not just the target. Implies "
+        "--trust-ft-wheels."
+    ),
+)
 def run(
     target_python: str,
     iterations: int,
@@ -123,6 +143,8 @@ def run(
     env_pairs: tuple[str, ...],
     verbose: bool,
     install_from: str,
+    trust_ft_wheels: bool,
+    trust_ft_wheels_any_version: bool,
 ) -> None:
     """Run free-threading compatibility tests.
 
@@ -179,6 +201,8 @@ def run(
         check_stability=check_stability,
         verbose=verbose,
         install_from=install_from,
+        trust_ft_wheels=trust_ft_wheels or trust_ft_wheels_any_version,
+        trust_ft_wheels_any_version=trust_ft_wheels_any_version,
     )
 
     results = run_ft(config)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from labeille.classifier import classify_from_urls, has_platform_wheel, is_pure_wheel
+from labeille.classifier import classify_from_urls, has_ft_wheel, has_platform_wheel, is_pure_wheel
 
 
 class TestIsPureWheel(unittest.TestCase):
@@ -89,6 +89,61 @@ class TestClassifyFromUrls(unittest.TestCase):
     def test_no_filename_key(self) -> None:
         urls = [{"url": "https://example.com/pkg-1.0.tar.gz"}]
         self.assertEqual(classify_from_urls(urls), "unknown")
+
+
+class TestHasFtWheel(unittest.TestCase):
+    def test_ft_wheel_found_any_version(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp313t-cp313t-manylinux_2_17_x86_64.whl"}]
+        self.assertTrue(has_ft_wheel(urls))
+
+    def test_ft_wheel_found_matching_version(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp315t-cp315t-manylinux_2_17_x86_64.whl"}]
+        self.assertTrue(has_ft_wheel(urls, target_version=(3, 15)))
+
+    def test_ft_wheel_wrong_version(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp313t-cp313t-manylinux_2_17_x86_64.whl"}]
+        self.assertFalse(has_ft_wheel(urls, target_version=(3, 15)))
+
+    def test_no_ft_wheel(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp315-cp315-manylinux_2_17_x86_64.whl"}]
+        self.assertFalse(has_ft_wheel(urls))
+
+    def test_pure_wheel_not_matched(self) -> None:
+        urls = [{"filename": "requests-2.31.0-py3-none-any.whl"}]
+        self.assertFalse(has_ft_wheel(urls))
+
+    def test_mixed_ft_and_non_ft(self) -> None:
+        urls = [
+            {"filename": "numpy-2.1.0-cp315-cp315-manylinux_2_17_x86_64.whl"},
+            {"filename": "numpy-2.1.0-cp315t-cp315t-manylinux_2_17_x86_64.whl"},
+        ]
+        self.assertTrue(has_ft_wheel(urls, target_version=(3, 15)))
+
+    def test_empty_urls(self) -> None:
+        self.assertFalse(has_ft_wheel([]))
+
+    def test_no_filename_key(self) -> None:
+        urls = [{"url": "https://example.com/pkg.whl"}]
+        self.assertFalse(has_ft_wheel(urls))
+
+    def test_multiple_versions_picks_target(self) -> None:
+        urls = [
+            {"filename": "numpy-2.1.0-cp313t-cp313t-manylinux_2_17_x86_64.whl"},
+            {"filename": "numpy-2.1.0-cp315t-cp315t-manylinux_2_17_x86_64.whl"},
+        ]
+        self.assertTrue(has_ft_wheel(urls, target_version=(3, 15)))
+
+    def test_sdist_only(self) -> None:
+        urls = [{"filename": "numpy-2.1.0.tar.gz"}]
+        self.assertFalse(has_ft_wheel(urls))
+
+    def test_macosx_ft_wheel(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp315t-cp315t-macosx_14_0_arm64.whl"}]
+        self.assertTrue(has_ft_wheel(urls, target_version=(3, 15)))
+
+    def test_windows_ft_wheel(self) -> None:
+        urls = [{"filename": "numpy-2.1.0-cp315t-cp315t-win_amd64.whl"}]
+        self.assertTrue(has_ft_wheel(urls, target_version=(3, 15)))
 
 
 if __name__ == "__main__":

--- a/tests/test_ft_cli.py
+++ b/tests/test_ft_cli.py
@@ -175,5 +175,19 @@ class TestFtRunInstallFrom(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
 
+class TestFtRunTrustFtWheels(unittest.TestCase):
+    def test_ft_run_trust_ft_wheels_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--trust-ft-wheels", result.output)
+
+    def test_ft_run_trust_ft_wheels_any_version_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["ft", "run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--trust-ft-wheels-any-version", result.output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ft_display.py
+++ b/tests/test_ft_display.py
@@ -82,6 +82,24 @@ class TestFormatCompatibilitySummary(unittest.TestCase):
         output = format_compatibility_summary(summary, system_info="System: AMD Ryzen 9, 64GB RAM")
         self.assertIn("System: AMD Ryzen 9, 64GB RAM", output)
 
+    def test_summary_compatible_by_wheel(self) -> None:
+        summary = {
+            "total_packages": 100,
+            "categories": {"compatible": 50, "compatible_by_wheel": 15},
+        }
+        output = format_compatibility_summary(summary)
+        self.assertIn("Compatible (FT wheel)", output)
+        self.assertIn("15", output)
+        self.assertIn("⊕", output)
+
+    def test_summary_wheel_zero_omitted(self) -> None:
+        summary = {
+            "total_packages": 100,
+            "categories": {"compatible": 100, "compatible_by_wheel": 0},
+        }
+        output = format_compatibility_summary(summary)
+        self.assertNotIn("Compatible (FT wheel)", output)
+
     def test_summary_extension_breakdown(self) -> None:
         summary = {
             "total_packages": 350,
@@ -150,6 +168,18 @@ class TestFormatPackageTable(unittest.TestCase):
         )
         output = format_package_table([r])
         self.assertIn("3 flaky tests", output)
+
+    def test_table_wheel_trust_details(self) -> None:
+        r = _make_result(
+            "numpy",
+            FailureCategory.COMPATIBLE_BY_WHEEL,
+            ft_wheel_found=True,
+            ft_wheel_version="2.1.0",
+            iterations_completed=0,
+            pass_count=0,
+        )
+        output = format_package_table([r])
+        self.assertIn("FT wheel (2.1.0)", output)
 
     def test_table_install_failure(self) -> None:
         r = _make_result(

--- a/tests/test_ft_results.py
+++ b/tests/test_ft_results.py
@@ -36,6 +36,7 @@ class TestFailureCategory(unittest.TestCase):
     def test_category_is_usable(self) -> None:
         usable = {
             FailureCategory.COMPATIBLE,
+            FailureCategory.COMPATIBLE_BY_WHEEL,
             FailureCategory.COMPATIBLE_GIL_FALLBACK,
             FailureCategory.INTERMITTENT,
             FailureCategory.TSAN_WARNINGS,
@@ -74,6 +75,18 @@ class TestFailureCategory(unittest.TestCase):
     def test_category_invalid_string(self) -> None:
         with self.assertRaises(ValueError):
             FailureCategory("not_a_category")
+
+    def test_compatible_by_wheel_severity(self) -> None:
+        self.assertEqual(FailureCategory.COMPATIBLE_BY_WHEEL.severity, 0)
+
+    def test_compatible_by_wheel_is_usable(self) -> None:
+        self.assertTrue(FailureCategory.COMPATIBLE_BY_WHEEL.is_usable)
+
+    def test_compatible_by_wheel_symbol(self) -> None:
+        self.assertEqual(FailureCategory.COMPATIBLE_BY_WHEEL.symbol, "\u2295")
+
+    def test_compatible_by_wheel_value(self) -> None:
+        self.assertEqual(FailureCategory.COMPATIBLE_BY_WHEEL.value, "compatible_by_wheel")
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +338,28 @@ class TestFTPackageResult(unittest.TestCase):
         self.assertEqual(restored.install_from, "")
         self.assertIsNone(restored.sdist_version)
 
+    def test_ft_wheel_fields_roundtrip(self) -> None:
+        result = FTPackageResult(
+            package="mypkg",
+            ft_wheel_found=True,
+            ft_wheel_version="2.1.0",
+        )
+        result.compute_aggregates()
+        result.categorize()
+        d = result.to_dict()
+        self.assertTrue(d["ft_wheel_found"])
+        self.assertEqual(d["ft_wheel_version"], "2.1.0")
+
+        restored = FTPackageResult.from_dict(d)
+        self.assertTrue(restored.ft_wheel_found)
+        self.assertEqual(restored.ft_wheel_version, "2.1.0")
+
+    def test_ft_wheel_fields_missing_defaults(self) -> None:
+        d = {"package": "pkg", "category": "unknown"}
+        restored = FTPackageResult.from_dict(d)
+        self.assertIsNone(restored.ft_wheel_found)
+        self.assertIsNone(restored.ft_wheel_version)
+
 
 # ---------------------------------------------------------------------------
 # Categorization tests
@@ -455,6 +490,37 @@ class TestFTRunSummary(unittest.TestCase):
         self.assertEqual(summary.pure_python_count, 1)
         self.assertEqual(summary.extension_count, 2)
         self.assertEqual(summary.pure_python_compatible_pct, 100.0)
+        self.assertEqual(summary.extension_compatible_pct, 50.0)
+
+    def test_summary_compatible_by_wheel_counted(self) -> None:
+        wheel_result = FTPackageResult(
+            package="numpy",
+            category=FailureCategory.COMPATIBLE_BY_WHEEL,
+            ft_wheel_found=True,
+            ft_wheel_version="2.1.0",
+        )
+        results = [
+            make_package_result("a", ["pass"] * 5),
+            wheel_result,
+        ]
+        summary = FTRunSummary.compute(results)
+        self.assertEqual(summary.categories.get("compatible_by_wheel"), 1)
+        self.assertEqual(summary.categories.get("compatible"), 1)
+
+    def test_summary_wheel_counts_as_compatible_pct(self) -> None:
+        wheel_result = FTPackageResult(
+            package="numpy",
+            category=FailureCategory.COMPATIBLE_BY_WHEEL,
+            extension_compat={"is_pure_python": False},
+        )
+        fail_result = make_package_result(
+            "badext",
+            ["fail"] * 5,
+            extension_compat={"is_pure_python": False},
+        )
+        results = [wheel_result, fail_result]
+        summary = FTRunSummary.compute(results)
+        self.assertEqual(summary.extension_count, 2)
         self.assertEqual(summary.extension_compatible_pct, 50.0)
 
     def test_summary_serialization_roundtrip(self) -> None:

--- a/tests/test_ft_runner.py
+++ b/tests/test_ft_runner.py
@@ -14,6 +14,7 @@ from labeille.ft.results import FailureCategory, IterationOutcome
 from labeille.ft.runner import (
     FTRunConfig,
     OutputMonitor,
+    _parse_python_version,
     extract_tsan_warnings,
     parse_pytest_summary,
     parse_pytest_verbose,
@@ -667,6 +668,242 @@ class TestFTRunConfig(unittest.TestCase):
         )
         errors = config.validate()
         self.assertTrue(any("comparison" in e.lower() for e in errors))
+
+
+# ---------------------------------------------------------------------------
+# _parse_python_version tests
+# ---------------------------------------------------------------------------
+
+
+class TestParsePythonVersion(unittest.TestCase):
+    def test_full_version(self) -> None:
+        self.assertEqual(_parse_python_version("3.15.0a1"), (3, 15))
+
+    def test_release_version(self) -> None:
+        self.assertEqual(_parse_python_version("3.14.0"), (3, 14))
+
+    def test_short_version(self) -> None:
+        self.assertEqual(_parse_python_version("3.15"), (3, 15))
+
+    def test_two_digit_minor(self) -> None:
+        self.assertEqual(_parse_python_version("3.15.0"), (3, 15))
+
+    def test_empty_string(self) -> None:
+        self.assertIsNone(_parse_python_version(""))
+
+    def test_garbage(self) -> None:
+        self.assertIsNone(_parse_python_version("not-a-version"))
+
+
+# ---------------------------------------------------------------------------
+# FTRunConfig trust wheels tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTRunConfigTrustWheels(unittest.TestCase):
+    def test_any_version_implies_trust(self) -> None:
+        config = FTRunConfig(
+            target_python=Path(sys.executable),
+            trust_ft_wheels_any_version=True,
+            trust_ft_wheels=False,
+        )
+        config.validate()
+        self.assertTrue(config.trust_ft_wheels)
+
+    def test_default_no_trust(self) -> None:
+        config = FTRunConfig(target_python=Path(sys.executable))
+        self.assertFalse(config.trust_ft_wheels)
+        self.assertFalse(config.trust_ft_wheels_any_version)
+
+
+# ---------------------------------------------------------------------------
+# run_package_ft wheel trust tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunPackageFtWheelTrust(unittest.TestCase):
+    def _make_pkg(self, **overrides: object) -> SimpleNamespace:
+        defaults = {
+            "package": "mypkg",
+            "repo": "https://github.com/x/mypkg",
+            "install_command": "pip install -e .",
+            "test_command": "python -m pytest tests/",
+            "import_name": "mypkg",
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _make_config(self, **overrides: object) -> FTRunConfig:
+        import tempfile
+
+        tmpdir = Path(tempfile.mkdtemp())
+        defaults: dict[str, object] = {
+            "target_python": Path("/fake/python"),
+            "iterations": 3,
+            "timeout": 60,
+            "stall_threshold": 30,
+            "repos_dir": tmpdir / "repos",
+            "venvs_dir": tmpdir / "venvs",
+            "results_dir": tmpdir / "results",
+            "detect_extensions": False,
+            "compare_with_gil": False,
+            "stop_on_first_pass": False,
+        }
+        defaults.update(overrides)
+        return FTRunConfig(**defaults)  # type: ignore[arg-type]
+
+    @patch("labeille.ft.runner.install_package")
+    @patch("labeille.ft.runner.create_venv")
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.has_ft_wheel", return_value=True)
+    @patch("labeille.ft.runner.fetch_pypi_metadata")
+    def test_ft_wheel_found_skips_package(
+        self,
+        mock_metadata: MagicMock,
+        mock_has_ft: MagicMock,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+    ) -> None:
+        mock_metadata.return_value = {"info": {"version": "2.1.0"}, "urls": []}
+        config = self._make_config(trust_ft_wheels=True, _target_python_version=(3, 15))
+        result = run_package_ft(self._make_pkg(), config)
+
+        self.assertEqual(result.category, FailureCategory.COMPATIBLE_BY_WHEEL)
+        self.assertTrue(result.ft_wheel_found)
+        self.assertEqual(result.ft_wheel_version, "2.1.0")
+        self.assertEqual(result.install_from, "skipped")
+        mock_clone.assert_not_called()
+        mock_venv.assert_not_called()
+        mock_install.assert_not_called()
+
+    @patch("labeille.ft.runner.run_single_iteration")
+    @patch("labeille.ft.runner.install_package")
+    @patch("labeille.ft.runner.create_venv")
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.has_ft_wheel", return_value=False)
+    @patch("labeille.ft.runner.fetch_pypi_metadata")
+    def test_ft_wheel_not_found_continues(
+        self,
+        mock_metadata: MagicMock,
+        mock_has_ft: MagicMock,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+        mock_run_iter: MagicMock,
+    ) -> None:
+        mock_metadata.return_value = {"info": {"version": "2.1.0"}, "urls": []}
+        config = self._make_config(trust_ft_wheels=True, _target_python_version=(3, 15))
+        repo_dir = config.repos_dir / "mypkg"
+        repo_dir.mkdir(parents=True)
+
+        mock_install.return_value = MagicMock(returncode=0)
+        mock_run_iter.return_value = IterationOutcome(
+            index=1, status="pass", exit_code=0, duration_s=5.0
+        )
+
+        with patch("labeille.ft.runner.pull_repo"):
+            result = run_package_ft(self._make_pkg(), config)
+
+        self.assertFalse(result.ft_wheel_found)
+        mock_clone.assert_not_called()  # repo_dir exists, so pull_repo is used
+        self.assertNotEqual(result.category, FailureCategory.COMPATIBLE_BY_WHEEL)
+
+    @patch("labeille.ft.runner.run_single_iteration")
+    @patch("labeille.ft.runner.install_package")
+    @patch("labeille.ft.runner.create_venv")
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.fetch_pypi_metadata", return_value=None)
+    def test_pypi_failure_continues(
+        self,
+        mock_metadata: MagicMock,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+        mock_run_iter: MagicMock,
+    ) -> None:
+        config = self._make_config(trust_ft_wheels=True, _target_python_version=(3, 15))
+        repo_dir = config.repos_dir / "mypkg"
+        repo_dir.mkdir(parents=True)
+
+        mock_install.return_value = MagicMock(returncode=0)
+        mock_run_iter.return_value = IterationOutcome(
+            index=1, status="pass", exit_code=0, duration_s=5.0
+        )
+
+        with patch("labeille.ft.runner.pull_repo"):
+            result = run_package_ft(self._make_pkg(), config)
+
+        self.assertIsNone(result.ft_wheel_found)
+        self.assertNotEqual(result.category, FailureCategory.COMPATIBLE_BY_WHEEL)
+
+    @patch("labeille.ft.runner.run_single_iteration")
+    @patch("labeille.ft.runner.install_package")
+    @patch("labeille.ft.runner.create_venv")
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.fetch_pypi_metadata")
+    def test_trust_off_skips_check(
+        self,
+        mock_metadata: MagicMock,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+        mock_run_iter: MagicMock,
+    ) -> None:
+        config = self._make_config(trust_ft_wheels=False)
+        repo_dir = config.repos_dir / "mypkg"
+        repo_dir.mkdir(parents=True)
+
+        mock_install.return_value = MagicMock(returncode=0)
+        mock_run_iter.return_value = IterationOutcome(
+            index=1, status="pass", exit_code=0, duration_s=5.0
+        )
+
+        with patch("labeille.ft.runner.pull_repo"):
+            run_package_ft(self._make_pkg(), config)
+
+        mock_metadata.assert_not_called()
+
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.has_ft_wheel", return_value=True)
+    @patch("labeille.ft.runner.fetch_pypi_metadata")
+    def test_any_version_passes_none(
+        self,
+        mock_metadata: MagicMock,
+        mock_has_ft: MagicMock,
+        mock_clone: MagicMock,
+    ) -> None:
+        mock_metadata.return_value = {"info": {"version": "2.1.0"}, "urls": []}
+        config = self._make_config(
+            trust_ft_wheels=True,
+            trust_ft_wheels_any_version=True,
+        )
+
+        run_package_ft(self._make_pkg(), config)
+        mock_has_ft.assert_called_once()
+        _, kwargs = mock_has_ft.call_args
+        self.assertIsNone(kwargs.get("target_version"))
+
+    @patch("labeille.ft.runner.clone_repo")
+    @patch("labeille.ft.runner.has_ft_wheel", return_value=True)
+    @patch("labeille.ft.runner.fetch_pypi_metadata")
+    def test_version_matched_passes_tuple(
+        self,
+        mock_metadata: MagicMock,
+        mock_has_ft: MagicMock,
+        mock_clone: MagicMock,
+    ) -> None:
+        mock_metadata.return_value = {"info": {"version": "2.1.0"}, "urls": []}
+        config = self._make_config(
+            trust_ft_wheels=True,
+            trust_ft_wheels_any_version=False,
+            _target_python_version=(3, 15),
+        )
+
+        run_package_ft(self._make_pkg(), config)
+        mock_has_ft.assert_called_once()
+        _, kwargs = mock_has_ft.call_args
+        self.assertEqual(kwargs.get("target_version"), (3, 15))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `--trust-ft-wheels` and `--trust-ft-wheels-any-version` flags to `labeille ft run`. Packages that publish free-threaded wheels (`cpXYt` ABI tag) are classified as `compatible_by_wheel` without cloning, installing, or running tests.
- New `COMPATIBLE_BY_WHEEL` category in `FailureCategory` with `⊕` symbol. Counted as compatible in summaries, excluded from triage.
- `has_ft_wheel()` function in `classifier.py` with optional version matching. FT wheel check reuses PyPI metadata for sdist version lookup.

## Test plan
- [x] 1885 tests pass (39 new tests added across 5 test files)
- [x] ruff format and ruff check clean
- [x] mypy strict mode clean
- [x] TestHasFtWheel: 12 tests for wheel detection (any version, matching version, wrong version, pure wheel, mixed, empty, etc.)
- [x] TestParsePythonVersion: 6 tests for version parsing
- [x] TestFTRunConfigTrustWheels: 2 tests for config validation
- [x] TestRunPackageFtWheelTrust: 6 tests for early-exit logic (wheel found/not found, PyPI failure, trust off, any version, version matched)
- [x] TestFailureCategory: 4 new tests for COMPATIBLE_BY_WHEEL properties
- [x] TestFTPackageResult: 2 new tests for ft_wheel_found/ft_wheel_version roundtrip
- [x] TestFTRunSummary: 2 new tests for compatible counting
- [x] TestFormatCompatibilitySummary: 2 new tests for display
- [x] TestFormatPackageTable: 1 new test for wheel trust details
- [x] TestFtRunTrustFtWheels: 2 new CLI tests

Closes #114

Generated with [Claude Code](https://claude.com/claude-code)