### PR TITLE
Remove dead code, fix suppressions, and clean up quick wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Added Installation section to README with pipx, pip, and from-source instructions.
 - Added `Environment :: Console` and `Topic :: Software Development :: Quality Assurance` classifiers.
 - Renamed `Issues` URL key to `Bug Tracker` in project metadata for PyPI display consistency.
+- Replaced `raise SystemExit(130)  # noqa: B904` with `raise SystemExit(130) from None` in `bench_cli.py`, removing the suppression.
+- Narrowed `except Exception` in `bench/system.py` JIT detection to `except (AttributeError, TypeError)`.
+- Added explanatory comment for `except BaseException` in `io_utils.py` atomic write.
+
+### Removed
+- Dead code: `_log2()` from `bisect.py`, `RegistryStats`/`analyze_registry()` from `analyze.py` (superseded by `RegistryReport`/`generate_registry_report()`), `load_ft_summary()` from `ft/results.py`, `format_progress()`/`format_gil_comparison()` from `ft/display.py`, unused `_MOD_GIL_MENTION_PATTERN` regex from `ft/compat.py`.
+- Removed 12 unused `log = get_logger(...)` variables and their imports from modules that had logger scaffolding but no log calls.
 
 ### Fixed
 - `bench/timing.py` now sanitizes subprocess environment via `clean_env()`, preventing PYTHONHOME/PYTHONPATH pollution in benchmark runs.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -247,20 +247,6 @@ class ResultsStore:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class RegistryStats:
-    """Aggregate statistics about the registry."""
-
-    total: int = 0
-    active: int = 0
-    skipped: int = 0
-    by_extension_type: dict[str, tuple[int, int]] = field(default_factory=dict)
-    by_skip_category: dict[str, int] = field(default_factory=dict)
-    by_test_framework: dict[str, int] = field(default_factory=dict)
-    notable: dict[str, int] = field(default_factory=dict)
-    quality_warnings: list[tuple[str, str]] = field(default_factory=list)
-
-
 def categorize_skip_reason(reason: str) -> str:
     """Categorize a skip reason into a human-readable bucket."""
     lower = reason.lower()
@@ -296,77 +282,6 @@ def detect_quality_warnings(pkg: PackageEntry) -> list[str]:
     if pkg.skip and pkg.skip_versions:
         warnings.append("skip is true but skip_versions has entries (redundant)")
     return warnings
-
-
-def analyze_registry(
-    packages: list[PackageEntry],
-    *,
-    target_python_version: str | None = None,
-) -> RegistryStats:
-    """Analyze registry composition.
-
-    If *target_python_version* is given, ``skip_versions`` entries for that
-    version are counted as skipped.
-    """
-    stats = RegistryStats(total=len(packages))
-
-    for pkg in packages:
-        is_skipped = pkg.skip
-        if (
-            not is_skipped
-            and target_python_version
-            and pkg.skip_versions
-            and target_python_version in pkg.skip_versions
-        ):
-            is_skipped = True
-
-        if is_skipped:
-            stats.skipped += 1
-        else:
-            stats.active += 1
-
-        # Extension type breakdown.
-        ext = pkg.extension_type or "unknown"
-        active_count, skipped_count = stats.by_extension_type.get(ext, (0, 0))
-        if is_skipped:
-            stats.by_extension_type[ext] = (active_count, skipped_count + 1)
-        else:
-            stats.by_extension_type[ext] = (active_count + 1, skipped_count)
-
-        # Skip reason categorization.
-        if is_skipped:
-            reason = pkg.skip_reason or ""
-            if target_python_version and pkg.skip_versions:
-                ver_reason = pkg.skip_versions.get(target_python_version)
-                if ver_reason:
-                    reason = ver_reason
-            if reason:
-                cat = categorize_skip_reason(reason)
-            else:
-                cat = "Other"
-            stats.by_skip_category[cat] = stats.by_skip_category.get(cat, 0) + 1
-
-        # Test framework (active only).
-        if not is_skipped:
-            fw = pkg.test_framework or "unknown"
-            stats.by_test_framework[fw] = stats.by_test_framework.get(fw, 0) + 1
-
-        # Notable attributes (active only).
-        if not is_skipped:
-            if pkg.timeout is not None:
-                stats.notable["Custom timeout"] = stats.notable.get("Custom timeout", 0) + 1
-            if pkg.clone_depth is not None:
-                stats.notable["clone_depth set"] = stats.notable.get("clone_depth set", 0) + 1
-            if pkg.uses_xdist:
-                stats.notable["uses_xdist"] = stats.notable.get("uses_xdist", 0) + 1
-            if pkg.import_name is not None:
-                stats.notable["import_name set"] = stats.notable.get("import_name set", 0) + 1
-
-        # Quality warnings.
-        for warning in detect_quality_warnings(pkg):
-            stats.quality_warnings.append((pkg.package, warning))
-
-    return stats
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/bench/anomaly.py
+++ b/src/labeille/bench/anomaly.py
@@ -19,9 +19,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from labeille.bench.results import BenchConditionResult, BenchPackageResult
-from labeille.logging import get_logger
-
-log = get_logger("bench.anomaly")
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/bench/compare.py
+++ b/src/labeille/bench/compare.py
@@ -19,10 +19,6 @@ from labeille.bench.stats import (
 )
 from typing import Any
 
-from labeille.logging import get_logger
-
-log = get_logger("bench.compare")
-
 
 # ---------------------------------------------------------------------------
 # Per-package comparison result

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -17,9 +17,6 @@ from typing import Any
 
 from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.results import ConditionDef
-from labeille.logging import get_logger
-
-log = get_logger("bench.config")
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -718,7 +718,7 @@ result["build_flags"] = [
 try:
     result["jit_available"] = hasattr(sys.flags, "jit")
     result["jit_enabled"] = bool(getattr(sys.flags, "jit", False))
-except Exception:
+except (AttributeError, TypeError):
     result["jit_available"] = False
     result["jit_enabled"] = False
 

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -17,9 +17,6 @@ from pathlib import Path
 import click
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
-from labeille.logging import get_logger
-
-log = get_logger("bench_cli")
 
 
 @click.group()
@@ -408,7 +405,7 @@ def run(  # noqa: PLR0913
         raise click.ClickException(str(exc)) from exc
     except KeyboardInterrupt:
         click.echo("\nBenchmark interrupted.", err=True)
-        raise SystemExit(130)  # noqa: B904
+        raise SystemExit(130) from None
 
     # Display results.
     from labeille.bench.display import format_bench_show

--- a/src/labeille/bisect.py
+++ b/src/labeille/bisect.py
@@ -532,14 +532,3 @@ def _try_neighbors(
                 if neighbor_step.status == "good":
                     return (candidate, hi)
     return None
-
-
-def _log2(n: int) -> int:
-    """Rough log base 2 for estimating bisect steps."""
-    if n <= 0:
-        return 0
-    count = 0
-    while n > 1:
-        n >>= 1
-        count += 1
-    return count

--- a/src/labeille/classifier.py
+++ b/src/labeille/classifier.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from labeille.logging import get_logger
-
-log = get_logger("classifier")
 
 # Patterns that indicate a platform-specific (native extension) wheel.
 _PLATFORM_INDICATORS = re.compile(

--- a/src/labeille/crash.py
+++ b/src/labeille/crash.py
@@ -11,9 +11,6 @@ import re
 import signal as _signal
 from dataclasses import dataclass
 
-from labeille.logging import get_logger
-
-log = get_logger("crash")
 
 # Exit codes that map to well-known signals on systems that don't use negative
 # return codes.

--- a/src/labeille/ft/analysis.py
+++ b/src/labeille/ft/analysis.py
@@ -20,10 +20,6 @@ from labeille.ft.results import (
     FTRunSummary,
     IterationOutcome,
 )
-from labeille.logging import get_logger
-
-log = get_logger("ft.analysis")
-
 
 # ---------------------------------------------------------------------------
 # Flakiness profiling

--- a/src/labeille/ft/compare.py
+++ b/src/labeille/ft/compare.py
@@ -15,10 +15,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from labeille.logging import get_logger
-
-log = get_logger("ft.compare")
-
 
 @dataclass
 class PackageTransition:

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -416,8 +416,6 @@ _MOD_GIL_PATTERN = re.compile(
     re.VERBOSE,
 )
 
-_MOD_GIL_MENTION_PATTERN = re.compile(r"Py_MOD_GIL_NOT_USED|Py_MOD_GIL_USED|Py_mod_gil")
-
 
 def scan_source_for_mod_gil(
     repo_dir: Path,

--- a/src/labeille/ft/display.py
+++ b/src/labeille/ft/display.py
@@ -10,9 +10,6 @@ from __future__ import annotations
 from typing import Any
 
 from labeille.ft.results import FailureCategory
-from labeille.logging import get_logger
-
-log = get_logger("ft.display")
 
 
 def format_compatibility_summary(
@@ -270,59 +267,6 @@ def format_flakiness_profile(profile: Any) -> str:
     return "\n".join(lines)
 
 
-def format_gil_comparison(
-    comparisons: list[Any],
-) -> str:
-    """Format GIL-enabled vs GIL-disabled comparison table.
-
-    Output::
-
-        GIL Comparison (free-threaded vs GIL-enabled)
-        ──────────────────────────────────────────────
-        Package          GIL=0 Rate  GIL=1 Rate  Classification
-        ─────────────────────────────────────────────────────────
-        requests            100%        100%      ft_compatible
-        numpy                70%        100%      ft_intermittent  ← FT-specific
-        sqlalchemy           60%         80%      ft_exacerbated
-        celery               50%         50%      pre_existing
-        ...
-
-        Summary:
-          FT-specific failures: 12 packages
-          Pre-existing failures: 5 packages
-    """
-    lines = [
-        "GIL Comparison (free-threaded vs GIL-enabled)",
-        "──────────────────────────────────────────────",
-        f"{'Package':<20s} {'GIL=0 Rate':>11s} {'GIL=1 Rate':>11s}  {'Classification':<20s}",
-        "─" * 75,
-    ]
-
-    ft_specific = 0
-    pre_existing = 0
-
-    for c in comparisons:
-        ft_rate = f"{c.gil_disabled_pass_rate * 100:.0f}%"
-        gil_rate = f"{c.gil_enabled_pass_rate * 100:.0f}%"
-        marker = ""
-        if c.free_threading_specific:
-            marker = " ← FT-specific"
-            ft_specific += 1
-        if c.classification == "pre_existing":
-            pre_existing += 1
-
-        lines.append(
-            f"{c.package:<20s} {ft_rate:>11s} {gil_rate:>11s}  {c.classification:<20s}{marker}"
-        )
-
-    lines.append("")
-    lines.append("Summary:")
-    lines.append(f"  FT-specific failures: {ft_specific} packages")
-    lines.append(f"  Pre-existing failures: {pre_existing} packages")
-
-    return "\n".join(lines)
-
-
 def format_ft_comparison(
     comp: Any,
     *,
@@ -394,23 +338,3 @@ def format_ft_comparison(
     lines.append(f"  Crashes:    {comp.crash_count_a} → {comp.crash_count_b} ({crash_str})")
 
     return "\n".join(lines)
-
-
-def format_progress(
-    package: str,
-    iteration: int,
-    total_iterations: int,
-    status: str,
-    duration: float,
-    packages_done: int,
-    packages_total: int,
-) -> str:
-    """Format a single-line progress update.
-
-    Output: ``(15/350) requests iter 3/10: pass (12.3s)``
-    """
-    return (
-        f"({packages_done}/{packages_total}) {package} "
-        f"iter {iteration}/{total_iterations}: "
-        f"{status} ({duration:.1f}s)"
-    )

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -11,10 +11,6 @@ import io
 import json
 from typing import Any
 
-from labeille.logging import get_logger
-
-log = get_logger("ft.export")
-
 
 def export_csv(
     results: list[Any],

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -583,12 +583,3 @@ def load_ft_run(
     meta = FTRunMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
     results = load_jsonl(results_path, FTPackageResult.from_dict)
     return meta, results
-
-
-def load_ft_summary(results_dir: Path) -> FTRunSummary:
-    """Load the summary file, or recompute from results."""
-    summary_path = results_dir / "ft_summary.json"
-    if summary_path.exists():
-        return FTRunSummary.from_dict(json.loads(summary_path.read_text(encoding="utf-8")))
-    _, results = load_ft_run(results_dir)
-    return FTRunSummary.compute(results)

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -6,10 +6,6 @@ from pathlib import Path
 
 import click
 
-from labeille.logging import get_logger
-
-log = get_logger("ft_cli")
-
 
 @click.group()
 def ft() -> None:

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -27,7 +27,7 @@ def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> N
         with os.fdopen(fd, "w", encoding=encoding) as f:
             f.write(content)
         os.replace(tmp_path, path)
-    except BaseException:
+    except BaseException:  # Cleanup temp file on any failure, including KeyboardInterrupt.
         try:
             os.unlink(tmp_path)
         except OSError:

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -12,7 +12,6 @@ from typing import Any, get_type_hints
 
 import yaml
 
-from labeille.logging import get_logger
 from labeille.registry import (
     IndexEntry,
     PackageEntry,
@@ -31,8 +30,6 @@ from labeille.yaml_lines import (
     rename_field as rename_field_lines,
     set_field_value,
 )
-
-log = get_logger("registry_ops")
 
 # Fields that cannot be removed from package YAML files.
 PROTECTED_FIELDS = frozenset({"package", "repo", "pypi_url", "enriched"})

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -18,7 +18,6 @@ from labeille.analyze import (
     _classify_repo_host,
     analyze_history,
     analyze_package,
-    analyze_registry,
     analyze_run,
     build_reproduce_command,
     categorize_install_errors,
@@ -288,47 +287,6 @@ class TestResultsStore(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Registry analysis tests
 # ---------------------------------------------------------------------------
-
-
-class TestAnalyzeRegistry(unittest.TestCase):
-    def test_counts(self) -> None:
-        packages = [
-            _make_pkg("a", skip=False),
-            _make_pkg("b", skip=True, skip_reason="PyO3"),
-            _make_pkg("c", skip=False),
-        ]
-        stats = analyze_registry(packages)
-        self.assertEqual(stats.total, 3)
-        self.assertEqual(stats.active, 2)
-        self.assertEqual(stats.skipped, 1)
-
-    def test_extension_types(self) -> None:
-        packages = [
-            _make_pkg("a", extension_type="pure"),
-            _make_pkg("b", extension_type="extensions", skip=True, skip_reason="reason"),
-            _make_pkg("c", extension_type="pure"),
-        ]
-        stats = analyze_registry(packages)
-        self.assertEqual(stats.by_extension_type["pure"], (2, 0))
-        self.assertEqual(stats.by_extension_type["extensions"], (0, 1))
-
-    def test_with_skip_versions(self) -> None:
-        packages = [
-            _make_pkg("a", skip_versions={"3.15": "PyO3 not supported"}),
-            _make_pkg("b"),
-        ]
-        stats = analyze_registry(packages, target_python_version="3.15")
-        self.assertEqual(stats.active, 1)
-        self.assertEqual(stats.skipped, 1)
-
-    def test_without_target_version(self) -> None:
-        packages = [
-            _make_pkg("a", skip_versions={"3.15": "PyO3 not supported"}),
-        ]
-        stats = analyze_registry(packages)
-        # Without target_python_version, skip_versions doesn't count as skipped.
-        self.assertEqual(stats.active, 1)
-        self.assertEqual(stats.skipped, 0)
 
 
 class TestCategorizeSkipReason(unittest.TestCase):

--- a/tests/test_bisect.py
+++ b/tests/test_bisect.py
@@ -7,42 +7,18 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
+
 from labeille.bisect import (
     BisectConfig,
     BisectResult,
     BisectStep,
-    _log2,
     _try_neighbors,
     get_commit_range,
     run_bisect,
     test_revision,
 )
 from labeille.runner import InstallerBackend
-
-
-class TestLog2(unittest.TestCase):
-    """Tests for the _log2 helper."""
-
-    def test_zero(self) -> None:
-        self.assertEqual(_log2(0), 0)
-
-    def test_negative(self) -> None:
-        self.assertEqual(_log2(-5), 0)
-
-    def test_one(self) -> None:
-        self.assertEqual(_log2(1), 0)
-
-    def test_two(self) -> None:
-        self.assertEqual(_log2(2), 1)
-
-    def test_eight(self) -> None:
-        self.assertEqual(_log2(8), 3)
-
-    def test_non_power_of_two(self) -> None:
-        self.assertEqual(_log2(10), 3)
-
-    def test_large(self) -> None:
-        self.assertEqual(_log2(1024), 10)
 
 
 class TestBisectResult(unittest.TestCase):
@@ -890,10 +866,6 @@ class TestBisectCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         call_args = mock_bisect.call_args[0][0]
         self.assertEqual(call_args.extra_deps, ["pytest", "coverage"])
-
-
-# Need to import click for the CLI test class.
-import click  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/tests/test_ft_display.py
+++ b/tests/test_ft_display.py
@@ -9,9 +9,7 @@ from labeille.ft.display import (
     format_compatibility_summary,
     format_flakiness_profile,
     format_ft_comparison,
-    format_gil_comparison,
     format_package_table,
-    format_progress,
     format_triage_list,
 )
 from labeille.ft.results import FailureCategory, FTPackageResult
@@ -300,55 +298,6 @@ class TestFormatFlakinessProfile(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# format_gil_comparison tests
-# ---------------------------------------------------------------------------
-
-
-class TestFormatGilComparison(unittest.TestCase):
-    def _make_comparison(
-        self,
-        package: str = "pkg",
-        disabled_rate: float = 0.7,
-        enabled_rate: float = 1.0,
-        classification: str = "ft_intermittent",
-        ft_specific: bool = True,
-    ) -> MagicMock:
-        c = MagicMock()
-        c.package = package
-        c.gil_disabled_pass_rate = disabled_rate
-        c.gil_enabled_pass_rate = enabled_rate
-        c.classification = classification
-        c.free_threading_specific = ft_specific
-        return c
-
-    def test_gil_comparison_basic(self) -> None:
-        comparisons = [
-            self._make_comparison("requests", 1.0, 1.0, "ft_compatible", False),
-            self._make_comparison("numpy", 0.7, 1.0, "ft_intermittent", True),
-            self._make_comparison("celery", 0.5, 0.5, "pre_existing", False),
-        ]
-        output = format_gil_comparison(comparisons)
-        self.assertIn("requests", output)
-        self.assertIn("numpy", output)
-        self.assertIn("celery", output)
-
-    def test_gil_comparison_ft_specific_marker(self) -> None:
-        comparisons = [self._make_comparison("numpy", 0.7, 1.0, "ft_intermittent", True)]
-        output = format_gil_comparison(comparisons)
-        self.assertIn("FT-specific", output)
-
-    def test_gil_comparison_summary_counts(self) -> None:
-        comparisons = [
-            self._make_comparison("a", 0.7, 1.0, "ft_intermittent", True),
-            self._make_comparison("b", 0.5, 1.0, "ft_incompatible", True),
-            self._make_comparison("c", 0.5, 0.5, "pre_existing", False),
-        ]
-        output = format_gil_comparison(comparisons)
-        self.assertIn("FT-specific failures: 2", output)
-        self.assertIn("Pre-existing failures: 1", output)
-
-
-# ---------------------------------------------------------------------------
 # format_ft_comparison tests
 # ---------------------------------------------------------------------------
 
@@ -415,25 +364,6 @@ class TestFormatFtComparison(unittest.TestCase):
         self.assertIn("Unchanged: 100 packages", output)
         self.assertNotIn("Improvements", output)
         self.assertNotIn("Regressions", output)
-
-
-# ---------------------------------------------------------------------------
-# format_progress tests
-# ---------------------------------------------------------------------------
-
-
-class TestFormatProgress(unittest.TestCase):
-    def test_progress_basic(self) -> None:
-        output = format_progress(
-            package="requests",
-            iteration=3,
-            total_iterations=10,
-            status="pass",
-            duration=12.3,
-            packages_done=15,
-            packages_total=350,
-        )
-        self.assertEqual(output, "(15/350) requests iter 3/10: pass (12.3s)")
 
 
 if __name__ == "__main__":

--- a/tests/test_ft_results.py
+++ b/tests/test_ft_results.py
@@ -18,7 +18,6 @@ from labeille.ft.results import (
     append_ft_result,
     categorize_package,
     load_ft_run,
-    load_ft_summary,
     save_ft_run,
 )
 
@@ -605,33 +604,6 @@ class TestIO(unittest.TestCase):
             (d / "ft_results.jsonl").write_text("")
             _, loaded = load_ft_run(d)
             self.assertEqual(loaded, [])
-
-    def test_load_ft_summary_from_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            d = Path(tmpdir)
-            results = [make_package_result("a", ["pass"] * 5)]
-            meta = FTRunMeta(run_id="test", timestamp="t")
-            save_ft_run(d, meta, results)
-
-            summary = load_ft_summary(d)
-            self.assertEqual(summary.total_packages, 1)
-            self.assertEqual(summary.categories.get("compatible"), 1)
-
-    def test_load_ft_summary_recomputes_if_missing(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            d = Path(tmpdir)
-            results = [
-                make_package_result("a", ["pass"] * 5),
-                make_package_result("b", ["crash", "pass"]),
-            ]
-            meta = FTRunMeta(run_id="test", timestamp="t")
-            save_ft_run(d, meta, results)
-
-            # Delete summary file.
-            (d / "ft_summary.json").unlink()
-
-            summary = load_ft_summary(d)
-            self.assertEqual(summary.total_packages, 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove 6 unused functions/classes, 1 unused regex, and 12 unused logger scaffolding variables (394 lines deleted)
- Fix `raise SystemExit(130)` to use `from None` instead of `noqa: B904` suppression
- Narrow `except Exception` in `bench/system.py` to `except (AttributeError, TypeError)`
- Move late `import click` in `test_bisect.py` to top-level imports

## Test plan
- [x] All 1981 tests pass (17 removed with dead code)
- [x] mypy strict clean (47 files)
- [x] ruff check and format clean

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)