### PR TITLE
refactor: split runner.py into runner_models.py and repo_ops.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Restructured `cli.py` subgroup registration into `_register_subcommands()` function, eliminating 5 `noqa: E402` suppressions.
 - Fixed `type: ignore[operator]` in `ft/display.py` by adding explicit `None` guard, in `bench_cli.py` by restructuring conditionals, and `type: ignore[no-any-return]` in `resolve.py` by using intermediate variable.
 - Extracted 7 helper functions from `run_package_ft` in `ft/runner.py` (360→~80 lines): `_check_ft_wheel_trust`, `_clone_and_align_ft`, `_create_venv_and_install_ft`, `_install_sdist_mode`, `_install_source_mode`, `_run_ft_iterations`, `_run_gil_comparison`.
+- Split `runner.py` (1972→1445 lines): extracted data models to `runner_models.py` and git/repo/sdist operations to `repo_ops.py`, with re-exports preserving all existing imports.
 
 ### Removed
 - Dead code: `_log2()` from `bisect.py`, `RegistryStats`/`analyze_registry()` from `analyze.py` (superseded by `RegistryReport`/`generate_registry_report()`), `load_ft_summary()` from `ft/results.py`, `format_progress()`/`format_gil_comparison()` from `ft/display.py`, unused `_MOD_GIL_MENTION_PATTERN` regex from `ft/compat.py`.

--- a/src/labeille/repo_ops.py
+++ b/src/labeille/repo_ops.py
@@ -1,0 +1,459 @@
+"""Git operations, package spec parsing, and sdist helpers for the test runner.
+
+Extracted from :mod:`labeille.runner` for clarity.  All names are
+re-exported by :mod:`labeille.runner` so existing imports are unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from labeille.logging import get_logger
+from labeille.resolve import fetch_pypi_metadata
+
+log = get_logger("repo_ops")
+
+
+# ---------------------------------------------------------------------------
+# Git operations
+# ---------------------------------------------------------------------------
+
+
+def clone_repo(repo_url: str, dest: Path, clone_depth: int | None = None) -> str | None:
+    """Clone a git repository and return the HEAD revision.
+
+    Args:
+        repo_url: The URL of the git repository.
+        dest: The destination directory for the clone.
+        clone_depth: Clone depth. ``None`` means shallow (depth=1).
+            A positive integer uses that depth.
+
+    Returns:
+        The HEAD commit hash, or ``None`` on failure.
+
+    Raises:
+        subprocess.CalledProcessError: If the clone fails.
+    """
+    depth = clone_depth if clone_depth is not None else 1
+    log.debug("Running: git clone --depth=%d %s %s", depth, repo_url, dest)
+    clone_proc = subprocess.run(
+        ["git", "clone", f"--depth={depth}", repo_url, str(dest)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    if clone_proc.stderr:
+        log.debug("git clone stderr: %s", clone_proc.stderr.strip())
+
+    # Fetch tags when using deeper clones (needed for setuptools-scm etc.).
+    if clone_depth is not None and clone_depth > 1:
+        log.debug("Fetching tags for %s (clone_depth=%d)", dest, clone_depth)
+        fetch_proc = subprocess.run(
+            ["git", "fetch", "--tags"],
+            capture_output=True,
+            text=True,
+            cwd=str(dest),
+            timeout=120,
+            check=False,
+        )
+        if fetch_proc.returncode != 0:
+            log.debug("git fetch --tags failed (non-fatal): %s", fetch_proc.stderr.strip())
+
+    # Get the revision.
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=str(dest),
+        timeout=10,
+    )
+    if proc.returncode == 0:
+        return proc.stdout.strip()
+    return None
+
+
+def pull_repo(dest: Path) -> str | None:
+    """Fetch latest changes and force-reset to upstream HEAD.
+
+    Uses ``fetch`` + ``reset --hard`` + ``clean -fdx`` instead of
+    ``pull --ff-only`` to handle dirty working trees left by test
+    suites without needing a full re-clone.
+
+    Args:
+        dest: The directory containing the existing clone.
+
+    Returns:
+        The HEAD commit hash, or ``None`` on failure.
+
+    Raises:
+        subprocess.CalledProcessError: If the fetch fails.
+    """
+    log.debug("Fetching and resetting repo in %s", dest)
+
+    # Fetch latest from origin.
+    subprocess.run(
+        ["git", "fetch", "origin"],
+        capture_output=True,
+        text=True,
+        cwd=str(dest),
+        timeout=120,
+        check=True,
+    )
+
+    # Reset to the fetched HEAD, discarding any local modifications.
+    # FETCH_HEAD works reliably with shallow clones where origin/HEAD
+    # or origin/main might not be set.
+    reset_proc = subprocess.run(
+        ["git", "reset", "--hard", "FETCH_HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=str(dest),
+        timeout=60,
+        check=False,
+    )
+    if reset_proc.returncode != 0:
+        log.debug(
+            "git reset --hard failed (non-fatal): %s",
+            reset_proc.stderr.strip(),
+        )
+
+    # Remove untracked files and directories left by test runs.
+    clean_proc = subprocess.run(
+        ["git", "clean", "-fdx"],
+        capture_output=True,
+        text=True,
+        cwd=str(dest),
+        timeout=60,
+        check=False,
+    )
+    if clean_proc.returncode != 0:
+        log.debug(
+            "git clean failed (non-fatal): %s",
+            clean_proc.stderr.strip(),
+        )
+
+    # Get the HEAD revision.
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=str(dest),
+        timeout=10,
+    )
+    if proc.returncode == 0:
+        return proc.stdout.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Package spec parsing and revision checkout
+# ---------------------------------------------------------------------------
+
+
+def parse_package_specs(
+    raw: str,
+) -> tuple[list[str], dict[str, str]]:
+    """Parse a comma-separated package spec string.
+
+    Each spec is either ``name`` or ``name@revision``.
+
+    Returns:
+        A tuple of (package_names, revision_overrides) where
+        revision_overrides maps package name to revision string.
+
+    Examples::
+
+        "requests,click" → (["requests", "click"], {})
+        "requests@abc123,click" → (["requests", "click"], {"requests": "abc123"})
+        "numpy@HEAD~5" → (["numpy"], {"numpy": "HEAD~5"})
+    """
+    names: list[str] = []
+    revisions: dict[str, str] = {}
+    for spec in raw.split(","):
+        spec = spec.strip()
+        if not spec:
+            continue
+        if "@" in spec:
+            name, rev = spec.split("@", 1)
+            name = name.strip()
+            rev = rev.strip()
+            if name and rev:
+                names.append(name)
+                revisions[name] = rev
+            elif name:
+                names.append(name)
+        else:
+            names.append(spec)
+    return names, revisions
+
+
+def parse_repo_overrides(raw: tuple[str, ...]) -> dict[str, str]:
+    """Parse ``--repo-override`` arguments into a dict.
+
+    Each argument is ``package_name=repo_url``.
+
+    Raises:
+        ValueError: If an argument is malformed (no ``=``, or empty name/URL).
+    """
+    overrides: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(
+                f"Invalid --repo-override format: {item!r}. "
+                f"Expected PKG=URL (e.g., 'requests=https://...')"
+            )
+        name, url = item.split("=", 1)
+        name = name.strip()
+        url = url.strip()
+        if not name or not url:
+            raise ValueError("Invalid --repo-override: both package name and URL required.")
+        overrides[name] = url
+    return overrides
+
+
+def checkout_revision(repo_dir: Path, revision: str) -> str | None:
+    """Checkout a specific git revision and return the resulting HEAD hash.
+
+    Args:
+        repo_dir: Path to the git repository.
+        revision: Any git ref — commit hash, branch, tag, ``HEAD~N``.
+
+    Returns:
+        The full commit hash after checkout, or ``None`` on failure.
+    """
+    proc = subprocess.run(
+        ["git", "checkout", revision],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_dir),
+        timeout=60,
+        check=False,
+    )
+    if proc.returncode != 0:
+        log.warning(
+            "git checkout %s failed in %s: %s. "
+            "If using a revision beyond the clone depth, try --no-shallow.",
+            revision,
+            repo_dir,
+            proc.stderr.strip(),
+        )
+        return None
+
+    # Get the resolved commit hash.
+    rev_proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_dir),
+        timeout=10,
+    )
+    if rev_proc.returncode == 0:
+        return rev_proc.stdout.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Sdist-mode helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_latest_pypi_version(
+    package_name: str,
+    *,
+    timeout: float = 10.0,
+) -> str | None:
+    """Fetch the latest release version of a package from PyPI.
+
+    Returns:
+        Version string (e.g. ``"2.1.0"``), or ``None`` on failure.
+    """
+    metadata = fetch_pypi_metadata(package_name, timeout=timeout)
+    if metadata is None:
+        return None
+    try:
+        return str(metadata["info"]["version"])
+    except (KeyError, TypeError):
+        return None
+
+
+_TAG_PATTERNS: list[str] = [
+    "v{version}",
+    "{version}",
+    "{package}-{version}",
+    "release-{version}",
+    "V{version}",
+]
+
+
+def checkout_matching_tag(
+    repo_dir: Path,
+    package_name: str,
+    version: str,
+) -> tuple[str | None, str | None]:
+    """Attempt to check out the git tag matching a PyPI version.
+
+    Tries several common tag naming conventions.  Fetches tags first
+    for shallow clones.
+
+    Returns:
+        Tuple of ``(commit_hash, matched_tag)``.  Both ``None`` if no
+        tag found.
+    """
+    # Best-effort fetch of tags for shallow clones.
+    subprocess.run(
+        ["git", "fetch", "--tags", "--depth=1", "origin"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_dir),
+        timeout=60,
+    )
+
+    normalized = package_name.lower().replace("_", "-")
+
+    for pattern in _TAG_PATTERNS:
+        tag = pattern.format(version=version, package=normalized)
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", f"refs/tags/{tag}^{{}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(repo_dir),
+            timeout=10,
+        )
+        if proc.returncode == 0:
+            commit = checkout_revision(repo_dir, tag)
+            return (commit, tag)
+
+    return (None, None)
+
+
+def detect_source_layout(repo_dir: Path, import_name: str) -> str:
+    """Detect whether a repo uses ``src/`` layout or flat layout.
+
+    Returns:
+        ``"src"`` if import_name exists under ``src/``, ``"flat"``
+        if it exists at the repo root, or ``"unknown"`` if neither.
+    """
+    if (repo_dir / "src" / import_name).is_dir():
+        return "src"
+    if (repo_dir / import_name).is_dir():
+        return "flat"
+    return "unknown"
+
+
+@contextmanager
+def shield_source_dir(
+    repo_dir: Path,
+    import_name: str,
+    layout: str,
+) -> Iterator[None]:
+    """Context manager that temporarily hides the source directory.
+
+    For flat-layout packages, renames ``repo_dir/import_name`` to
+    ``repo_dir/_labeille_shielded_import_name`` before yielding,
+    and restores it after.  For src-layout or unknown, this is a
+    no-op.
+    """
+    if layout != "flat":
+        yield
+        return
+    src_path = repo_dir / import_name
+    if not src_path.exists():
+        yield
+        return
+    shield_path = repo_dir / f"_labeille_shielded_{import_name}"
+    src_path.rename(shield_path)
+    try:
+        yield
+    finally:
+        shield_path.rename(src_path)
+
+
+_SELF_INSTALL_RE = re.compile(
+    r"""
+    (?:pip\s+install|python\s+-m\s+pip\s+install)  # pip install variant
+    \s+.*                                            # flags
+    (?:
+        -e\s+[.'"]                                   # editable: -e . or -e '.[dev]'
+        | \.\s*$                                     # bare: pip install .
+        | '\.\[                                      # pip install '.[extras]'
+        | "\.\[                                      # pip install ".[extras]"
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def _is_self_install_segment(segment: str) -> bool:
+    """Return True if this command segment installs the package itself."""
+    return bool(_SELF_INSTALL_RE.search(segment))
+
+
+_EXTRAS_RE = re.compile(r"\.\[([^\]]+)\]")
+
+
+def _extract_extras(segment: str) -> str | None:
+    """Extract extras from an install segment.
+
+    E.g. ``'.[dev,test]'`` -> ``'dev,test'``.
+    """
+    m = _EXTRAS_RE.search(segment)
+    return m.group(1) if m else None
+
+
+def split_install_command(
+    install_command: str,
+) -> tuple[list[str], list[str]]:
+    """Split an install command into self-install and dependency segments.
+
+    Segments are split on ``&&``.  A segment is classified as a
+    "self-install" if it contains editable install markers (``-e .``,
+    ``pip install .``, etc.).
+
+    Returns:
+        Tuple of ``(self_install_segments, other_segments)``.
+    """
+    if not install_command.strip():
+        return ([], [])
+    parts = re.split(r"\s*&&\s*", install_command)
+    parts = [p.strip() for p in parts if p.strip()]
+    self_install: list[str] = []
+    other: list[str] = []
+    for seg in parts:
+        if _is_self_install_segment(seg):
+            self_install.append(seg)
+        else:
+            other.append(seg)
+    return (self_install, other)
+
+
+def build_sdist_install_commands(
+    package_name: str,
+    install_command: str,
+) -> tuple[str, str]:
+    """Build sdist-mode install commands from a registry install_command.
+
+    Replaces self-install segments with a ``pip install --no-binary``
+    command.  If the self-install had extras, those are included.
+
+    Returns:
+        Tuple of ``(sdist_install_cmd, deps_install_cmd)``.
+    """
+    self_segments, other_segments = split_install_command(install_command)
+    extras: str | None = None
+    for seg in self_segments:
+        extras = _extract_extras(seg)
+        if extras:
+            break
+    if extras:
+        sdist_cmd = f"pip install --no-binary {package_name} '{package_name}[{extras}]'"
+    else:
+        sdist_cmd = f"pip install --no-binary {package_name} {package_name}"
+    deps_cmd = " && ".join(other_segments) if other_segments else ""
+    return (sdist_cmd, deps_cmd)

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -14,42 +14,56 @@ the results including any crashes (segfaults, aborts, assertion failures).
 
 from __future__ import annotations
 
-import enum
 import json
 import os
 import platform
-import re
 import shutil
 import socket
 import subprocess
 import tempfile
 import threading
 import time
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Iterator, Literal
+from typing import Any
 
 from labeille.crash import detect_crash
 from labeille.io_utils import append_jsonl, utc_now_iso, write_meta_json
 from labeille.logging import get_logger
 from labeille.registry import Index, PackageEntry, load_index, load_package, package_exists
-from labeille.resolve import fetch_pypi_metadata
+
+# Re-export data models from runner_models (preserves all existing imports).
+from labeille.runner_models import InstallerBackend as InstallerBackend
+from labeille.runner_models import PackageResult as PackageResult
+from labeille.runner_models import RunnerConfig as RunnerConfig
+from labeille.runner_models import RunOutput as RunOutput
+from labeille.runner_models import RunSummary as RunSummary
+
+# Re-export repo operations from repo_ops (preserves all existing imports).
+from labeille.repo_ops import _EXTRAS_RE as _EXTRAS_RE
+from labeille.repo_ops import _SELF_INSTALL_RE as _SELF_INSTALL_RE
+from labeille.repo_ops import _TAG_PATTERNS as _TAG_PATTERNS
+from labeille.repo_ops import _extract_extras as _extract_extras
+from labeille.repo_ops import _is_self_install_segment as _is_self_install_segment
+from labeille.repo_ops import build_sdist_install_commands as build_sdist_install_commands
+from labeille.repo_ops import checkout_matching_tag as checkout_matching_tag
+from labeille.repo_ops import checkout_revision as checkout_revision
+from labeille.repo_ops import clone_repo as clone_repo
+from labeille.repo_ops import detect_source_layout as detect_source_layout
+from labeille.repo_ops import fetch_latest_pypi_version as fetch_latest_pypi_version
+from labeille.repo_ops import parse_package_specs as parse_package_specs
+from labeille.repo_ops import parse_repo_overrides as parse_repo_overrides
+from labeille.repo_ops import pull_repo as pull_repo
+from labeille.repo_ops import shield_source_dir as shield_source_dir
+from labeille.repo_ops import split_install_command as split_install_command
 
 log = get_logger("runner")
 
 
 # ---------------------------------------------------------------------------
-# Installer backend
+# Installer backend helpers
 # ---------------------------------------------------------------------------
-
-
-class InstallerBackend(enum.Enum):
-    """Package installer backend."""
-
-    PIP = "pip"
-    UV = "uv"
 
 
 def detect_uv() -> str | None:
@@ -83,109 +97,6 @@ def resolve_installer(preference: str = "auto") -> InstallerBackend:
     if detect_uv() is not None:
         return InstallerBackend.UV
     return InstallerBackend.PIP
-
-
-# ---------------------------------------------------------------------------
-# Data structures
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class RunnerConfig:
-    """Top-level configuration for a test run."""
-
-    target_python: Path
-    registry_dir: Path
-    results_dir: Path
-    run_id: str
-    timeout: int = 600
-    top_n: int | None = None
-    packages_filter: list[str] | None = None
-    skip_extensions: bool = False
-    skip_completed: bool = False
-    stop_after_crash: int | None = None
-    env_overrides: dict[str, str] = field(default_factory=dict)
-    dry_run: bool = False
-    verbose: bool = False
-    quiet: bool = False
-    keep_work_dirs: bool = False
-    repos_dir: Path | None = None
-    venvs_dir: Path | None = None
-    refresh_venvs: bool = False
-    force_run: bool = False
-    target_python_version: str = ""
-    workers: int = 1
-    cli_args: list[str] = field(default_factory=list)
-    clone_depth_override: int | None = None
-    revision_overrides: dict[str, str] = field(default_factory=dict)
-    extra_deps: list[str] = field(default_factory=list)
-    test_command_override: str | None = None
-    test_command_suffix: str | None = None
-    repo_overrides: dict[str, str] = field(default_factory=dict)
-    installer: str = "auto"  # auto | uv | pip
-    install_from: str = "source"  # source | sdist
-
-
-@dataclass
-class PackageResult:
-    """Result of testing a single package."""
-
-    package: str
-    repo: str | None = None
-    package_version: str | None = None
-    git_revision: str | None = None
-    status: Literal[
-        "pass", "fail", "crash", "timeout", "install_error", "clone_error", "error"
-    ] = "error"
-    exit_code: int = -1
-    signal: int | None = None
-    crash_signature: str | None = None
-    duration_seconds: float = 0.0
-    install_duration_seconds: float = 0.0
-    test_command: str = ""
-    timeout_hit: bool = False
-    stderr_tail: str = ""
-    installed_dependencies: dict[str, str] = field(default_factory=dict)
-    error_message: str | None = None
-    requested_revision: str | None = None
-    install_from: str = ""  # "source" or "sdist"
-    sdist_version: str | None = None
-    sdist_tag_matched: bool | None = None
-    installer_backend: str = ""
-    timestamp: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to a plain dict suitable for JSON serialization."""
-        return asdict(self)
-
-
-@dataclass
-class RunSummary:
-    """Aggregate summary of a test run."""
-
-    total: int = 0
-    tested: int = 0
-    passed: int = 0
-    failed: int = 0
-    crashed: int = 0
-    timed_out: int = 0
-    install_errors: int = 0
-    clone_errors: int = 0
-    errors: int = 0
-    skipped: int = 0
-    version_skipped: int = 0
-
-
-@dataclass
-class RunOutput:
-    """Complete output from a test run."""
-
-    results: list[PackageResult]
-    summary: RunSummary
-    total_duration: float
-    python_version: str
-    jit_enabled: bool
-    run_dir: Path = field(default_factory=lambda: Path("."))
 
 
 # ---------------------------------------------------------------------------
@@ -352,133 +263,6 @@ def build_env(config: RunnerConfig) -> dict[str, str]:
     if config.env_overrides:
         log.debug("Env overrides: %s", config.env_overrides)
     return env
-
-
-def clone_repo(repo_url: str, dest: Path, clone_depth: int | None = None) -> str | None:
-    """Clone a git repository and return the HEAD revision.
-
-    Args:
-        repo_url: The URL of the git repository.
-        dest: The destination directory for the clone.
-        clone_depth: Clone depth. ``None`` means shallow (depth=1).
-            A positive integer uses that depth.
-
-    Returns:
-        The HEAD commit hash, or ``None`` on failure.
-
-    Raises:
-        subprocess.CalledProcessError: If the clone fails.
-    """
-    depth = clone_depth if clone_depth is not None else 1
-    log.debug("Running: git clone --depth=%d %s %s", depth, repo_url, dest)
-    clone_proc = subprocess.run(
-        ["git", "clone", f"--depth={depth}", repo_url, str(dest)],
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=True,
-    )
-    if clone_proc.stderr:
-        log.debug("git clone stderr: %s", clone_proc.stderr.strip())
-
-    # Fetch tags when using deeper clones (needed for setuptools-scm etc.).
-    if clone_depth is not None and clone_depth > 1:
-        log.debug("Fetching tags for %s (clone_depth=%d)", dest, clone_depth)
-        fetch_proc = subprocess.run(
-            ["git", "fetch", "--tags"],
-            capture_output=True,
-            text=True,
-            cwd=str(dest),
-            timeout=120,
-            check=False,
-        )
-        if fetch_proc.returncode != 0:
-            log.debug("git fetch --tags failed (non-fatal): %s", fetch_proc.stderr.strip())
-
-    # Get the revision.
-    proc = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=str(dest),
-        timeout=10,
-    )
-    if proc.returncode == 0:
-        return proc.stdout.strip()
-    return None
-
-
-def pull_repo(dest: Path) -> str | None:
-    """Fetch latest changes and force-reset to upstream HEAD.
-
-    Uses ``fetch`` + ``reset --hard`` + ``clean -fdx`` instead of
-    ``pull --ff-only`` to handle dirty working trees left by test
-    suites without needing a full re-clone.
-
-    Args:
-        dest: The directory containing the existing clone.
-
-    Returns:
-        The HEAD commit hash, or ``None`` on failure.
-
-    Raises:
-        subprocess.CalledProcessError: If the fetch fails.
-    """
-    log.debug("Fetching and resetting repo in %s", dest)
-
-    # Fetch latest from origin.
-    subprocess.run(
-        ["git", "fetch", "origin"],
-        capture_output=True,
-        text=True,
-        cwd=str(dest),
-        timeout=120,
-        check=True,
-    )
-
-    # Reset to the fetched HEAD, discarding any local modifications.
-    # FETCH_HEAD works reliably with shallow clones where origin/HEAD
-    # or origin/main might not be set.
-    reset_proc = subprocess.run(
-        ["git", "reset", "--hard", "FETCH_HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=str(dest),
-        timeout=60,
-        check=False,
-    )
-    if reset_proc.returncode != 0:
-        log.debug(
-            "git reset --hard failed (non-fatal): %s",
-            reset_proc.stderr.strip(),
-        )
-
-    # Remove untracked files and directories left by test runs.
-    clean_proc = subprocess.run(
-        ["git", "clean", "-fdx"],
-        capture_output=True,
-        text=True,
-        cwd=str(dest),
-        timeout=60,
-        check=False,
-    )
-    if clean_proc.returncode != 0:
-        log.debug(
-            "git clean failed (non-fatal): %s",
-            clean_proc.stderr.strip(),
-        )
-
-    # Get the HEAD revision.
-    proc = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=str(dest),
-        timeout=10,
-    )
-    if proc.returncode == 0:
-        return proc.stdout.strip()
-    return None
 
 
 def create_venv(
@@ -781,315 +565,6 @@ def check_import(
 
 
 # ---------------------------------------------------------------------------
-# Package spec parsing and revision checkout
-# ---------------------------------------------------------------------------
-
-
-def parse_package_specs(
-    raw: str,
-) -> tuple[list[str], dict[str, str]]:
-    """Parse a comma-separated package spec string.
-
-    Each spec is either ``name`` or ``name@revision``.
-
-    Returns:
-        A tuple of (package_names, revision_overrides) where
-        revision_overrides maps package name to revision string.
-
-    Examples::
-
-        "requests,click" → (["requests", "click"], {})
-        "requests@abc123,click" → (["requests", "click"], {"requests": "abc123"})
-        "numpy@HEAD~5" → (["numpy"], {"numpy": "HEAD~5"})
-    """
-    names: list[str] = []
-    revisions: dict[str, str] = {}
-    for spec in raw.split(","):
-        spec = spec.strip()
-        if not spec:
-            continue
-        if "@" in spec:
-            name, rev = spec.split("@", 1)
-            name = name.strip()
-            rev = rev.strip()
-            if name and rev:
-                names.append(name)
-                revisions[name] = rev
-            elif name:
-                names.append(name)
-        else:
-            names.append(spec)
-    return names, revisions
-
-
-def parse_repo_overrides(raw: tuple[str, ...]) -> dict[str, str]:
-    """Parse ``--repo-override`` arguments into a dict.
-
-    Each argument is ``package_name=repo_url``.
-
-    Raises:
-        ValueError: If an argument is malformed (no ``=``, or empty name/URL).
-    """
-    overrides: dict[str, str] = {}
-    for item in raw:
-        if "=" not in item:
-            raise ValueError(
-                f"Invalid --repo-override format: {item!r}. "
-                f"Expected PKG=URL (e.g., 'requests=https://...')"
-            )
-        name, url = item.split("=", 1)
-        name = name.strip()
-        url = url.strip()
-        if not name or not url:
-            raise ValueError("Invalid --repo-override: both package name and URL required.")
-        overrides[name] = url
-    return overrides
-
-
-def checkout_revision(repo_dir: Path, revision: str) -> str | None:
-    """Checkout a specific git revision and return the resulting HEAD hash.
-
-    Args:
-        repo_dir: Path to the git repository.
-        revision: Any git ref — commit hash, branch, tag, ``HEAD~N``.
-
-    Returns:
-        The full commit hash after checkout, or ``None`` on failure.
-    """
-    proc = subprocess.run(
-        ["git", "checkout", revision],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_dir),
-        timeout=60,
-        check=False,
-    )
-    if proc.returncode != 0:
-        log.warning(
-            "git checkout %s failed in %s: %s. "
-            "If using a revision beyond the clone depth, try --no-shallow.",
-            revision,
-            repo_dir,
-            proc.stderr.strip(),
-        )
-        return None
-
-    # Get the resolved commit hash.
-    rev_proc = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_dir),
-        timeout=10,
-    )
-    if rev_proc.returncode == 0:
-        return rev_proc.stdout.strip()
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Sdist-mode helpers
-# ---------------------------------------------------------------------------
-
-
-def fetch_latest_pypi_version(
-    package_name: str,
-    *,
-    timeout: float = 10.0,
-) -> str | None:
-    """Fetch the latest release version of a package from PyPI.
-
-    Returns:
-        Version string (e.g. ``"2.1.0"``), or ``None`` on failure.
-    """
-    metadata = fetch_pypi_metadata(package_name, timeout=timeout)
-    if metadata is None:
-        return None
-    try:
-        return str(metadata["info"]["version"])
-    except (KeyError, TypeError):
-        return None
-
-
-_TAG_PATTERNS: list[str] = [
-    "v{version}",
-    "{version}",
-    "{package}-{version}",
-    "release-{version}",
-    "V{version}",
-]
-
-
-def checkout_matching_tag(
-    repo_dir: Path,
-    package_name: str,
-    version: str,
-) -> tuple[str | None, str | None]:
-    """Attempt to check out the git tag matching a PyPI version.
-
-    Tries several common tag naming conventions.  Fetches tags first
-    for shallow clones.
-
-    Returns:
-        Tuple of ``(commit_hash, matched_tag)``.  Both ``None`` if no
-        tag found.
-    """
-    # Best-effort fetch of tags for shallow clones.
-    subprocess.run(
-        ["git", "fetch", "--tags", "--depth=1", "origin"],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=str(repo_dir),
-        timeout=60,
-    )
-
-    normalized = package_name.lower().replace("_", "-")
-
-    for pattern in _TAG_PATTERNS:
-        tag = pattern.format(version=version, package=normalized)
-        proc = subprocess.run(
-            ["git", "rev-parse", "--verify", f"refs/tags/{tag}^{{}}"],
-            check=False,
-            capture_output=True,
-            text=True,
-            cwd=str(repo_dir),
-            timeout=10,
-        )
-        if proc.returncode == 0:
-            commit = checkout_revision(repo_dir, tag)
-            return (commit, tag)
-
-    return (None, None)
-
-
-def detect_source_layout(repo_dir: Path, import_name: str) -> str:
-    """Detect whether a repo uses ``src/`` layout or flat layout.
-
-    Returns:
-        ``"src"`` if import_name exists under ``src/``, ``"flat"``
-        if it exists at the repo root, or ``"unknown"`` if neither.
-    """
-    if (repo_dir / "src" / import_name).is_dir():
-        return "src"
-    if (repo_dir / import_name).is_dir():
-        return "flat"
-    return "unknown"
-
-
-@contextmanager
-def shield_source_dir(
-    repo_dir: Path,
-    import_name: str,
-    layout: str,
-) -> Iterator[None]:
-    """Context manager that temporarily hides the source directory.
-
-    For flat-layout packages, renames ``repo_dir/import_name`` to
-    ``repo_dir/_labeille_shielded_import_name`` before yielding,
-    and restores it after.  For src-layout or unknown, this is a
-    no-op.
-    """
-    if layout != "flat":
-        yield
-        return
-    src_path = repo_dir / import_name
-    if not src_path.exists():
-        yield
-        return
-    shield_path = repo_dir / f"_labeille_shielded_{import_name}"
-    src_path.rename(shield_path)
-    try:
-        yield
-    finally:
-        shield_path.rename(src_path)
-
-
-_SELF_INSTALL_RE = re.compile(
-    r"""
-    (?:pip\s+install|python\s+-m\s+pip\s+install)  # pip install variant
-    \s+.*                                            # flags
-    (?:
-        -e\s+[.'"]                                   # editable: -e . or -e '.[dev]'
-        | \.\s*$                                     # bare: pip install .
-        | '\.\[                                      # pip install '.[extras]'
-        | "\.\[                                      # pip install ".[extras]"
-    )
-    """,
-    re.VERBOSE | re.IGNORECASE,
-)
-
-
-def _is_self_install_segment(segment: str) -> bool:
-    """Return True if this command segment installs the package itself."""
-    return bool(_SELF_INSTALL_RE.search(segment))
-
-
-_EXTRAS_RE = re.compile(r"\.\[([^\]]+)\]")
-
-
-def _extract_extras(segment: str) -> str | None:
-    """Extract extras from an install segment.
-
-    E.g. ``'.[dev,test]'`` -> ``'dev,test'``.
-    """
-    m = _EXTRAS_RE.search(segment)
-    return m.group(1) if m else None
-
-
-def split_install_command(
-    install_command: str,
-) -> tuple[list[str], list[str]]:
-    """Split an install command into self-install and dependency segments.
-
-    Segments are split on ``&&``.  A segment is classified as a
-    "self-install" if it contains editable install markers (``-e .``,
-    ``pip install .``, etc.).
-
-    Returns:
-        Tuple of ``(self_install_segments, other_segments)``.
-    """
-    if not install_command.strip():
-        return ([], [])
-    parts = re.split(r"\s*&&\s*", install_command)
-    parts = [p.strip() for p in parts if p.strip()]
-    self_install: list[str] = []
-    other: list[str] = []
-    for seg in parts:
-        if _is_self_install_segment(seg):
-            self_install.append(seg)
-        else:
-            other.append(seg)
-    return (self_install, other)
-
-
-def build_sdist_install_commands(
-    package_name: str,
-    install_command: str,
-) -> tuple[str, str]:
-    """Build sdist-mode install commands from a registry install_command.
-
-    Replaces self-install segments with a ``pip install --no-binary``
-    command.  If the self-install had extras, those are included.
-
-    Returns:
-        Tuple of ``(sdist_install_cmd, deps_install_cmd)``.
-    """
-    self_segments, other_segments = split_install_command(install_command)
-    extras: str | None = None
-    for seg in self_segments:
-        extras = _extract_extras(seg)
-        if extras:
-            break
-    if extras:
-        sdist_cmd = f"pip install --no-binary {package_name} '{package_name}[{extras}]'"
-    else:
-        sdist_cmd = f"pip install --no-binary {package_name} {package_name}"
-    deps_cmd = " && ".join(other_segments) if other_segments else ""
-    return (sdist_cmd, deps_cmd)
-
-
-# ---------------------------------------------------------------------------
 # Per-package runner
 # ---------------------------------------------------------------------------
 
@@ -1297,9 +772,7 @@ def _run_install(
         result.error_message = (
             install_proc.stderr[-500:] if install_proc.stderr else f"non-zero{label}"
         )
-        log.error(
-            "Install failed for %s%s (exit %d)", pkg.package, label, install_proc.returncode
-        )
+        log.error("Install failed for %s%s (exit %d)", pkg.package, label, install_proc.returncode)
         return None
 
     if install_proc.stdout:
@@ -1452,8 +925,16 @@ def _run_package_inner(
         log.info("Installing %s from sdist: %s", pkg.package, sdist_install_cmd)
 
         install_result = _run_install(
-            pkg, config, result, venv_dir, repo_dir, env, per_pkg_timeout,
-            installer, sdist_install_cmd, label=" (sdist)",
+            pkg,
+            config,
+            result,
+            venv_dir,
+            repo_dir,
+            env,
+            per_pkg_timeout,
+            installer,
+            sdist_install_cmd,
+            label=" (sdist)",
         )
         if install_result is None:
             return result
@@ -1485,8 +966,15 @@ def _run_package_inner(
         log.info("Installing %s: %s", pkg.package, install_cmd)
 
         install_result = _run_install(
-            pkg, config, result, venv_dir, repo_dir, env, per_pkg_timeout,
-            installer, install_cmd,
+            pkg,
+            config,
+            result,
+            venv_dir,
+            repo_dir,
+            env,
+            per_pkg_timeout,
+            installer,
+            install_cmd,
         )
         if install_result is None:
             return result

--- a/src/labeille/runner_models.py
+++ b/src/labeille/runner_models.py
@@ -1,0 +1,127 @@
+"""Data models for the test runner.
+
+Extracted from :mod:`labeille.runner` for clarity.  All names are
+re-exported by :mod:`labeille.runner` so existing imports are unaffected.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+
+# ---------------------------------------------------------------------------
+# Installer backend
+# ---------------------------------------------------------------------------
+
+
+class InstallerBackend(enum.Enum):
+    """Package installer backend."""
+
+    PIP = "pip"
+    UV = "uv"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunnerConfig:
+    """Top-level configuration for a test run."""
+
+    target_python: Path
+    registry_dir: Path
+    results_dir: Path
+    run_id: str
+    timeout: int = 600
+    top_n: int | None = None
+    packages_filter: list[str] | None = None
+    skip_extensions: bool = False
+    skip_completed: bool = False
+    stop_after_crash: int | None = None
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    dry_run: bool = False
+    verbose: bool = False
+    quiet: bool = False
+    keep_work_dirs: bool = False
+    repos_dir: Path | None = None
+    venvs_dir: Path | None = None
+    refresh_venvs: bool = False
+    force_run: bool = False
+    target_python_version: str = ""
+    workers: int = 1
+    cli_args: list[str] = field(default_factory=list)
+    clone_depth_override: int | None = None
+    revision_overrides: dict[str, str] = field(default_factory=dict)
+    extra_deps: list[str] = field(default_factory=list)
+    test_command_override: str | None = None
+    test_command_suffix: str | None = None
+    repo_overrides: dict[str, str] = field(default_factory=dict)
+    installer: str = "auto"  # auto | uv | pip
+    install_from: str = "source"  # source | sdist
+
+
+@dataclass
+class PackageResult:
+    """Result of testing a single package."""
+
+    package: str
+    repo: str | None = None
+    package_version: str | None = None
+    git_revision: str | None = None
+    status: Literal[
+        "pass", "fail", "crash", "timeout", "install_error", "clone_error", "error"
+    ] = "error"
+    exit_code: int = -1
+    signal: int | None = None
+    crash_signature: str | None = None
+    duration_seconds: float = 0.0
+    install_duration_seconds: float = 0.0
+    test_command: str = ""
+    timeout_hit: bool = False
+    stderr_tail: str = ""
+    installed_dependencies: dict[str, str] = field(default_factory=dict)
+    error_message: str | None = None
+    requested_revision: str | None = None
+    install_from: str = ""  # "source" or "sdist"
+    sdist_version: str | None = None
+    sdist_tag_matched: bool | None = None
+    installer_backend: str = ""
+    timestamp: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a plain dict suitable for JSON serialization."""
+        return asdict(self)
+
+
+@dataclass
+class RunSummary:
+    """Aggregate summary of a test run."""
+
+    total: int = 0
+    tested: int = 0
+    passed: int = 0
+    failed: int = 0
+    crashed: int = 0
+    timed_out: int = 0
+    install_errors: int = 0
+    clone_errors: int = 0
+    errors: int = 0
+    skipped: int = 0
+    version_skipped: int = 0
+
+
+@dataclass
+class RunOutput:
+    """Complete output from a test run."""
+
+    results: list[PackageResult]
+    summary: RunSummary
+    total_duration: float
+    python_version: str
+    jit_enabled: bool
+    run_dir: Path = field(default_factory=lambda: Path("."))

--- a/tests/test_sdist_install.py
+++ b/tests/test_sdist_install.py
@@ -21,26 +21,26 @@ from labeille.runner import (
 
 
 class TestFetchLatestPypiVersion(unittest.TestCase):
-    @patch("labeille.runner.fetch_pypi_metadata")
+    @patch("labeille.repo_ops.fetch_pypi_metadata")
     def test_returns_version(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = {"info": {"version": "2.31.0"}}
         result = fetch_latest_pypi_version("requests")
         self.assertEqual(result, "2.31.0")
         mock_fetch.assert_called_once_with("requests", timeout=10.0)
 
-    @patch("labeille.runner.fetch_pypi_metadata")
+    @patch("labeille.repo_ops.fetch_pypi_metadata")
     def test_returns_none_on_fetch_failure(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = None
         result = fetch_latest_pypi_version("nonexistent")
         self.assertIsNone(result)
 
-    @patch("labeille.runner.fetch_pypi_metadata")
+    @patch("labeille.repo_ops.fetch_pypi_metadata")
     def test_returns_none_on_missing_key(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = {"info": {}}
         result = fetch_latest_pypi_version("bad-response")
         self.assertIsNone(result)
 
-    @patch("labeille.runner.fetch_pypi_metadata")
+    @patch("labeille.repo_ops.fetch_pypi_metadata")
     def test_custom_timeout(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = {"info": {"version": "1.0"}}
         fetch_latest_pypi_version("pkg", timeout=5.0)


### PR DESCRIPTION
## Summary
- Extract data models (`InstallerBackend`, `RunnerConfig`, `PackageResult`, `RunSummary`, `RunOutput`) to `runner_models.py`
- Extract git operations, package spec parsing, and sdist helpers to `repo_ops.py`
- All names re-exported from `runner.py` with `as` idiom — existing imports and `mock.patch` targets unchanged
- `runner.py` reduced from 1972 to 1445 lines (~27%)

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (49 files)
- [x] ruff format + check clean
- [x] Only 4 test patches updated (`labeille.runner.fetch_pypi_metadata` → `labeille.repo_ops.fetch_pypi_metadata`) for functions that moved to a new module with internal cross-calls

Closes #136

Generated with [Claude Code](https://claude.com/claude-code)