### PR TITLE
refactor: use setup_logging() in bench_cli and ft_cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Enhanced
+- `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
+
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.
 

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -10,7 +10,6 @@ Subcommands:
 
 from __future__ import annotations
 
-import logging
 import sys
 from pathlib import Path
 from typing import Any
@@ -18,6 +17,7 @@ from typing import Any
 import click
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
+from labeille.logging import setup_logging
 
 
 @click.group()
@@ -464,10 +464,7 @@ def run(  # noqa: PLR0913
         # Quick mode for development
         labeille bench run --profile bench-jit.yaml --quick
     """
-    if verbose:
-        logging.basicConfig(level=logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.INFO, format="%(message)s")
+    setup_logging(verbose=verbose)
 
     config = _build_bench_config(locals())
 

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -176,7 +176,10 @@ def run(
             --tsan --iterations 5
     """
     from labeille.ft.runner import FTRunConfig, run_ft
+    from labeille.logging import setup_logging
     from labeille.registry import default_registry_dir
+
+    setup_logging(verbose=verbose)
 
     if registry_dir is None:
         registry_dir = default_registry_dir()


### PR DESCRIPTION
## Summary
- Replace `logging.basicConfig()` in `bench_cli.py` with shared `setup_logging()` for consistent log formatting
- Add `setup_logging(verbose=verbose)` to `ft_cli.py` which had no logging setup despite accepting `--verbose`

## Test plan
- [x] All 2007 tests pass
- [x] ruff format/check clean
- [x] mypy strict clean

Closes #150

Generated with [Claude Code](https://claude.com/claude-code)