### PR TITLE
refactor: reduce type:ignore markers in tests from 59 to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Fixed `type: ignore[operator]` in `ft/display.py` by adding explicit `None` guard, in `bench_cli.py` by restructuring conditionals, and `type: ignore[no-any-return]` in `resolve.py` by using intermediate variable.
 - Extracted 7 helper functions from `run_package_ft` in `ft/runner.py` (360→~80 lines): `_check_ft_wheel_trust`, `_clone_and_align_ft`, `_create_venv_and_install_ft`, `_install_sdist_mode`, `_install_source_mode`, `_run_ft_iterations`, `_run_gil_comparison`.
 - Split `runner.py` (1972→1445 lines): extracted data models to `runner_models.py` and git/repo/sdist operations to `repo_ops.py`, with re-exports preserving all existing imports.
+- Reduced `type: ignore` markers in test files from 59 to 2 by typing builder kwargs as `Any`, using `assert x is not None` for type narrowing, adding explicit generic parameters, and typing mock parameters as `MagicMock`.
 
 ### Removed
 - Dead code: `_log2()` from `bisect.py`, `RegistryStats`/`analyze_registry()` from `analyze.py` (superseded by `RegistryReport`/`generate_registry_report()`), `load_ft_summary()` from `ft/results.py`, `format_progress()`/`format_gil_comparison()` from `ft/display.py`, unused `_MOD_GIL_MENTION_PATTERN` regex from `ft/compat.py`.

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 from labeille.analyze import (
     PackageComparison,
@@ -106,7 +107,7 @@ def _make_pkg(
     enriched: bool = True,
     extension_type: str = "pure",
     test_framework: str = "pytest",
-    **kwargs: object,
+    **kwargs: Any,
 ) -> PackageEntry:
     """Create a PackageEntry for testing."""
     return PackageEntry(
@@ -119,11 +120,11 @@ def _make_pkg(
         test_framework=test_framework,
         install_command=str(kwargs.get("install_command", "pip install -e '.[dev]'")),
         test_command=str(kwargs.get("test_command", "python -m pytest")),
-        timeout=kwargs.get("timeout"),  # type: ignore[arg-type]
-        clone_depth=kwargs.get("clone_depth"),  # type: ignore[arg-type]
-        import_name=kwargs.get("import_name"),  # type: ignore[arg-type]
+        timeout=kwargs.get("timeout"),
+        clone_depth=kwargs.get("clone_depth"),
+        import_name=kwargs.get("import_name"),
         uses_xdist=bool(kwargs.get("uses_xdist", False)),
-        skip_versions=kwargs.get("skip_versions") or {},  # type: ignore[arg-type]
+        skip_versions=kwargs.get("skip_versions") or {},
     )
 
 
@@ -167,8 +168,8 @@ class TestRunData(unittest.TestCase):
         )
         run = RunData(run_id="run1", run_dir=self.results_dir / "run1")
         r = run.result_for("alpha")
-        self.assertIsNotNone(r)
-        self.assertEqual(r.package, "alpha")  # type: ignore[union-attr]
+        assert r is not None
+        self.assertEqual(r.package, "alpha")
 
     def test_result_for_missing(self) -> None:
         _write_run(self.results_dir, "run1", results=[_make_result("alpha")])
@@ -229,15 +230,15 @@ class TestResultsStore(unittest.TestCase):
         _write_run(self.results_dir, "2026-02-22", results=[_make_result()])
         store = ResultsStore(self.results_dir)
         latest = store.latest()
-        self.assertIsNotNone(latest)
-        self.assertEqual(latest.run_id, "2026-02-22")  # type: ignore[union-attr]
+        assert latest is not None
+        self.assertEqual(latest.run_id, "2026-02-22")
 
     def test_get_by_id(self) -> None:
         _write_run(self.results_dir, "run1", results=[_make_result()])
         store = ResultsStore(self.results_dir)
         run = store.get("run1")
-        self.assertIsNotNone(run)
-        self.assertEqual(run.run_id, "run1")  # type: ignore[union-attr]
+        assert run is not None
+        self.assertEqual(run.run_id, "run1")
 
     def test_get_latest_alias(self) -> None:
         _write_run(self.results_dir, "run1", results=[_make_result()])
@@ -372,10 +373,10 @@ class TestAnalyzeRun(unittest.TestCase):
         analysis = analyze_run(run)
         self.assertAlmostEqual(analysis.total_duration, 30.0)
         self.assertAlmostEqual(analysis.avg_duration, 10.0)
-        self.assertIsNotNone(analysis.fastest)
-        self.assertEqual(analysis.fastest.package, "a")  # type: ignore[union-attr]
-        self.assertIsNotNone(analysis.slowest)
-        self.assertEqual(analysis.slowest.package, "b")  # type: ignore[union-attr]
+        assert analysis.fastest is not None
+        self.assertEqual(analysis.fastest.package, "a")
+        assert analysis.slowest is not None
+        self.assertEqual(analysis.slowest.package, "b")
 
     def test_duration_buckets(self) -> None:
         results = [
@@ -411,8 +412,8 @@ class TestAnalyzeRun(unittest.TestCase):
         old = RunData(run_id="run1", run_dir=self.results_dir / "run1")
         new = RunData(run_id="run2", run_dir=self.results_dir / "run2")
         analysis = analyze_run(new, previous_run=old)
-        self.assertIsNotNone(analysis.status_changes)
-        self.assertEqual(len(analysis.status_changes), 2)  # type: ignore[arg-type]
+        assert analysis.status_changes is not None
+        self.assertEqual(len(analysis.status_changes), 2)
 
     def test_no_previous(self) -> None:
         _write_run(self.results_dir, "run1", results=[_make_result()])

--- a/tests/test_bench_cache.py
+++ b/tests/test_bench_cache.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from labeille.bench.cache import (
     DROP_CACHES_SCRIPT,
@@ -30,9 +30,9 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.sys.platform", "linux")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
     def test_linux_all_configured(
-        self, mock_uid: object, mock_exists: object, mock_run: object
+        self, mock_uid: MagicMock, mock_exists: MagicMock, mock_run: MagicMock
     ) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)  # type: ignore[attr-defined]
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
         status = check_cache_drop_available()
         self.assertTrue(status.available)
         self.assertTrue(status.platform_supported)
@@ -45,16 +45,16 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.sys.platform", "darwin")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
     def test_macos_all_configured(
-        self, mock_uid: object, mock_exists: object, mock_run: object
+        self, mock_uid: MagicMock, mock_exists: MagicMock, mock_run: MagicMock
     ) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)  # type: ignore[attr-defined]
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
         status = check_cache_drop_available()
         self.assertTrue(status.available)
         self.assertTrue(status.platform_supported)
 
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
     @patch("labeille.bench.cache.sys.platform", "win32")
-    def test_unsupported_platform(self, mock_uid: object) -> None:
+    def test_unsupported_platform(self, mock_uid: MagicMock) -> None:
         status = check_cache_drop_available()
         self.assertFalse(status.available)
         self.assertFalse(status.platform_supported)
@@ -63,7 +63,7 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.Path.exists", return_value=False)
     @patch("labeille.bench.cache.sys.platform", "linux")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_script_missing(self, mock_uid: object, mock_exists: object) -> None:
+    def test_script_missing(self, mock_uid: MagicMock, mock_exists: MagicMock) -> None:
         status = check_cache_drop_available()
         self.assertFalse(status.available)
         self.assertFalse(status.script_exists)
@@ -73,8 +73,10 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.Path.exists", return_value=True)
     @patch("labeille.bench.cache.sys.platform", "linux")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_sudo_fails(self, mock_uid: object, mock_exists: object, mock_run: object) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)  # type: ignore[attr-defined]
+    def test_sudo_fails(
+        self, mock_uid: MagicMock, mock_exists: MagicMock, mock_run: MagicMock
+    ) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
         status = check_cache_drop_available()
         self.assertFalse(status.available)
         self.assertFalse(status.sudo_works)
@@ -84,8 +86,10 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.Path.exists", return_value=True)
     @patch("labeille.bench.cache.sys.platform", "linux")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_sudo_timeout(self, mock_uid: object, mock_exists: object, mock_run: object) -> None:
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sudo", timeout=5)  # type: ignore[attr-defined]
+    def test_sudo_timeout(
+        self, mock_uid: MagicMock, mock_exists: MagicMock, mock_run: MagicMock
+    ) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sudo", timeout=5)
         status = check_cache_drop_available()
         self.assertFalse(status.available)
         self.assertFalse(status.sudo_works)
@@ -95,9 +99,9 @@ class TestCheckCacheDropAvailable(unittest.TestCase):
     @patch("labeille.bench.cache.sys.platform", "linux")
     @patch("labeille.bench.cache.os.getuid", return_value=0)
     def test_running_as_root_detected(
-        self, mock_uid: object, mock_exists: object, mock_run: object
+        self, mock_uid: MagicMock, mock_exists: MagicMock, mock_run: MagicMock
     ) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)  # type: ignore[attr-defined]
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
         status = check_cache_drop_available()
         self.assertTrue(status.running_as_root)
         self.assertTrue(status.available)
@@ -113,51 +117,51 @@ class TestDropCaches(unittest.TestCase):
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_drop_caches_success(self, mock_uid: object, mock_run: object) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+    def test_drop_caches_success(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=b"", stderr=b""
         )
         self.assertTrue(drop_caches())
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_drop_caches_failure(self, mock_uid: object, mock_run: object) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+    def test_drop_caches_failure(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=1, stdout=b"", stderr=b"permission denied"
         )
         self.assertFalse(drop_caches())
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=0)
-    def test_drop_caches_refuses_root(self, mock_uid: object, mock_run: object) -> None:
+    def test_drop_caches_refuses_root(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
         self.assertFalse(drop_caches(allow_root=False))
-        mock_run.assert_not_called()  # type: ignore[attr-defined]
+        mock_run.assert_not_called()
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=0)
-    def test_drop_caches_allows_root(self, mock_uid: object, mock_run: object) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+    def test_drop_caches_allows_root(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=b"", stderr=b""
         )
         self.assertTrue(drop_caches(allow_root=True))
         # Should run without sudo.
-        args = mock_run.call_args[0][0]  # type: ignore[attr-defined]
+        args = mock_run.call_args[0][0]
         self.assertEqual(args, [DROP_CACHES_SCRIPT])
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_drop_caches_timeout(self, mock_uid: object, mock_run: object) -> None:
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sudo", timeout=10)  # type: ignore[attr-defined]
+    def test_drop_caches_timeout(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sudo", timeout=10)
         self.assertFalse(drop_caches())
 
     @patch("labeille.bench.cache.subprocess.run")
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_drop_caches_uses_sudo(self, mock_uid: object, mock_run: object) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+    def test_drop_caches_uses_sudo(self, mock_uid: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=b"", stderr=b""
         )
         drop_caches()
-        args = mock_run.call_args[0][0]  # type: ignore[attr-defined]
+        args = mock_run.call_args[0][0]
         self.assertEqual(args[:2], ["sudo", "-n"])
 
 
@@ -170,17 +174,17 @@ class TestCheckNotRoot(unittest.TestCase):
     """Tests for check_not_root()."""
 
     @patch("labeille.bench.cache.os.getuid", return_value=1000)
-    def test_not_root_passes(self, mock_uid: object) -> None:
+    def test_not_root_passes(self, mock_uid: MagicMock) -> None:
         # Should not raise.
         check_not_root()
 
     @patch("labeille.bench.cache.os.getuid", return_value=0)
-    def test_root_without_flag_exits(self, mock_uid: object) -> None:
+    def test_root_without_flag_exits(self, mock_uid: MagicMock) -> None:
         with self.assertRaises(SystemExit):
             check_not_root(allow_root=False)
 
     @patch("labeille.bench.cache.os.getuid", return_value=0)
-    def test_root_with_flag_passes(self, mock_uid: object) -> None:
+    def test_root_with_flag_passes(self, mock_uid: MagicMock) -> None:
         # Should not raise.
         check_not_root(allow_root=True)
 

--- a/tests/test_bench_export.py
+++ b/tests/test_bench_export.py
@@ -9,13 +9,13 @@ import unittest
 from bench_test_helpers import make_meta, make_package_result
 
 from labeille.bench.export import export_csv, export_csv_summary, export_markdown
-from labeille.bench.results import BenchPackageResult
+from labeille.bench.results import BenchMeta, BenchPackageResult
 
 
 class TestExportCSV(unittest.TestCase):
     """Tests for export_csv (long-format CSV)."""
 
-    def _make_data(self) -> tuple[object, list[BenchPackageResult]]:
+    def _make_data(self) -> tuple[BenchMeta, list[BenchPackageResult]]:
         meta = make_meta(conditions=["baseline", "treatment"])
         results = [
             make_package_result(
@@ -38,7 +38,7 @@ class TestExportCSV(unittest.TestCase):
     def test_export_csv_header(self) -> None:
         """First line contains all expected column names."""
         meta, results = self._make_data()
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         first_line = output.splitlines()[0]
         for col in [
             "package",
@@ -61,7 +61,7 @@ class TestExportCSV(unittest.TestCase):
     def test_export_csv_row_count(self) -> None:
         """2 packages x 2 conditions x 3 iterations = 12 data rows + 1 header."""
         meta, results = self._make_data()
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         lines = [line for line in output.splitlines() if line.strip()]
         self.assertEqual(len(lines), 13)
 
@@ -77,7 +77,7 @@ class TestExportCSV(unittest.TestCase):
                 warmup_count=1,
             ),
         ]
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         self.assertIn("True", output)  # warmup=True for first iteration
 
     def test_export_csv_values_correct(self) -> None:
@@ -86,7 +86,7 @@ class TestExportCSV(unittest.TestCase):
         results = [
             make_package_result("testpkg", {"baseline": [1.234567]}),
         ]
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         self.assertIn("testpkg", output)
         self.assertIn("1.234567", output)
 
@@ -97,14 +97,14 @@ class TestExportCSV(unittest.TestCase):
             make_package_result("active", {"baseline": [10.0, 10.1, 10.0]}),
             BenchPackageResult(package="skipped", skipped=True, skip_reason="fail"),
         ]
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         self.assertIn("active", output)
         self.assertNotIn("skipped", output)
 
     def test_export_csv_parseable(self) -> None:
         """Parse output with csv.reader — no errors, correct column count."""
         meta, results = self._make_data()
-        output = export_csv(meta, results)  # type: ignore[arg-type]
+        output = export_csv(meta, results)
         reader = csv.reader(io.StringIO(output))
         rows = list(reader)
         self.assertTrue(len(rows) > 1)
@@ -122,7 +122,7 @@ class TestExportCSVSummary(unittest.TestCase):
         results = [
             make_package_result("pkg1", {"baseline": [10.0, 10.1, 10.0, 10.1, 10.0]}),
         ]
-        output = export_csv_summary(meta, results)  # type: ignore[arg-type]
+        output = export_csv_summary(meta, results)
         first_line = output.splitlines()[0]
         for col in [
             "package",
@@ -145,7 +145,7 @@ class TestExportCSVSummary(unittest.TestCase):
             make_package_result("pkg1", {"baseline": [10.0, 10.1, 10.0]}),
             make_package_result("pkg2", {"baseline": [5.0, 5.1, 5.0]}),
         ]
-        output = export_csv_summary(meta, results)  # type: ignore[arg-type]
+        output = export_csv_summary(meta, results)
         lines = [line for line in output.splitlines() if line.strip()]
         self.assertEqual(len(lines), 3)  # 1 header + 2 data
 

--- a/tests/test_bench_results.py
+++ b/tests/test_bench_results.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 from labeille.bench.results import (
     BenchConditionResult,
@@ -28,9 +29,9 @@ from labeille.bench.system import PythonProfile, SystemProfile
 class TestBenchIteration(unittest.TestCase):
     """Tests for BenchIteration dataclass."""
 
-    def _make_iteration(self, **kwargs: object) -> BenchIteration:
+    def _make_iteration(self, **kwargs: Any) -> BenchIteration:
         """Create a BenchIteration with sensible defaults."""
-        defaults: dict[str, object] = {
+        defaults: dict[str, Any] = {
             "index": 1,
             "warmup": False,
             "wall_time_s": 1.5,
@@ -45,7 +46,7 @@ class TestBenchIteration(unittest.TestCase):
             "ram_available_start_gb": 8.0,
         }
         defaults.update(kwargs)
-        return BenchIteration(**defaults)  # type: ignore[arg-type]
+        return BenchIteration(**defaults)
 
     def test_iteration_to_dict_roundtrip(self) -> None:
         """to_dict → from_dict should preserve all fields."""

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -8,6 +8,7 @@ import unittest
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from labeille.bench.config import BenchConfig
@@ -27,21 +28,21 @@ from labeille.registry import Index, IndexEntry
 # ---------------------------------------------------------------------------
 
 
-def _make_config(**kwargs: object) -> BenchConfig:
+def _make_config(**kwargs: Any) -> BenchConfig:
     """Create a BenchConfig with sensible test defaults."""
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "iterations": 3,
         "warmup": 1,
         "timeout": 60,
         "default_target_python": "/usr/bin/python3",
     }
     defaults.update(kwargs)
-    return BenchConfig(**defaults)  # type: ignore[arg-type]
+    return BenchConfig(**defaults)
 
 
-def _make_condition(name: str = "baseline", **kwargs: object) -> ConditionDef:
+def _make_condition(name: str = "baseline", **kwargs: Any) -> ConditionDef:
     """Create a ConditionDef with defaults."""
-    return ConditionDef(name=name, **kwargs)  # type: ignore[arg-type]
+    return ConditionDef(name=name, **kwargs)
 
 
 @dataclass
@@ -56,9 +57,9 @@ class FakePackage:
     enriched: bool = True
 
 
-def _make_timed_result(**kwargs: object) -> TimedResult:
+def _make_timed_result(**kwargs: Any) -> TimedResult:
     """Create a TimedResult with sensible defaults."""
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "wall_time_s": 1.5,
         "user_time_s": 1.2,
         "sys_time_s": 0.1,
@@ -69,7 +70,7 @@ def _make_timed_result(**kwargs: object) -> TimedResult:
         "timed_out": False,
     }
     defaults.update(kwargs)
-    return TimedResult(**defaults)  # type: ignore[arg-type]
+    return TimedResult(**defaults)
 
 
 def _make_snapshot(load_avg: float = 0.5, ram_gb: float = 8.0) -> SystemSnapshot:
@@ -185,9 +186,9 @@ class TestValidation(unittest.TestCase):
 class TestSetupPackage(unittest.TestCase):
     """Tests for _setup_package."""
 
-    def _make_runner(self, **config_kwargs: object) -> BenchRunner:
+    def _make_runner(self, **config_kwargs: Any) -> BenchRunner:
         """Create a BenchRunner with a single condition and temp dirs."""
-        conditions = config_kwargs.pop("conditions", None) or {  # type: ignore[union-attr]
+        conditions = config_kwargs.pop("conditions", None) or {
             "baseline": _make_condition(),
         }
         config = _make_config(conditions=conditions, **config_kwargs)
@@ -679,16 +680,16 @@ class TestExecutionStrategies(unittest.TestCase):
 
         def tracking_run_iteration(
             *,
-            pkg: object,
-            cond: object,
+            pkg: Any,
+            cond: Any,
             setup: object,
             iter_index: int,
             is_warmup: bool,
         ) -> BenchIteration:
             call_log.append(
                 (
-                    pkg.package,  # type: ignore[union-attr]
-                    cond.name,  # type: ignore[union-attr]
+                    pkg.package,
+                    cond.name,
                     iter_index,
                     is_warmup,
                 )
@@ -1097,8 +1098,8 @@ class TestAdaptiveConvergence(unittest.TestCase):
 
         def tracking_run_iteration(
             *,
-            pkg: object,
-            cond: object,
+            pkg: Any,
+            cond: Any,
             setup: object,
             iter_index: int,
             is_warmup: bool,
@@ -1106,8 +1107,8 @@ class TestAdaptiveConvergence(unittest.TestCase):
             wt = next(time_iter, 1.0)
             call_log.append(
                 (
-                    pkg.package,  # type: ignore[union-attr]
-                    cond.name,  # type: ignore[union-attr]
+                    pkg.package,
+                    cond.name,
                     iter_index,
                     is_warmup,
                 )

--- a/tests/test_bench_system.py
+++ b/tests/test_bench_system.py
@@ -720,8 +720,8 @@ class TestGetAvailableRamGb(unittest.TestCase):
         from labeille.bench.system import _get_available_ram_gb
 
         result = _get_available_ram_gb()
-        self.assertIsNotNone(result)
-        self.assertAlmostEqual(result, 8.0, places=0)  # type: ignore[arg-type]
+        assert result is not None
+        self.assertAlmostEqual(result, 8.0, places=0)
 
     @patch("labeille.bench.system.sys.platform", "darwin")
     @patch("labeille.bench.system._parse_vm_stat")
@@ -732,9 +732,9 @@ class TestGetAvailableRamGb(unittest.TestCase):
             page_size=16384, pages_free=100000, pages_inactive=50000
         )
         result = _get_available_ram_gb()
-        self.assertIsNotNone(result)
+        assert result is not None
         expected = (100000 + 50000) * 16384 / (1024**3)
-        self.assertAlmostEqual(result, expected, places=1)  # type: ignore[arg-type]
+        self.assertAlmostEqual(result, expected, places=1)
 
     @patch("labeille.bench.system.sys.platform", "win32")
     def test_unsupported_platform(self) -> None:

--- a/tests/test_bisect.py
+++ b/tests/test_bisect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import click
@@ -90,15 +91,15 @@ class TestGetCommitRange(unittest.TestCase):
 class TestTestRevision(unittest.TestCase):
     """Tests for test_revision."""
 
-    def _make_config(self, **overrides: object) -> BisectConfig:
-        defaults: dict[str, object] = {
+    def _make_config(self, **overrides: Any) -> BisectConfig:
+        defaults: dict[str, Any] = {
             "package": "test-pkg",
             "good_rev": "v1.0",
             "bad_rev": "v2.0",
             "target_python": Path("/usr/bin/python3"),
         }
         defaults.update(overrides)
-        return BisectConfig(**defaults)  # type: ignore[arg-type]
+        return BisectConfig(**defaults)
 
     @patch("labeille.bisect.subprocess.run")
     def test_checkout_failure_returns_skip(self, mock_run: MagicMock) -> None:
@@ -438,8 +439,8 @@ class TestTryNeighbors(unittest.TestCase):
 class TestRunBisect(unittest.TestCase):
     """Tests for the main run_bisect function."""
 
-    def _make_config(self, **overrides: object) -> BisectConfig:
-        defaults: dict[str, object] = {
+    def _make_config(self, **overrides: Any) -> BisectConfig:
+        defaults: dict[str, Any] = {
             "package": "test-pkg",
             "good_rev": "v1.0",
             "bad_rev": "v2.0",
@@ -447,7 +448,7 @@ class TestRunBisect(unittest.TestCase):
             "registry_dir": Path("/registry"),
         }
         defaults.update(overrides)
-        return BisectConfig(**defaults)  # type: ignore[arg-type]
+        return BisectConfig(**defaults)
 
     @patch("labeille.bisect.test_revision")
     @patch("labeille.bisect.get_commit_range")

--- a/tests/test_compat_cli.py
+++ b/tests/test_compat_cli.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -229,7 +230,7 @@ class TestShowCommand(unittest.TestCase):
 class TestDiffCommand(unittest.TestCase):
     """Tests for compat diff command."""
 
-    def _create_survey_dir(self, tmpdir: str, sid: str, results: list[dict]) -> str:  # type: ignore[type-arg]
+    def _create_survey_dir(self, tmpdir: str, sid: str, results: list[dict[str, Any]]) -> str:
         survey_dir = Path(tmpdir) / sid
         survey_dir.mkdir()
         meta = {

--- a/tests/test_ft_compare.py
+++ b/tests/test_ft_compare.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from typing import Any
 
 from labeille.ft.compare import (
     PackageTransition,
@@ -18,7 +19,7 @@ def _make_result(
     pass_rate: float = 1.0,
     crash_count: int = 0,
     deadlock_count: int = 0,
-    **kwargs: object,
+    **kwargs: Any,
 ) -> FTPackageResult:
     """Create a minimal FTPackageResult for comparison tests."""
     if "pass_count" not in kwargs:
@@ -31,7 +32,7 @@ def _make_result(
         pass_rate=pass_rate,
         crash_count=crash_count,
         deadlock_count=deadlock_count,
-        **kwargs,  # type: ignore[arg-type]
+        **kwargs,
     )
 
 

--- a/tests/test_ft_display.py
+++ b/tests/test_ft_display.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from typing import Any
 from unittest.mock import MagicMock
 
 from labeille.ft.display import (
@@ -22,7 +23,7 @@ def _make_result(
     iterations_completed: int = 10,
     crash_count: int = 0,
     pass_rate: float = 1.0,
-    **kwargs: object,
+    **kwargs: Any,
 ) -> FTPackageResult:
     """Create a minimal FTPackageResult for display tests."""
     return FTPackageResult(
@@ -32,7 +33,7 @@ def _make_result(
         iterations_completed=iterations_completed,
         crash_count=crash_count,
         pass_rate=pass_rate,
-        **kwargs,  # type: ignore[arg-type]
+        **kwargs,
     )
 
 

--- a/tests/test_ft_export.py
+++ b/tests/test_ft_export.py
@@ -6,6 +6,7 @@ import csv
 import io
 import json
 import unittest
+from typing import Any
 
 from labeille.ft.export import export_csv, export_json, generate_report
 from labeille.ft.results import (
@@ -21,7 +22,7 @@ def _make_result(
     category: FailureCategory = FailureCategory.COMPATIBLE,
     pass_rate: float = 1.0,
     crash_count: int = 0,
-    **kwargs: object,
+    **kwargs: Any,
 ) -> FTPackageResult:
     """Create a minimal FTPackageResult for export tests."""
     if "pass_count" not in kwargs:
@@ -33,23 +34,23 @@ def _make_result(
         category=category,
         pass_rate=pass_rate,
         crash_count=crash_count,
-        **kwargs,  # type: ignore[arg-type]
+        **kwargs,
     )
 
 
-def _make_meta(**kwargs: object) -> FTRunMeta:
+def _make_meta(**kwargs: Any) -> FTRunMeta:
     return FTRunMeta(
-        run_id=kwargs.get("run_id", "test-run"),  # type: ignore[arg-type]
-        timestamp=kwargs.get("timestamp", "2026-01-15T12:00:00"),  # type: ignore[arg-type]
-        python_profile=kwargs.get(  # type: ignore[arg-type]
+        run_id=kwargs.get("run_id", "test-run"),
+        timestamp=kwargs.get("timestamp", "2026-01-15T12:00:00"),
+        python_profile=kwargs.get(
             "python_profile",
             {"version": "3.14.0b2", "gil_disabled": True, "implementation": "cpython"},
         ),
-        system_profile=kwargs.get(  # type: ignore[arg-type]
+        system_profile=kwargs.get(
             "system_profile",
             {"cpu_model": "AMD Ryzen 9", "ram_total_gb": 64, "os_distro": "Ubuntu 24.04"},
         ),
-        config=kwargs.get("config", {"iterations": 10}),  # type: ignore[arg-type]
+        config=kwargs.get("config", {"iterations": 10}),
     )
 
 

--- a/tests/test_ft_results.py
+++ b/tests/test_ft_results.py
@@ -269,8 +269,8 @@ class TestFTPackageResult(unittest.TestCase):
             gil_enabled_iterations=gil_iters,
         )
         result.compute_aggregates()
-        self.assertIsNotNone(result.gil_enabled_pass_rate)
-        self.assertAlmostEqual(result.gil_enabled_pass_rate, 0.8)  # type: ignore[arg-type]
+        assert result.gil_enabled_pass_rate is not None
+        self.assertAlmostEqual(result.gil_enabled_pass_rate, 0.8)
 
     def test_serialization_roundtrip(self) -> None:
         result = FTPackageResult(

--- a/tests/test_ft_runner.py
+++ b/tests/test_ft_runner.py
@@ -8,6 +8,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from labeille.ft.results import FailureCategory, IterationOutcome
@@ -384,12 +385,12 @@ class TestRunPackageFt(unittest.TestCase):
         defaults.update(overrides)
         return SimpleNamespace(**defaults)
 
-    def _make_config(self, **overrides: object) -> FTRunConfig:
+    def _make_config(self, **overrides: Any) -> FTRunConfig:
         """Create a test config with real tmp paths."""
         import tempfile
 
         tmpdir = Path(tempfile.mkdtemp())
-        defaults: dict[str, object] = {
+        defaults: dict[str, Any] = {
             "target_python": Path("/fake/python"),
             "iterations": 3,
             "timeout": 60,
@@ -402,7 +403,7 @@ class TestRunPackageFt(unittest.TestCase):
             "stop_on_first_pass": False,
         }
         defaults.update(overrides)
-        return FTRunConfig(**defaults)  # type: ignore[arg-type]
+        return FTRunConfig(**defaults)
 
     @patch("labeille.ft.runner.clone_repo")
     def test_run_package_clone_failure(self, mock_clone: MagicMock) -> None:
@@ -733,11 +734,11 @@ class TestRunPackageFtWheelTrust(unittest.TestCase):
         defaults.update(overrides)
         return SimpleNamespace(**defaults)
 
-    def _make_config(self, **overrides: object) -> FTRunConfig:
+    def _make_config(self, **overrides: Any) -> FTRunConfig:
         import tempfile
 
         tmpdir = Path(tempfile.mkdtemp())
-        defaults: dict[str, object] = {
+        defaults: dict[str, Any] = {
             "target_python": Path("/fake/python"),
             "iterations": 3,
             "timeout": 60,
@@ -750,7 +751,7 @@ class TestRunPackageFtWheelTrust(unittest.TestCase):
             "stop_on_first_pass": False,
         }
         defaults.update(overrides)
-        return FTRunConfig(**defaults)  # type: ignore[arg-type]
+        return FTRunConfig(**defaults)
 
     @patch("labeille.ft.runner.install_package")
     @patch("labeille.ft.runner.create_venv")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -29,7 +30,7 @@ class TestVersionCommand(unittest.TestCase):
         self.assertIn(__version__, result.output)
 
 
-def _fake_pypi_metadata(name: str) -> dict:  # type: ignore[type-arg]
+def _fake_pypi_metadata(name: str) -> dict[str, Any]:
     """Return minimal PyPI-like metadata for mocked fetch calls."""
     return {
         "info": {


### PR DESCRIPTION
## Summary
- Type builder kwargs as `Any` instead of `object` across 10 test files (fixes 32 arg-type suppressions)
- Use `assert x is not None` for mypy type narrowing (fixes 10 union-attr)
- Add explicit generic parameters and proper return types (fixes 2 type-arg, 8 arg-type)
- Type mock parameters as `MagicMock` instead of `object` (fixes 13 attr-defined)
- Remaining 2 markers are inherent `assignment` suppressions for monkey-patching methods

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (49 files)
- [x] ruff format + check clean
- [x] type:ignore count: 59 → 2

Closes #138

Generated with [Claude Code](https://claude.com/claude-code)