### PR TITLE
Narrow exception catches, restructure CLI imports, fix type suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Replaced `raise SystemExit(130)  # noqa: B904` with `raise SystemExit(130) from None` in `bench_cli.py`, removing the suppression.
 - Narrowed `except Exception` in `bench/system.py` JIT detection to `except (AttributeError, TypeError)`.
 - Added explanatory comment for `except BaseException` in `io_utils.py` atomic write.
+- Narrowed 5 `except Exception` catches in `bench/runner.py` and 1 in `ft/runner.py` to specific exception tuples (`OSError`, `subprocess.SubprocessError`, `ValueError`, `KeyError`), removing all `noqa: BLE001` suppressions.
+- Restructured `cli.py` subgroup registration into `_register_subcommands()` function, eliminating 5 `noqa: E402` suppressions.
+- Fixed `type: ignore[operator]` in `ft/display.py` by adding explicit `None` guard, in `bench_cli.py` by restructuring conditionals, and `type: ignore[no-any-return]` in `resolve.py` by using intermediate variable.
 
 ### Removed
 - Dead code: `_log2()` from `bisect.py`, `RegistryStats`/`analyze_registry()` from `analyze.py` (superseded by `RegistryReport`/`generate_registry_report()`), `load_ft_summary()` from `ft/results.py`, `format_progress()`/`format_gil_comparison()` from `ft/display.py`, unused `_MOD_GIL_MENTION_PATTERN` regex from `ft/compat.py`.

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -19,6 +19,7 @@ Execution strategies:
 
 from __future__ import annotations
 
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -319,7 +320,7 @@ class BenchRunner:
             try:
                 entry = load_package(name, self.config.registry_dir)
                 packages.append(entry)
-            except Exception as exc:  # noqa: BLE001
+            except (OSError, ValueError, KeyError) as exc:
                 log.warning("Failed to load package '%s': %s", name, exc)
 
         # Apply top_n.
@@ -616,7 +617,7 @@ class BenchRunner:
                 pull_repo(repo_dir)
             else:
                 clone_repo(pkg.repo, repo_dir)
-        except Exception as exc:  # noqa: BLE001
+        except (OSError, subprocess.SubprocessError) as exc:
             log.error("Failed to clone %s: %s", pkg.package, exc)
             return None
         setup["clone_duration"] = time.monotonic() - clone_start
@@ -642,7 +643,7 @@ class BenchRunner:
 
                     shutil.rmtree(venv_dir)
                 create_venv(python_path, venv_dir, installer)
-            except Exception as exc:  # noqa: BLE001
+            except (OSError, subprocess.SubprocessError) as exc:
                 log.error(
                     "Failed to create venv for %s/%s: %s",
                     pkg.package,
@@ -682,7 +683,7 @@ class BenchRunner:
                         result.returncode,
                     )
                     return None
-            except Exception as exc:  # noqa: BLE001
+            except (OSError, subprocess.SubprocessError) as exc:
                 log.error("Install failed for %s/%s: %s", pkg.package, cond_name, exc)
                 return None
             setup[f"install_{cond_name}"] = time.monotonic() - install_start
@@ -700,7 +701,7 @@ class BenchRunner:
                         timeout=self.config.timeout,
                         installer=actual_backend,
                     )
-                except Exception as exc:  # noqa: BLE001
+                except (OSError, subprocess.SubprocessError) as exc:
                     log.warning(
                         "Extra deps install warning for %s/%s: %s",
                         pkg.package,

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -341,10 +341,14 @@ def run(  # noqa: PLR0913
             default_target_python=str(target_python) if target_python else "",
             registry_dir=registry_dir,
         )
-        if repos_dir or work_dir:
-            config.repos_dir = repos_dir or (work_dir / "repos")  # type: ignore[operator]
-        if venvs_dir or work_dir:
-            config.venvs_dir = venvs_dir or (work_dir / "venvs")  # type: ignore[operator]
+        if repos_dir:
+            config.repos_dir = repos_dir
+        elif work_dir:
+            config.repos_dir = work_dir / "repos"
+        if venvs_dir:
+            config.venvs_dir = venvs_dir
+        elif work_dir:
+            config.venvs_dir = work_dir / "venvs"
         config.results_dir = results_dir
         if packages:
             config.packages_filter = [p.strip() for p in packages.split(",") if p.strip()]

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -33,26 +33,22 @@ def main() -> None:
     """labeille — Hunt for CPython JIT bugs by running real-world test suites."""
 
 
-# Register subgroups.
-from labeille.registry_cli import registry as registry_group  # noqa: E402
+def _register_subcommands() -> None:
+    """Register subcommand groups on the main CLI group."""
+    from labeille.analyze_cli import analyze as analyze_group
+    from labeille.bench_cli import bench as bench_group
+    from labeille.compat_cli import compat as compat_group
+    from labeille.ft_cli import ft as ft_group
+    from labeille.registry_cli import registry as registry_group
 
-main.add_command(registry_group)
+    main.add_command(registry_group)
+    main.add_command(analyze_group)
+    main.add_command(bench_group)
+    main.add_command(ft_group)
+    main.add_command(compat_group)
 
-from labeille.analyze_cli import analyze as analyze_group  # noqa: E402
 
-main.add_command(analyze_group)
-
-from labeille.bench_cli import bench as bench_group  # noqa: E402
-
-main.add_command(bench_group)
-
-from labeille.ft_cli import ft as ft_group  # noqa: E402
-
-main.add_command(ft_group)
-
-from labeille.compat_cli import compat as compat_group  # noqa: E402
-
-main.add_command(compat_group)
+_register_subcommands()
 
 
 @main.command()

--- a/src/labeille/ft/display.py
+++ b/src/labeille/ft/display.py
@@ -176,8 +176,8 @@ def format_package_table(
             f"{detail_str}"
         )
 
-    if truncated:
-        lines.append(f"  ... ({total - max_rows} more)")  # type: ignore[operator]
+    if truncated and max_rows is not None:
+        lines.append(f"  ... ({total - max_rows} more)")
 
     return "\n".join(lines)
 

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -1007,7 +1007,7 @@ def _select_packages(index: Any, config: FTRunConfig) -> list[Any]:
         try:
             pkg = load_package(entry.package, config.registry_dir)
             packages.append(pkg)
-        except Exception as exc:  # noqa: BLE001
+        except (OSError, ValueError, KeyError) as exc:
             log.warning("Could not load package %s, skipping: %s", entry.package, exc)
 
     if config.packages_filter:

--- a/src/labeille/resolve.py
+++ b/src/labeille/resolve.py
@@ -311,7 +311,8 @@ def fetch_pypi_metadata(
         return None
 
     try:
-        return resp.json()  # type: ignore[no-any-return]
+        data: dict[str, Any] = resp.json()
+        return data
     except (ValueError, requests.JSONDecodeError):
         log.error("Invalid JSON response for %s", package_name)
         return None

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -244,7 +244,7 @@ class TestSetupPackage(unittest.TestCase):
             runner = self._make_runner(repos_dir=Path(tmpdir) / "repos")
             pkg = FakePackage(package="clonefail")
 
-            with patch("labeille.runner.clone_repo", side_effect=RuntimeError("clone failed")):
+            with patch("labeille.runner.clone_repo", side_effect=OSError("clone failed")):
                 result = runner._setup_package(pkg)
 
             self.assertIsNone(result)
@@ -300,7 +300,7 @@ class TestSetupPackage(unittest.TestCase):
             with (
                 patch("labeille.runner.clone_repo"),
                 patch("labeille.runner.create_venv"),
-                patch("labeille.runner.install_package", side_effect=RuntimeError("install boom")),
+                patch("labeille.runner.install_package", side_effect=OSError("install boom")),
             ):
                 result = runner._setup_package(pkg)
 
@@ -424,7 +424,7 @@ class TestSetupPackage(unittest.TestCase):
                 # Main install succeeds, extra deps install raises.
                 mock_install.side_effect = [
                     SimpleNamespace(returncode=0),
-                    RuntimeError("extra deps failed"),
+                    OSError("extra deps failed"),
                 ]
                 result = runner._setup_package(pkg)
 


### PR DESCRIPTION
## Summary
- Narrow 6 `except Exception` catches in `bench/runner.py` and `ft/runner.py` to `(OSError, subprocess.SubprocessError, ValueError, KeyError)`, removing all `noqa: BLE001` suppressions
- Restructure `cli.py` subgroup registration into `_register_subcommands()`, eliminating 5 `noqa: E402` suppressions
- Fix 3 `type: ignore` suppressions in source code (`ft/display.py`, `bench_cli.py`, `resolve.py`)

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (47 files)
- [x] ruff check and format clean

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)