### PR TITLE
refactor: add Literal types to 6 string-constrained fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - All documentation updated to reflect the split. Enrichment docs now live in laruche.
 
 ### Enhanced
+- Added `Literal` types to 6 string-constrained fields: `IterationOutcome.status`, `RunnerConfig.installer`/`install_from`, `PackageEntry.extension_type`/`install_method`/`test_framework`. Mypy now catches invalid values at type-check time.
 - Extracted shared `kill_process_group()` into `io_utils.py`, replacing 3 independent implementations in `runner.py`, `bench/timing.py`, and `ft/runner.py`. The FT runner now correctly uses `os.getpgid()` and `signal.SIGKILL` instead of raw `os.killpg(pid, 9)`.
 - Extracted `_build_bench_config()` helper from `bench_cli.run`, reducing the command body from ~130 lines to ~15 lines. Organized 35 Click options into labeled sections (profile, execution, package selection, paths, stability, adaptive, advanced).
 - Added `utc_now_iso()` helper to `io_utils.py`, unifying 15+ timestamp generation sites across 8 modules to a single canonical UTC format with Z suffix.

--- a/src/labeille/classifier.py
+++ b/src/labeille/classifier.py
@@ -10,7 +10,7 @@ native code interactions.
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, Literal
 
 
 # Patterns that indicate a platform-specific (native extension) wheel.
@@ -19,7 +19,7 @@ _PLATFORM_INDICATORS = re.compile(
 )
 
 
-def classify_from_urls(urls: list[dict[str, Any]]) -> str:
+def classify_from_urls(urls: list[dict[str, Any]]) -> Literal["pure", "extensions", "unknown"]:
     """Classify a package from its PyPI ``urls`` array.
 
     Examines the distribution files for the *latest* version to determine

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -437,8 +437,8 @@ def run_cmd(
         test_command_override=test_command_override,
         test_command_suffix=test_command_suffix,
         repo_overrides=repo_overrides,
-        installer=installer,
-        install_from=install_from,
+        installer=installer,  # type: ignore[arg-type]  # Click Choice returns str
+        install_from=install_from,  # type: ignore[arg-type]  # Click Choice returns str
     )
 
     click.echo(f"Run ID: {run_id}")

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -17,7 +17,7 @@ import enum
 import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from labeille.io_utils import append_jsonl, load_jsonl, write_meta_json
 from labeille.logging import get_logger
@@ -100,7 +100,7 @@ class IterationOutcome:
     """
 
     index: int
-    status: str  # pass, fail, crash, timeout, deadlock
+    status: Literal["pass", "fail", "crash", "timeout", "deadlock"]
     exit_code: int | None = None
     duration_s: float = 0.0
     crash_signal: str | None = None

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -16,7 +16,7 @@ import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from labeille.classifier import has_ft_wheel
 from labeille.crash import detect_crash
@@ -418,6 +418,7 @@ def run_single_iteration(
             stderr_tail=monitor.stderr_tail,
         )
 
+    status: Literal["pass", "fail", "crash", "timeout", "deadlock"]
     if exit_code is None or (duration >= timeout and exit_code in (None, -9, 137)):
         status = "deadlock" if is_deadlocked else "timeout"
         return IterationOutcome(

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
@@ -110,12 +110,12 @@ class PackageEntry:
     package: str
     repo: str | None = None
     pypi_url: str = ""
-    extension_type: str = "unknown"  # pure | extensions | unknown
+    extension_type: Literal["pure", "extensions", "unknown"] = "unknown"
     python_versions: list[str] = field(default_factory=list)
-    install_method: str = "pip"  # pip | pip-extras | custom
+    install_method: Literal["pip", "pip-extras", "custom"] = "pip"
     install_command: str = ""
     test_command: str = ""
-    test_framework: str = "pytest"  # pytest | unittest | custom
+    test_framework: Literal["pytest", "unittest", "custom"] = "pytest"
     uses_xdist: bool = False
     timeout: int | None = None
     skip: bool = False

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -547,6 +547,7 @@ _KNOWN_FIELDS = {f.name for f in dataclass_fields(PackageEntry)}
 def _build_field_types() -> dict[str, type | tuple[type, ...]]:
     """Derive expected YAML types from PackageEntry field annotations."""
     import types as _types
+    from typing import Literal, get_origin
 
     mapping: dict[str, type | tuple[type, ...]] = {}
     hints = get_type_hints(PackageEntry, include_extras=True)
@@ -558,6 +559,9 @@ def _build_field_types() -> dict[str, type | tuple[type, ...]]:
             mapping[f.name] = list
         elif origin is dict:
             mapping[f.name] = dict
+        # Literal["x", "y"] → str (all our Literals are string-valued)
+        elif get_origin(ann) is Literal:
+            mapping[f.name] = str
         # str | None  (types.UnionType on 3.10+)
         elif isinstance(ann, _types.UnionType):
             non_none = [t for t in ann.__args__ if t is not _types.NoneType]

--- a/src/labeille/resolve.py
+++ b/src/labeille/resolve.py
@@ -163,7 +163,7 @@ class ResolveResult:
 
     name: str
     repo_url: str | None = None
-    extension_type: str = "unknown"
+    extension_type: Literal["pure", "extensions", "unknown"] = "unknown"
     action: Literal["created", "updated", "skipped", "skipped_enriched", "failed"] = "skipped"
     error: str | None = None
 

--- a/src/labeille/runner_models.py
+++ b/src/labeille/runner_models.py
@@ -61,8 +61,8 @@ class RunnerConfig:
     test_command_override: str | None = None
     test_command_suffix: str | None = None
     repo_overrides: dict[str, str] = field(default_factory=dict)
-    installer: str = "auto"  # auto | uv | pip
-    install_from: str = "source"  # source | sdist
+    installer: Literal["auto", "uv", "pip"] = "auto"
+    install_from: Literal["source", "sdist"] = "source"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `Literal` types to `IterationOutcome.status`, `RunnerConfig.installer`/`install_from`, `PackageEntry.extension_type`/`install_method`/`test_framework`
- Update `classify_from_urls` return type and `ResolveResult.extension_type` to match
- Fix `_build_field_types` in `registry_ops.py` to handle `Literal` annotations for validation

## Test plan
- [x] All 1981 tests pass
- [x] mypy strict clean (49 files)
- [x] ruff format + check clean

Closes #146

Generated with [Claude Code](https://claude.com/claude-code)