### PR TITLE
feat: adaptive iteration convergence for bench run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- `--adaptive` flag for `labeille bench run`: stop iterating early when wall-time measurements converge (RSE below threshold).
+- `--adaptive-threshold` option (default 0.005 = 0.5% RSE) and `--adaptive-min-iterations` option (default 5) for fine-tuning convergence behavior.
+- `adaptive`, `adaptive_threshold`, and `adaptive_min_iterations` fields in YAML benchmark profiles.
+- `converged_early` field on `BenchConditionResult`, recorded in `bench_results.jsonl`.
+- `relative_standard_error()` function in `bench/stats.py`.
+- Adaptive convergence support in all three execution strategies (block, alternating, interleaved).
+- Quick mode (`--quick`) now enables adaptive convergence by default.
+- Convergence indicators in benchmark display: checkmark in table, count in quality summary, config line.
 - `--trust-ft-wheels` flag for `labeille ft run`: packages with free-threaded wheels (`cpXYt` ABI tag) for the target Python version are classified as `compatible_by_wheel` without running tests.
 - `--trust-ft-wheels-any-version` flag for `labeille ft run`: like `--trust-ft-wheels` but trusts free-threaded wheels built for any Python version. Implies `--trust-ft-wheels`.
 - `COMPATIBLE_BY_WHEEL` category in `FailureCategory` with `⊕` symbol and severity 0.

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -48,6 +48,11 @@ class BenchConfig:
     alternate: bool | None = None  # None = auto (True if multi-condition)
     interleave: bool = False
 
+    # Adaptive convergence
+    adaptive: bool = False  # Enable adaptive early stopping
+    adaptive_threshold: float = 0.005  # RSE threshold (0.5%)
+    adaptive_min_iterations: int = 5  # Minimum measured iterations before checking
+
     # Package selection (same semantics as labeille run)
     packages_filter: list[str] | None = None
     top_n: int | None = None
@@ -230,6 +235,40 @@ def validate_config(config: BenchConfig) -> list[ValidationError]:
             )
         )
 
+    # Adaptive convergence constraints.
+    if config.adaptive:
+        if config.adaptive_threshold <= 0:
+            errors.append(
+                ValidationError(
+                    field="adaptive_threshold",
+                    message=(
+                        f"Adaptive threshold must be positive (got {config.adaptive_threshold})."
+                    ),
+                )
+            )
+        if config.adaptive_min_iterations < 3:
+            errors.append(
+                ValidationError(
+                    field="adaptive_min_iterations",
+                    message=(
+                        f"Adaptive min iterations must be >= 3 "
+                        f"(got {config.adaptive_min_iterations})."
+                    ),
+                )
+            )
+        if config.adaptive_min_iterations > config.iterations:
+            errors.append(
+                ValidationError(
+                    field="adaptive_min_iterations",
+                    message=(
+                        f"Adaptive min iterations ({config.adaptive_min_iterations}) "
+                        f"exceeds total iterations ({config.iterations}). "
+                        f"Adaptive stopping would never trigger."
+                    ),
+                    severity="warning",
+                )
+            )
+
     # Condition names must be non-empty.
     for name in config.conditions:
         if not name or not name.strip():
@@ -388,6 +427,20 @@ def config_from_profile(
     default_constraints_data = profile_data.get("constraints")
     if default_constraints_data and isinstance(default_constraints_data, dict):
         config.default_constraints = ResourceConstraints.from_dict(default_constraints_data)
+
+    # Adaptive convergence.
+    if cli.get("adaptive") is not None:
+        config.adaptive = cli["adaptive"]
+    elif profile_data.get("adaptive"):
+        config.adaptive = True
+    if cli.get("adaptive_threshold") is not None:
+        config.adaptive_threshold = cli["adaptive_threshold"]
+    elif profile_data.get("adaptive_threshold") is not None:
+        config.adaptive_threshold = float(profile_data["adaptive_threshold"])
+    if cli.get("adaptive_min_iterations") is not None:
+        config.adaptive_min_iterations = cli["adaptive_min_iterations"]
+    elif profile_data.get("adaptive_min_iterations") is not None:
+        config.adaptive_min_iterations = int(profile_data["adaptive_min_iterations"])
 
     # Cache control — drop_caches is allowed in profiles.
     if profile_data.get("drop_caches"):

--- a/src/labeille/bench/display.py
+++ b/src/labeille/bench/display.py
@@ -121,6 +121,12 @@ def format_bench_show(
     if cfg.get("interleave"):
         strategy = "interleaved"
     lines.append(f"Strategy: {strategy}")
+    if cfg.get("adaptive"):
+        threshold_pct = cfg.get("adaptive_threshold", 0.005) * 100
+        lines.append(
+            f"Adaptive: on (threshold {threshold_pct:.1f}% RSE, "
+            f"min {cfg.get('adaptive_min_iterations', 5)} iterations)"
+        )
     lines.append(f"Packages: {meta.packages_completed} completed, {meta.packages_skipped} skipped")
     if meta.start_time and meta.end_time:
         lines.append(f"Time: {meta.start_time} \u2192 {meta.end_time}")
@@ -171,11 +177,12 @@ def _format_single_condition_table(
         statuses = [it.status for it in cond.measured_iterations]
         status = max(set(statuses), key=statuses.count) if statuses else "N/A"
 
+        converge_marker = " \u2713" if cond.converged_early else ""
         lines.append(
             f"{r.package:<30s} {ws.median:>10.2f} {ws.stdev:>7.2f}s "
             f"{us.mean if us else 0:>10.2f} "
             f"{rs.median if rs else 0:>10.1f} "
-            f"{cv_str:>6s} {status:>8s}"
+            f"{cv_str:>6s} {status:>8s}{converge_marker}"
         )
 
     return "\n".join(lines)
@@ -297,6 +304,18 @@ def _format_quality_summary(
             lines.append(f"    Packages with CV > 10%: {high_cv}")
         lines.append(f"    Outliers:          {outlier_count} / {total_iterations} iterations")
         lines.append(f"    Max system load:   {max_load:.1f}")
+
+        # Count converged packages.
+        converged_count = sum(
+            1
+            for r in results
+            if not r.skipped
+            and r.conditions.get(cond_name)
+            and r.conditions[cond_name].converged_early
+        )
+        if converged_count:
+            total_active = sum(1 for r in results if not r.skipped)
+            lines.append(f"    Converged early:   {converged_count} / {total_active} packages")
 
     # Overall quality assessment.
     all_cvs: list[float] = []

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -114,6 +114,9 @@ class BenchConditionResult:
     user_time_stats: DescriptiveStats | None = None
     sys_time_stats: DescriptiveStats | None = None
     peak_rss_stats: DescriptiveStats | None = None
+    # Adaptive convergence.
+    converged_early: bool = False  # True if adaptive stopping triggered
+
     # Setup timing (not part of the benchmark):
     install_duration_s: float = 0.0
     venv_setup_duration_s: float = 0.0
@@ -166,6 +169,8 @@ class BenchConditionResult:
             "install_duration_s": round(self.install_duration_s, 2),
             "venv_setup_duration_s": round(self.venv_setup_duration_s, 2),
         }
+        if self.converged_early:
+            d["converged_early"] = True
         if self.wall_time_stats:
             d["wall_time_stats"] = self.wall_time_stats.to_dict()
         if self.user_time_stats:
@@ -183,6 +188,7 @@ class BenchConditionResult:
         result.iterations = [BenchIteration.from_dict(it) for it in data.get("iterations", [])]
         result.install_duration_s = data.get("install_duration_s", 0.0)
         result.venv_setup_duration_s = data.get("venv_setup_duration_s", 0.0)
+        result.converged_early = data.get("converged_early", False)
         # Recompute stats rather than deserializing — ensures consistency.
         result.compute_stats()
         return result

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -36,6 +36,7 @@ from labeille.bench.config import (
     resolve_test_command,
     validate_config,
 )
+from labeille.bench.stats import relative_standard_error
 from labeille.bench.results import (
     BenchConditionResult,
     BenchIteration,
@@ -246,6 +247,9 @@ class BenchRunner:
                 "interleave": self.config.interleave,
                 "packages_filter": self.config.packages_filter,
                 "top_n": self.config.top_n,
+                "adaptive": self.config.adaptive,
+                "adaptive_threshold": self.config.adaptive_threshold,
+                "adaptive_min_iterations": self.config.adaptive_min_iterations,
             },
             cli_args=self.config.cli_args,
             start_time=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
@@ -387,6 +391,9 @@ class BenchRunner:
         total_iter = self.config.total_iterations
         condition_names = list(self.config.conditions.keys())
 
+        # Track which packages have converged (for adaptive mode).
+        converged_packages: set[int] = set()
+
         for iter_idx in range(total_iter):
             is_warmup = iter_idx < self.config.warmup
             phase = "warmup" if is_warmup else "measure"
@@ -395,7 +402,7 @@ class BenchRunner:
             for pkg_idx, (pkg, setup, pkg_result) in enumerate(
                 zip(packages, pkg_setups, pkg_results),
             ):
-                if pkg_result.skipped or not setup:
+                if pkg_result.skipped or not setup or pkg_idx in converged_packages:
                     continue
 
                 for cond_name in condition_names:
@@ -422,6 +429,22 @@ class BenchRunner:
                             status=iteration.status,
                         )
                     )
+
+                # Adaptive convergence: check after each full round of conditions.
+                if self.config.adaptive and not is_warmup:
+                    all_converged = all(
+                        self._check_convergence(pkg_result.conditions[cn])
+                        for cn in condition_names
+                    )
+                    if all_converged:
+                        for cn in condition_names:
+                            pkg_result.conditions[cn].converged_early = True
+                        converged_packages.add(pkg_idx)
+                        log.info(
+                            "Adaptive: %s converged after %d measured iterations",
+                            pkg.package,
+                            iter_idx + 1 - self.config.warmup,
+                        )
 
         # Compute stats and write results.
         results: list[BenchPackageResult] = []
@@ -493,6 +516,22 @@ class BenchRunner:
                             status=iteration.status,
                         )
                     )
+
+                # Adaptive convergence: check after each full round of conditions.
+                if self.config.adaptive and not is_warmup:
+                    all_converged = all(
+                        self._check_convergence(pkg_result.conditions[cn])
+                        for cn in condition_names
+                    )
+                    if all_converged:
+                        for cn in condition_names:
+                            pkg_result.conditions[cn].converged_early = True
+                        log.info(
+                            "Adaptive: %s converged after %d measured iterations",
+                            pkg.package,
+                            iter_idx + 1 - self.config.warmup,
+                        )
+                        break
         else:
             # Block: all iterations of condition A, then B.
             for cond_name in condition_names:
@@ -523,6 +562,21 @@ class BenchRunner:
                             status=iteration.status,
                         )
                     )
+
+                    # Adaptive convergence: check after each measured iteration.
+                    if (
+                        self.config.adaptive
+                        and not is_warmup
+                        and self._check_convergence(pkg_result.conditions[cond_name])
+                    ):
+                        pkg_result.conditions[cond_name].converged_early = True
+                        log.info(
+                            "Adaptive: %s/%s converged after %d measured iterations",
+                            pkg.package,
+                            cond_name,
+                            iter_idx + 1 - self.config.warmup,
+                        )
+                        break
 
         # Compute stats.
         for cond_result in pkg_result.conditions.values():
@@ -761,6 +815,31 @@ class BenchRunner:
             per_test_timings=per_test_timings,
         )
 
+    def _check_convergence(
+        self,
+        cond_result: BenchConditionResult,
+    ) -> bool:
+        """Check if wall-time measurements have converged.
+
+        Convergence is reached when the Relative Standard Error (RSE)
+        of measured wall times drops below the adaptive threshold.
+
+        Args:
+            cond_result: The condition result to check.
+
+        Returns:
+            True if RSE is below the threshold.
+        """
+        measured = [it for it in cond_result.iterations if not it.warmup]
+        n = len(measured)
+        if n < self.config.adaptive_min_iterations:
+            return False
+        wall_times = [it.wall_time_s for it in measured]
+        rse = relative_standard_error(wall_times)
+        if rse != rse:  # NaN check
+            return False
+        return rse < self.config.adaptive_threshold
+
     def _wait_for_stability(self) -> None:
         """Block until the system meets stability criteria."""
         log.info(
@@ -823,11 +902,13 @@ class BenchRunner:
 def quick_config(config: BenchConfig) -> BenchConfig:
     """Apply quick mode settings for rapid iteration.
 
-    Reduces iterations to 3, warmup to 0, and limits to top 20
-    packages.  Useful during development and testing.
+    Reduces iterations to 3, warmup to 0, limits to top 20
+    packages, and enables adaptive convergence.  Useful during
+    development and testing.
     """
     config.iterations = 3
     config.warmup = 0
     config.top_n = min(config.top_n or 20, 20)
+    config.adaptive = True
     config.name = f"{config.name} (quick)" if config.name else "Quick benchmark"
     return config

--- a/src/labeille/bench/stats.py
+++ b/src/labeille/bench/stats.py
@@ -117,6 +117,31 @@ def describe(values: Sequence[float]) -> DescriptiveStats:
     )
 
 
+def relative_standard_error(values: Sequence[float]) -> float:
+    """Compute the Relative Standard Error (RSE) of a sample.
+
+    RSE = (stdev / sqrt(n)) / mean
+
+    This measures the precision of the sample mean as a fraction.
+    Lower RSE means the mean is more precisely estimated.  A value
+    of 0.005 means the sample mean is estimated to within 0.5%.
+
+    Args:
+        values: Numeric sample. Must have at least 2 elements.
+
+    Returns:
+        RSE as a float. Returns NaN if n < 2 or mean == 0.
+    """
+    n = len(values)
+    if n < 2:
+        return float("nan")
+    mean = statistics.mean(values)
+    if mean == 0:
+        return float("nan")
+    stdev = statistics.stdev(values)
+    return (stdev / math.sqrt(n)) / abs(mean)
+
+
 def _percentile(sorted_values: list[float], p: float) -> float:
     """Compute the p-th percentile using linear interpolation.
 

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -153,10 +153,28 @@ def bench() -> None:
     help="Wait for system to stabilize.",
 )
 @click.option(
+    "--adaptive",
+    is_flag=True,
+    default=False,
+    help="Stop iterating early when measurements converge (RSE below threshold).",
+)
+@click.option(
+    "--adaptive-threshold",
+    type=float,
+    default=None,
+    help="RSE convergence threshold (default: 0.005 = 0.5%%).",
+)
+@click.option(
+    "--adaptive-min-iterations",
+    type=int,
+    default=None,
+    help="Minimum measured iterations before convergence check (default: 5).",
+)
+@click.option(
     "--quick",
     is_flag=True,
     default=False,
-    help="Quick mode: 3 iterations, no warmup, top 20.",
+    help="Quick mode: 3 iterations, no warmup, top 20, adaptive.",
 )
 @click.option(
     "--env",
@@ -236,6 +254,9 @@ def run(  # noqa: PLR0913
     name: str | None,
     check_stability: bool,
     wait_for_stability: bool,
+    adaptive: bool,
+    adaptive_threshold: float | None,
+    adaptive_min_iterations: int | None,
     quick: bool,
     per_test_timing: bool,
     memory_limit: int | None,
@@ -302,6 +323,9 @@ def run(  # noqa: PLR0913
             [p.strip() for p in packages.split(",") if p.strip()] if packages else None
         ),
         "top_n": top_n,
+        "adaptive": adaptive or None,
+        "adaptive_threshold": adaptive_threshold,
+        "adaptive_min_iterations": adaptive_min_iterations,
     }
 
     if profile_path:
@@ -344,6 +368,12 @@ def run(  # noqa: PLR0913
             config.default_env[k] = v
 
     config.installer = installer
+    if adaptive:
+        config.adaptive = True
+    if adaptive_threshold is not None:
+        config.adaptive_threshold = adaptive_threshold
+    if adaptive_min_iterations is not None:
+        config.adaptive_min_iterations = adaptive_min_iterations
     config.check_stability = check_stability
     config.wait_for_stability = wait_for_stability
     config.per_test_timing = per_test_timing

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -164,6 +164,51 @@ class TestValidateConfig(unittest.TestCase):
         warnings = [e for e in errors if e.severity == "warning"]
         self.assertTrue(len(warnings) > 0)
 
+    def test_validate_adaptive_threshold_positive(self) -> None:
+        """Adaptive threshold must be positive."""
+        config = self._valid_config()
+        config.adaptive = True
+        config.adaptive_threshold = 0.0
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "adaptive_threshold" for e in errors))
+
+    def test_validate_adaptive_min_iterations_too_low(self) -> None:
+        """Adaptive min iterations must be >= 3."""
+        config = self._valid_config()
+        config.adaptive = True
+        config.adaptive_min_iterations = 2
+        errors = validate_config(config)
+        self.assertTrue(any(e.field == "adaptive_min_iterations" for e in errors))
+
+    def test_validate_adaptive_min_exceeds_total_warns(self) -> None:
+        """Adaptive min > iterations should produce a warning."""
+        config = self._valid_config()
+        config.adaptive = True
+        config.iterations = 5
+        config.adaptive_min_iterations = 10
+        errors = validate_config(config)
+        warnings = [e for e in errors if e.severity == "warning"]
+        self.assertTrue(any(e.field == "adaptive_min_iterations" for e in warnings))
+
+    def test_validate_adaptive_valid(self) -> None:
+        """Valid adaptive config should produce no errors."""
+        config = self._valid_config()
+        config.adaptive = True
+        config.adaptive_threshold = 0.005
+        config.adaptive_min_iterations = 5
+        config.iterations = 10
+        errors = validate_config(config)
+        fatal = [e for e in errors if e.severity == "error"]
+        self.assertEqual(fatal, [])
+
+    def test_validate_adaptive_disabled_skips_checks(self) -> None:
+        """With adaptive=False, bad threshold doesn't error."""
+        config = self._valid_config()
+        config.adaptive = False
+        config.adaptive_threshold = -1.0
+        errors = validate_config(config)
+        self.assertFalse(any(e.field == "adaptive_threshold" for e in errors))
+
 
 # ---------------------------------------------------------------------------
 # Profile loading tests
@@ -316,6 +361,33 @@ class TestConfigFromProfile(unittest.TestCase):
         data = {"warmup": 3, "conditions": {"a": None}}
         config = config_from_profile(data, cli_overrides={"warmup": 0})
         self.assertEqual(config.warmup, 0)
+
+    def test_config_from_profile_adaptive(self) -> None:
+        """Adaptive settings should be loaded from profile."""
+        data = {
+            "conditions": {"a": None},
+            "adaptive": True,
+            "adaptive_threshold": 0.01,
+            "adaptive_min_iterations": 7,
+        }
+        config = config_from_profile(data)
+        self.assertTrue(config.adaptive)
+        self.assertAlmostEqual(config.adaptive_threshold, 0.01)
+        self.assertEqual(config.adaptive_min_iterations, 7)
+
+    def test_config_from_profile_adaptive_cli_overrides(self) -> None:
+        """CLI adaptive settings should override profile."""
+        data = {
+            "conditions": {"a": None},
+            "adaptive": True,
+            "adaptive_threshold": 0.01,
+        }
+        config = config_from_profile(
+            data,
+            cli_overrides={"adaptive_threshold": 0.002, "adaptive_min_iterations": 10},
+        )
+        self.assertAlmostEqual(config.adaptive_threshold, 0.002)
+        self.assertEqual(config.adaptive_min_iterations, 10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bench_display.py
+++ b/tests/test_bench_display.py
@@ -362,5 +362,57 @@ class TestComparisonSummary(unittest.TestCase):
         self.assertIn("improved", output)
 
 
+# ---------------------------------------------------------------------------
+# Adaptive convergence display tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveDisplay(unittest.TestCase):
+    def test_adaptive_shown_in_config(self) -> None:
+        """Adaptive settings should appear in format_bench_show output."""
+        meta = _make_meta(["baseline"])
+        meta.config["adaptive"] = True
+        meta.config["adaptive_threshold"] = 0.005
+        meta.config["adaptive_min_iterations"] = 5
+        output = format_bench_show(meta, [])
+        self.assertIn("Adaptive: on", output)
+        self.assertIn("0.5% RSE", output)
+        self.assertIn("min 5", output)
+
+    def test_adaptive_not_shown_when_disabled(self) -> None:
+        """Adaptive should not appear when disabled."""
+        meta = _make_meta(["baseline"])
+        meta.config["adaptive"] = False
+        output = format_bench_show(meta, [])
+        self.assertNotIn("Adaptive:", output)
+
+    def test_converged_marker_in_table(self) -> None:
+        """Converged packages should show checkmark in single-condition table."""
+        meta = _make_meta(["baseline"])
+        cr = _make_condition_result("baseline")
+        cr.converged_early = True
+        results = [_make_package_result("mypkg", conditions={"baseline": cr})]
+        output = format_bench_show(meta, results)
+        self.assertIn("\u2713", output)
+
+    def test_no_converged_marker_when_not_converged(self) -> None:
+        """Non-converged packages should not show checkmark."""
+        meta = _make_meta(["baseline"])
+        results = [_make_package_result("mypkg")]
+        output = format_bench_show(meta, results)
+        self.assertNotIn("\u2713", output)
+
+    def test_converged_count_in_quality(self) -> None:
+        """Quality summary should show converged count."""
+        cr = _make_condition_result("A")
+        cr.converged_early = True
+        results = [
+            _make_package_result("pkg1", conditions={"A": cr}),
+            _make_package_result("pkg2", conditions={"A": _make_condition_result("A")}),
+        ]
+        output = _format_quality_summary(results, ["A"])
+        self.assertIn("Converged early:   1 / 2", output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bench_results.py
+++ b/tests/test_bench_results.py
@@ -198,6 +198,35 @@ class TestBenchConditionResult(unittest.TestCase):
         self.assertIsNone(cond.wall_time_stats)
         self.assertIsNone(cond.user_time_stats)
 
+    def test_condition_converged_early_default(self) -> None:
+        """converged_early defaults to False."""
+        cond = BenchConditionResult(condition_name="test")
+        self.assertFalse(cond.converged_early)
+
+    def test_condition_converged_early_to_dict(self) -> None:
+        """converged_early=True should appear in to_dict."""
+        cond = BenchConditionResult(condition_name="test")
+        cond.converged_early = True
+        d = cond.to_dict()
+        self.assertTrue(d["converged_early"])
+
+    def test_condition_converged_early_omitted_when_false(self) -> None:
+        """converged_early=False should not appear in to_dict."""
+        cond = BenchConditionResult(condition_name="test")
+        d = cond.to_dict()
+        self.assertNotIn("converged_early", d)
+
+    def test_condition_converged_early_roundtrip(self) -> None:
+        """converged_early should survive serialization roundtrip."""
+        cond = BenchConditionResult(condition_name="test")
+        cond.converged_early = True
+        for i in range(1, 4):
+            cond.iterations.append(self._make_iteration(i, float(i)))
+        cond.compute_stats()
+        d = cond.to_dict()
+        restored = BenchConditionResult.from_dict(d)
+        self.assertTrue(restored.converged_early)
+
     def test_condition_only_warmup_iterations(self) -> None:
         """compute_stats with only warmup iterations leaves stats as None."""
         cond = BenchConditionResult(condition_name="warmup_only")

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -1053,6 +1053,243 @@ class TestQuickConfig(unittest.TestCase):
         result = quick_config(config)
         self.assertEqual(result.name, "My bench (quick)")
 
+    def test_quick_enables_adaptive(self) -> None:
+        config = BenchConfig()
+        result = quick_config(config)
+        self.assertTrue(result.adaptive)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive convergence tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveConvergence(unittest.TestCase):
+    """Tests for adaptive early stopping in _benchmark_package."""
+
+    def _make_tracking_runner_with_times(
+        self,
+        conditions: dict[str, ConditionDef],
+        wall_times: list[float],
+        *,
+        warmup: int = 0,
+        iterations: int = 10,
+        alternate: bool | None = None,
+        adaptive: bool = True,
+        adaptive_threshold: float = 0.005,
+        adaptive_min_iterations: int = 3,
+    ) -> tuple[BenchRunner, list[tuple[str, str, int, bool]]]:
+        """Create a runner that returns predetermined wall times."""
+        config = _make_config(
+            conditions=conditions,
+            warmup=warmup,
+            iterations=iterations,
+            alternate=alternate,
+            default_target_python="/usr/bin/python3",
+            adaptive=adaptive,
+            adaptive_threshold=adaptive_threshold,
+            adaptive_min_iterations=adaptive_min_iterations,
+        )
+        runner = BenchRunner(config, progress_callback=lambda p: None)
+
+        call_log: list[tuple[str, str, int, bool]] = []
+        time_iter = iter(wall_times)
+
+        def tracking_run_iteration(
+            *,
+            pkg: object,
+            cond: object,
+            setup: object,
+            iter_index: int,
+            is_warmup: bool,
+        ) -> BenchIteration:
+            wt = next(time_iter, 1.0)
+            call_log.append(
+                (
+                    pkg.package,  # type: ignore[union-attr]
+                    cond.name,  # type: ignore[union-attr]
+                    iter_index,
+                    is_warmup,
+                )
+            )
+            return BenchIteration(
+                index=iter_index,
+                warmup=is_warmup,
+                wall_time_s=wt,
+                user_time_s=wt * 0.8,
+                sys_time_s=wt * 0.1,
+                peak_rss_mb=100.0,
+                exit_code=0,
+                status="ok",
+            )
+
+        runner._run_iteration = tracking_run_iteration  # type: ignore[assignment]
+        return runner, call_log
+
+    def test_adaptive_block_convergence(self) -> None:
+        """Block mode: stops early when RSE is below threshold."""
+        conds = {"A": _make_condition("A")}
+        # All identical times → RSE=0 → converges at min_iterations=3
+        wall_times = [10.0] * 20
+        runner, call_log = self._make_tracking_runner_with_times(
+            conds,
+            wall_times,
+            iterations=10,
+            alternate=False,
+            adaptive_min_iterations=3,
+        )
+        pkg = FakePackage(package="mypkg")
+        setup: dict[str, object] = {
+            "repo_dir": Path("/tmp/fake/repo"),
+            "venvs": {"A": Path("/tmp/fake/venv_A")},
+            "clone_duration": 0.5,
+        }
+        with patch.object(runner, "_setup_package", return_value=setup):
+            result = runner._benchmark_package(pkg, 0, 1)
+
+        # Should converge early: 3 measured iterations (not all 10).
+        measured = [c for c in call_log if not c[3]]
+        self.assertEqual(len(measured), 3)
+        self.assertTrue(result.conditions["A"].converged_early)
+
+    def test_adaptive_alternating_convergence(self) -> None:
+        """Alternating mode: stops early when all conditions converge."""
+        conds = {
+            "A": _make_condition("A"),
+            "B": _make_condition("B"),
+        }
+        # Identical times → immediate convergence at min_iterations
+        wall_times = [10.0] * 40
+        runner, call_log = self._make_tracking_runner_with_times(
+            conds,
+            wall_times,
+            iterations=10,
+            alternate=True,
+            adaptive_min_iterations=3,
+        )
+        pkg = FakePackage(package="mypkg")
+        setup: dict[str, object] = {
+            "repo_dir": Path("/tmp/fake/repo"),
+            "venvs": {"A": Path("/tmp/A"), "B": Path("/tmp/B")},
+            "clone_duration": 0.5,
+        }
+        with patch.object(runner, "_setup_package", return_value=setup):
+            result = runner._benchmark_package(pkg, 0, 1)
+
+        # Should converge after 3 rounds (6 total calls: A,B,A,B,A,B).
+        self.assertEqual(len(call_log), 6)
+        self.assertTrue(result.conditions["A"].converged_early)
+        self.assertTrue(result.conditions["B"].converged_early)
+
+    def test_adaptive_no_convergence_high_variance(self) -> None:
+        """High variance: runs all iterations without converging."""
+        conds = {"A": _make_condition("A")}
+        # Highly variable times → won't converge with tight threshold
+        wall_times = [1.0, 100.0, 1.0, 100.0, 1.0, 100.0, 1.0, 100.0]
+        runner, call_log = self._make_tracking_runner_with_times(
+            conds,
+            wall_times,
+            iterations=5,
+            alternate=False,
+            adaptive_min_iterations=3,
+            adaptive_threshold=0.001,
+        )
+        pkg = FakePackage(package="mypkg")
+        setup: dict[str, object] = {
+            "repo_dir": Path("/tmp/fake/repo"),
+            "venvs": {"A": Path("/tmp/fake/venv_A")},
+            "clone_duration": 0.5,
+        }
+        with patch.object(runner, "_setup_package", return_value=setup):
+            result = runner._benchmark_package(pkg, 0, 1)
+
+        # All 5 measured iterations should run.
+        measured = [c for c in call_log if not c[3]]
+        self.assertEqual(len(measured), 5)
+        self.assertFalse(result.conditions["A"].converged_early)
+
+    def test_adaptive_disabled_runs_all(self) -> None:
+        """With adaptive=False, all iterations run even with identical times."""
+        conds = {"A": _make_condition("A")}
+        wall_times = [10.0] * 20
+        runner, call_log = self._make_tracking_runner_with_times(
+            conds,
+            wall_times,
+            iterations=5,
+            alternate=False,
+            adaptive=False,
+        )
+        pkg = FakePackage(package="mypkg")
+        setup: dict[str, object] = {
+            "repo_dir": Path("/tmp/fake/repo"),
+            "venvs": {"A": Path("/tmp/fake/venv_A")},
+            "clone_duration": 0.5,
+        }
+        with patch.object(runner, "_setup_package", return_value=setup):
+            result = runner._benchmark_package(pkg, 0, 1)
+
+        measured = [c for c in call_log if not c[3]]
+        self.assertEqual(len(measured), 5)
+        self.assertFalse(result.conditions["A"].converged_early)
+
+    def test_adaptive_respects_warmup(self) -> None:
+        """Warmup iterations are not counted for convergence."""
+        conds = {"A": _make_condition("A")}
+        wall_times = [10.0] * 20
+        runner, call_log = self._make_tracking_runner_with_times(
+            conds,
+            wall_times,
+            warmup=2,
+            iterations=10,
+            alternate=False,
+            adaptive_min_iterations=3,
+        )
+        pkg = FakePackage(package="mypkg")
+        setup: dict[str, object] = {
+            "repo_dir": Path("/tmp/fake/repo"),
+            "venvs": {"A": Path("/tmp/fake/venv_A")},
+            "clone_duration": 0.5,
+        }
+        with patch.object(runner, "_setup_package", return_value=setup):
+            result = runner._benchmark_package(pkg, 0, 1)
+
+        warmup_calls = [c for c in call_log if c[3]]
+        measured_calls = [c for c in call_log if not c[3]]
+        # 2 warmup + 3 measured (converges at min).
+        self.assertEqual(len(warmup_calls), 2)
+        self.assertEqual(len(measured_calls), 3)
+        self.assertTrue(result.conditions["A"].converged_early)
+
+    def test_adaptive_meta_config_recorded(self) -> None:
+        """Adaptive settings should appear in meta config dict."""
+        config = _make_config(
+            conditions={"baseline": _make_condition()},
+            adaptive=True,
+            adaptive_threshold=0.01,
+            adaptive_min_iterations=7,
+        )
+        runner = BenchRunner(config, progress_callback=lambda p: None)
+
+        with (
+            patch("labeille.bench.runner.validate_config", return_value=[]),
+            patch("labeille.bench.runner.capture_system_profile", return_value=SystemProfile()),
+            patch("labeille.bench.runner.capture_python_profile", return_value=PythonProfile()),
+            patch("labeille.bench.runner.format_system_profile", return_value=""),
+            patch("labeille.bench.runner.format_python_profile", return_value=""),
+            patch(
+                "labeille.bench.runner.resolve_target_python",
+                return_value=Path("/usr/bin/python3"),
+            ),
+            patch("labeille.bench.runner.resolve_env", return_value={}),
+            patch.object(runner, "_load_packages", return_value=[]),
+            patch("labeille.bench.runner.save_bench_run"),
+        ):
+            meta, _ = runner.run()
+
+        self.assertTrue(meta.config["adaptive"])
+        self.assertAlmostEqual(meta.config["adaptive_threshold"], 0.01)
+        self.assertEqual(meta.config["adaptive_min_iterations"], 7)
+
 
 # ---------------------------------------------------------------------------
 # Full integration test (heavily mocked)

--- a/tests/test_bench_stats.py
+++ b/tests/test_bench_stats.py
@@ -24,6 +24,7 @@ from labeille.bench.stats import (
     compute_overhead,
     describe,
     detect_outliers,
+    relative_standard_error,
     welch_ttest,
 )
 
@@ -601,6 +602,56 @@ class TestIntegration(unittest.TestCase):
         # b > a, so t < 0 (sample_a - sample_b) and d > 0 (sample_b - sample_a)
         self.assertLess(ttest.t_statistic, 0)
         self.assertGreater(effect.d, 0)
+
+
+# ---------------------------------------------------------------------------
+# Relative Standard Error
+# ---------------------------------------------------------------------------
+
+
+class TestRelativeStandardError(unittest.TestCase):
+    """Tests for relative_standard_error()."""
+
+    def test_rse_known_value(self) -> None:
+        """RSE for a known sample."""
+        # values = [10, 10, 10, 10, 10]: stdev=0, rse=0
+        values = [10.0, 10.0, 10.0, 10.0, 10.0]
+        self.assertAlmostEqual(relative_standard_error(values), 0.0, places=10)
+
+    def test_rse_nonzero(self) -> None:
+        """RSE for a sample with variation."""
+        # mean=10.0, stdev≈1.58, n=5, SE=stdev/sqrt(5)≈0.707, RSE≈0.0707
+        values = [8.0, 9.0, 10.0, 11.0, 12.0]
+        rse = relative_standard_error(values)
+        self.assertGreater(rse, 0)
+        self.assertAlmostEqual(rse, 0.0707, places=3)
+
+    def test_rse_single_value(self) -> None:
+        """Single value: RSE is NaN (need n >= 2)."""
+        self.assertTrue(math.isnan(relative_standard_error([42.0])))
+
+    def test_rse_empty(self) -> None:
+        """Empty input: RSE is NaN."""
+        self.assertTrue(math.isnan(relative_standard_error([])))
+
+    def test_rse_zero_mean(self) -> None:
+        """Zero mean: RSE is NaN."""
+        self.assertTrue(math.isnan(relative_standard_error([-1.0, 1.0])))
+
+    def test_rse_decreases_with_more_samples(self) -> None:
+        """RSE should decrease as n increases (more precision)."""
+        values_5 = [10.0, 10.5, 9.5, 10.2, 9.8]
+        values_10 = values_5 + [10.1, 9.9, 10.3, 9.7, 10.0]
+        rse_5 = relative_standard_error(values_5)
+        rse_10 = relative_standard_error(values_10)
+        self.assertGreater(rse_5, rse_10)
+
+    def test_rse_uses_absolute_mean(self) -> None:
+        """RSE should use absolute mean for negative-mean samples."""
+        values = [-10.0, -10.5, -9.5, -10.2, -9.8]
+        rse = relative_standard_error(values)
+        self.assertGreater(rse, 0)
+        self.assertLess(rse, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add early stopping based on Relative Standard Error (RSE) for `bench run` — stops iterating when wall-clock RSE drops below a configurable threshold (default 0.5%) after a minimum number of measured iterations (default 5)
- Works with all three execution strategies (block, alternating, interleaved) and is enabled by default in quick mode
- Display shows convergence status with checkmarks in tables and converged counts in quality summaries

## Test plan
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy strict passes (46 source files)
- [x] All 1915 tests pass (0 failures, 6 skipped)

Closes #116

Generated with [Claude Code](https://claude.com/claude-code)