### PR TITLE
refactor: type pkg: Any params as PackageEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Enhanced
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 
+### Fixed
+- Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.
+- Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
+
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.
 

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -23,7 +23,11 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from labeille.bench.results import ConditionDef
+    from labeille.registry import PackageEntry
 
 from labeille.bench.config import (
     BenchConfig,
@@ -284,7 +288,7 @@ class BenchRunner:
         self._results = results
         return meta, results
 
-    def _load_packages(self) -> list[Any]:
+    def _load_packages(self) -> list[PackageEntry]:
         """Load package entries from the registry.
 
         Applies package filters and top_n selection.
@@ -458,7 +462,7 @@ class BenchRunner:
 
     def _benchmark_package(
         self,
-        pkg: Any,
+        pkg: PackageEntry,
         pkg_idx: int,
         pkg_total: int,
     ) -> BenchPackageResult:
@@ -584,7 +588,7 @@ class BenchRunner:
 
         return pkg_result
 
-    def _setup_package(self, pkg: Any) -> dict[str, Any] | None:
+    def _setup_package(self, pkg: PackageEntry) -> dict[str, Any] | None:
         """Clone repo and create venvs for all conditions.
 
         Returns a setup dict with repo_dir, venvs, and durations.
@@ -615,8 +619,10 @@ class BenchRunner:
                 from labeille.runner import pull_repo
 
                 pull_repo(repo_dir)
-            else:
+            elif pkg.repo:
                 clone_repo(pkg.repo, repo_dir)
+            else:
+                raise OSError(f"No repo URL for {pkg.package}")
         except (OSError, subprocess.SubprocessError) as exc:
             log.error("Failed to clone %s: %s", pkg.package, exc)
             return None
@@ -717,8 +723,8 @@ class BenchRunner:
     def _run_iteration(
         self,
         *,
-        pkg: Any,
-        cond: Any,
+        pkg: PackageEntry,
+        cond: ConditionDef,
         setup: dict[str, Any],
         iter_index: int,
         is_warmup: bool,

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -16,7 +16,10 @@ import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from labeille.registry import Index, PackageEntry
 
 from labeille.classifier import has_ft_wheel
 from labeille.crash import detect_crash
@@ -464,7 +467,7 @@ def run_single_iteration(
 
 
 def _check_ft_wheel_trust(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
 ) -> tuple[bool, dict[str, Any] | None]:
@@ -514,7 +517,7 @@ def _check_ft_wheel_trust(
 
 
 def _clone_and_align_ft(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     repo_dir: Path,
@@ -529,8 +532,10 @@ def _clone_and_align_ft(
     try:
         if repo_dir.exists():
             pull_repo(repo_dir)
-        else:
+        elif pkg.repo:
             clone_repo(pkg.repo, repo_dir)
+        else:
+            raise OSError(f"No repo URL for {pkg.package}")
     except (OSError, subprocess.SubprocessError) as exc:
         log.error("Failed to clone/pull %s: %s", pkg.package, exc)
         result.install_ok = False
@@ -596,7 +601,7 @@ def _clone_and_align_ft(
 
 
 def _create_venv_and_install_ft(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     repo_dir: Path,
@@ -645,7 +650,7 @@ def _create_venv_and_install_ft(
 
 
 def _install_sdist_mode(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     repo_dir: Path,
@@ -687,7 +692,7 @@ def _install_sdist_mode(
 
 
 def _install_source_mode(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     repo_dir: Path,
@@ -720,7 +725,7 @@ def _install_source_mode(
 
 
 def _run_ft_iterations(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     venv_python: Path,
@@ -766,7 +771,7 @@ def _run_ft_iterations(
 
 
 def _run_gil_comparison(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
     result: FTPackageResult,
     venv_python: Path,
@@ -817,7 +822,7 @@ def _run_gil_comparison(
 
 
 def run_package_ft(
-    pkg: Any,
+    pkg: PackageEntry,
     config: FTRunConfig,
 ) -> FTPackageResult:
     """Run free-threading tests for a single package.
@@ -1075,7 +1080,7 @@ def run_ft(config: FTRunConfig) -> list[FTPackageResult]:
     return results
 
 
-def _select_packages(index: Any, config: FTRunConfig) -> list[Any]:
+def _select_packages(index: Index, config: FTRunConfig) -> list[PackageEntry]:
     """Select and filter packages from the registry index.
 
     Applies --packages filter, --top N, and skips packages with
@@ -1091,10 +1096,10 @@ def _select_packages(index: Any, config: FTRunConfig) -> list[Any]:
         if entry.skip:
             continue
         try:
-            pkg = load_package(entry.package, config.registry_dir)
+            pkg = load_package(entry.name, config.registry_dir)
             packages.append(pkg)
         except (OSError, ValueError, KeyError) as exc:
-            log.warning("Could not load package %s, skipping: %s", entry.package, exc)
+            log.warning("Could not load package %s, skipping: %s", entry.name, exc)
 
     if config.packages_filter:
         names = set(config.packages_filter)


### PR DESCRIPTION
## Summary
- Replace ~12 `pkg: Any` with `PackageEntry` and `cond: Any` with `ConditionDef` in `bench/runner.py` and `ft/runner.py`
- Fix latent bug: `entry.package` should be `entry.name` in `ft/runner.py:_select_packages` (masked by `Any` typing)
- Add guards for `pkg.repo` being `None` before calling `clone_repo()`

## Test plan
- [x] All 2007 tests pass
- [x] ruff format/check clean
- [x] mypy strict clean (was 0 errors before and after)

Closes #152

Generated with [Claude Code](https://claude.com/claude-code)