### PR TITLE
fix: narrow 3 silent exception handlers in ft/compat.py and registry.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Removed 12 unused `log = get_logger(...)` variables and their imports from modules that had logger scaffolding but no log calls.
 
 ### Fixed
+- Narrowed 3 bare `except Exception` handlers: `ft/compat.py` GIL probe (to `ImportError, OSError, AttributeError`), submodule import loop (to `ImportError, OSError`), and `registry.py` schema parsing (to `yaml.YAMLError, OSError`). Programming errors now propagate instead of being silently swallowed.
 - `bench/timing.py` now sanitizes subprocess environment via `clean_env()`, preventing PYTHONHOME/PYTHONPATH pollution in benchmark runs.
 - `ft/runner.py` now uses `start_new_session=True` instead of deprecated `preexec_fn=os.setpgrp`, fixing a thread-safety hazard with `ThreadPoolExecutor`.
 - Top-level error handlers in `runner.py`, `ft/runner.py`, and `resolve.py` now preserve tracebacks via `exc_info=True`.

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -225,7 +225,7 @@ def probe_package(package_name):
                 to_check.append(modname)
                 if len(to_check) > 200:  # Safety limit.
                     break
-        except Exception:
+        except (ImportError, OSError, AttributeError):
             pass
 
     for modname in to_check:
@@ -242,7 +242,7 @@ def probe_package(package_name):
                     "is_extension": True,
                     "file": filepath,
                 })
-        except Exception:
+        except (ImportError, OSError):
             pass  # Some submodules may not be importable.
 
     print(json.dumps(result))

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -70,7 +70,7 @@ def check_registry_schema(registry_path: Path) -> None:
 
     try:
         data = yaml.safe_load(schema_file.read_text(encoding="utf-8"))
-    except Exception:
+    except (yaml.YAMLError, OSError):
         log.warning("Could not parse schema.yaml in %s", registry_path)
         return
 


### PR DESCRIPTION
## Summary
- Narrow `except Exception: pass` in ft/compat.py GIL probe to `(ImportError, OSError, AttributeError)`
- Narrow `except Exception: pass` in ft/compat.py submodule import loop to `(ImportError, OSError)`
- Narrow `except Exception:` in registry.py schema parsing to `(yaml.YAMLError, OSError)`

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (49 files)
- [x] ruff format + check clean

Closes #142

Generated with [Claude Code](https://claude.com/claude-code)