### PR TITLE
refactor: extract shared kill_process_group into io_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - All documentation updated to reflect the split. Enrichment docs now live in laruche.
 
 ### Enhanced
+- Extracted shared `kill_process_group()` into `io_utils.py`, replacing 3 independent implementations in `runner.py`, `bench/timing.py`, and `ft/runner.py`. The FT runner now correctly uses `os.getpgid()` and `signal.SIGKILL` instead of raw `os.killpg(pid, 9)`.
 - Extracted `_build_bench_config()` helper from `bench_cli.run`, reducing the command body from ~130 lines to ~15 lines. Organized 35 Click options into labeled sections (profile, execution, package selection, paths, stability, adaptive, advanced).
 - Added `utc_now_iso()` helper to `io_utils.py`, unifying 15+ timestamp generation sites across 8 modules to a single canonical UTC format with Z suffix.
 - Registry `save_index()` and `save_package()` now use `atomic_write_text()` for crash-safe writes, preventing corruption of the most sensitive files.

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from labeille.io_utils import kill_process_group
 from labeille.logging import get_logger
 
 log = get_logger("bench.timing")
@@ -117,7 +118,7 @@ def run_timed(
         exit_code = proc.returncode
     except subprocess.TimeoutExpired:
         timed_out = True
-        _kill_process_group(proc.pid)
+        kill_process_group(proc.pid)
         try:
             stdout, stderr = proc.communicate(timeout=5)
         except subprocess.TimeoutExpired:
@@ -146,16 +147,6 @@ def run_timed(
         stderr=stderr,
         timed_out=timed_out,
     )
-
-
-def _kill_process_group(pid: int) -> None:
-    """Attempt to kill the entire process group on timeout."""
-    import signal
-
-    try:
-        os.killpg(os.getpgid(pid), signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
-        pass
 
 
 def _extract_peak_rss(

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -8,7 +8,6 @@ to isolate free-threading-specific failures.
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys
@@ -30,7 +29,7 @@ from labeille.ft.results import (
     append_ft_result,
     save_ft_run,
 )
-from labeille.io_utils import utc_now_iso
+from labeille.io_utils import kill_process_group, utc_now_iso
 from labeille.logging import get_logger
 from labeille.resolve import fetch_pypi_metadata
 from labeille.runner import (
@@ -388,18 +387,12 @@ def run_single_iteration(
             elapsed = time.monotonic() - start_time
             if elapsed > timeout:
                 is_deadlocked = monitor.stalled
-                try:
-                    os.killpg(proc.pid, 9)
-                except OSError:
-                    proc.kill()
+                kill_process_group(proc.pid)
                 break
             time.sleep(0.5)
     except OSError as exc:
         log.debug("Process monitoring interrupted: %s", exc)
-        try:
-            os.killpg(proc.pid, 9)
-        except OSError:
-            proc.kill()
+        kill_process_group(proc.pid)
 
     reader_thread.join(timeout=5)
     stdout_thread.join(timeout=5)

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -1,9 +1,10 @@
-"""Shared file I/O utilities."""
+"""Shared file I/O and process utilities."""
 
 from __future__ import annotations
 
 import json
 import os
+import signal
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -87,3 +88,19 @@ def append_jsonl(path: Path, obj: dict[str, Any]) -> None:
     """Append a single JSON object as a line to a JSONL file."""
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(obj) + "\n")
+
+
+def kill_process_group(pid: int) -> None:
+    """Kill an entire process group by PID.
+
+    Resolves the process group ID via ``os.getpgid`` and sends SIGKILL to
+    the entire group.  Silently ignores errors if the process has already
+    exited or cannot be killed (e.g. permission denied).
+
+    Use with subprocesses started via ``start_new_session=True``.
+    """
+    try:
+        pgid = os.getpgid(pid)
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from labeille.crash import detect_crash
-from labeille.io_utils import append_jsonl, utc_now_iso, write_meta_json
+from labeille.io_utils import append_jsonl, kill_process_group, utc_now_iso, write_meta_json
 from labeille.logging import get_logger
 from labeille.registry import Index, PackageEntry, load_index, load_package, package_exists
 
@@ -343,8 +343,6 @@ def _run_in_process_group(
             The exception's ``stdout`` and ``stderr`` attributes contain any
             partial output captured before the timeout.
     """
-    import signal as signal_module
-
     proc = subprocess.Popen(
         cmd,
         shell=True,
@@ -359,13 +357,7 @@ def _run_in_process_group(
         stdout, stderr = proc.communicate(timeout=timeout)
         return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
     except subprocess.TimeoutExpired:
-        # Kill the entire process group.
-        try:
-            pgid = os.getpgid(proc.pid)
-            os.killpg(pgid, signal_module.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
-            # Process already exited or we can't kill it.
-            pass
+        kill_process_group(proc.pid)
         # Wait for the process to actually terminate and collect output.
         try:
             stdout, stderr = proc.communicate(timeout=5)

--- a/tests/test_ft_runner.py
+++ b/tests/test_ft_runner.py
@@ -202,12 +202,9 @@ class TestRunSingleIteration(unittest.TestCase):
         proc.stderr = iter(stderr.splitlines(True))
         return proc
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
     @patch("labeille.ft.runner.time.sleep")
-    def test_iteration_pass(
-        self, mock_sleep: MagicMock, mock_popen: MagicMock, mock_setpgrp: MagicMock
-    ) -> None:
+    def test_iteration_pass(self, mock_sleep: MagicMock, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(
             returncode=0,
             stdout="tests/test_foo.py::test_bar PASSED\n======= 1 passed in 0.5s =======\n",
@@ -227,12 +224,9 @@ class TestRunSingleIteration(unittest.TestCase):
         self.assertEqual(result.status, "pass")
         self.assertEqual(result.exit_code, 0)
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
     @patch("labeille.ft.runner.time.sleep")
-    def test_iteration_fail(
-        self, mock_sleep: MagicMock, mock_popen: MagicMock, mock_setpgrp: MagicMock
-    ) -> None:
+    def test_iteration_fail(self, mock_sleep: MagicMock, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(returncode=1, stdout="1 failed\n")
         mock_popen.return_value = proc
 
@@ -250,12 +244,9 @@ class TestRunSingleIteration(unittest.TestCase):
         self.assertEqual(result.status, "fail")
         self.assertEqual(result.exit_code, 1)
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
     @patch("labeille.ft.runner.time.sleep")
-    def test_iteration_crash(
-        self, mock_sleep: MagicMock, mock_popen: MagicMock, mock_setpgrp: MagicMock
-    ) -> None:
+    def test_iteration_crash(self, mock_sleep: MagicMock, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(returncode=-11, stderr="Segmentation fault\n")
         mock_popen.return_value = proc
 
@@ -272,9 +263,8 @@ class TestRunSingleIteration(unittest.TestCase):
         self.assertEqual(result.status, "crash")
         self.assertEqual(result.crash_signal, "SIGSEGV")
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
-    def test_iteration_tsan_warnings(self, mock_popen: MagicMock, mock_setpgrp: MagicMock) -> None:
+    def test_iteration_tsan_warnings(self, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(
             returncode=0,
             stderr="WARNING: ThreadSanitizer: data race (pid=123)\n",
@@ -296,11 +286,8 @@ class TestRunSingleIteration(unittest.TestCase):
         self.assertEqual(result.status, "pass")
         self.assertEqual(result.tsan_warnings, ["data race"])
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
-    def test_iteration_tsan_not_parsed_when_disabled(
-        self, mock_popen: MagicMock, mock_setpgrp: MagicMock
-    ) -> None:
+    def test_iteration_tsan_not_parsed_when_disabled(self, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(
             returncode=0,
             stderr="WARNING: ThreadSanitizer: data race (pid=123)\n",
@@ -321,11 +308,8 @@ class TestRunSingleIteration(unittest.TestCase):
 
         self.assertEqual(result.tsan_warnings, [])
 
-    @patch("labeille.ft.runner.os.setpgrp")
     @patch("labeille.ft.runner.subprocess.Popen")
-    def test_iteration_pytest_results_parsed(
-        self, mock_popen: MagicMock, mock_setpgrp: MagicMock
-    ) -> None:
+    def test_iteration_pytest_results_parsed(self, mock_popen: MagicMock) -> None:
         proc = self._make_mock_proc(
             returncode=0,
             stdout=(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -222,8 +222,8 @@ class TestRunInProcessGroup(unittest.TestCase):
         _, kwargs = mock_popen.call_args
         self.assertTrue(kwargs["start_new_session"])
 
-    @patch("labeille.runner.os.killpg")
-    @patch("labeille.runner.os.getpgid")
+    @patch("labeille.io_utils.os.killpg")
+    @patch("labeille.io_utils.os.getpgid")
     @patch("labeille.runner.subprocess.Popen")
     def test_timeout_kills_process_group(
         self, mock_popen: Any, mock_getpgid: Any, mock_killpg: Any
@@ -246,8 +246,8 @@ class TestRunInProcessGroup(unittest.TestCase):
         self.assertEqual(exc.output, "partial out")
         self.assertEqual(exc.stderr, "partial err")
 
-    @patch("labeille.runner.os.killpg")
-    @patch("labeille.runner.os.getpgid")
+    @patch("labeille.io_utils.os.killpg")
+    @patch("labeille.io_utils.os.getpgid")
     @patch("labeille.runner.subprocess.Popen")
     def test_timeout_process_already_exited(
         self, mock_popen: Any, mock_getpgid: Any, mock_killpg: Any
@@ -266,8 +266,8 @@ class TestRunInProcessGroup(unittest.TestCase):
         with self.assertRaises(subprocess.TimeoutExpired):
             _run_in_process_group("cmd", cwd="/tmp", env={}, timeout=30)
 
-    @patch("labeille.runner.os.killpg")
-    @patch("labeille.runner.os.getpgid")
+    @patch("labeille.io_utils.os.killpg")
+    @patch("labeille.io_utils.os.getpgid")
     @patch("labeille.runner.subprocess.Popen")
     def test_timeout_partial_output_in_exception(
         self, mock_popen: Any, mock_getpgid: Any, mock_killpg: Any
@@ -288,8 +288,8 @@ class TestRunInProcessGroup(unittest.TestCase):
         self.assertEqual(cm.exception.output, "partial stdout")
         self.assertEqual(cm.exception.stderr, "partial stderr")
 
-    @patch("labeille.runner.os.killpg")
-    @patch("labeille.runner.os.getpgid")
+    @patch("labeille.io_utils.os.killpg")
+    @patch("labeille.io_utils.os.getpgid")
     @patch("labeille.runner.subprocess.Popen")
     def test_timeout_second_communicate_also_times_out(
         self, mock_popen: Any, mock_getpgid: Any, mock_killpg: Any


### PR DESCRIPTION
## Summary
- Extract `kill_process_group(pid)` into `io_utils.py`, replacing 3 independent implementations in `runner.py`, `bench/timing.py`, and `ft/runner.py`
- Fix ft/runner.py: now uses `os.getpgid()` and `signal.SIGKILL` instead of raw `os.killpg(pid, 9)`
- Remove 6 stale `os.setpgrp` mocks from `test_ft_runner.py` (vestigial from `preexec_fn` era)

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (49 files)
- [x] ruff format + check clean

Closes #144

Generated with [Claude Code](https://claude.com/claude-code)