### PR TITLE
refactor: rename compat diff to compat compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Enhanced
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import_and_extras`.
+- Rename `compat diff` to `compat compare` for CLI vocabulary consistency.
 
 ### Fixed
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.

--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ labeille compat survey --target-python ~/cpython-315/python \
 labeille compat survey --target-python ~/cpython-315/python \
     --packages numpy,scipy,pandas --from source
 
-# View results, diff two surveys
+# View results, compare two surveys
 labeille compat show compat-results/compat_*
-labeille compat diff compat-results/compat_314 compat-results/compat_315
+labeille compat compare compat-results/compat_314 compat-results/compat_315
 ```
 
 Key features: three build modes (sdist, git source, `--no-binary :all:`), 40+

--- a/doc/compat.md
+++ b/doc/compat.md
@@ -50,7 +50,7 @@ labeille compat survey \
 labeille compat show results/compat_20260303
 
 # Compare two surveys (e.g., Python 3.14 vs 3.15)
-labeille compat diff results/compat_314 results/compat_315
+labeille compat compare results/compat_314 results/compat_315
 ```
 
 
@@ -208,7 +208,7 @@ labeille compat patterns --extra-patterns my-patterns.yaml
 Compare two surveys to track compatibility changes:
 
 ```bash
-labeille compat diff results/compat_314 results/compat_315
+labeille compat compare results/compat_314 results/compat_315
 ```
 
 Shows:
@@ -303,8 +303,8 @@ labeille compat survey \
     --packages-file c-ext-packages.txt \
     --output-dir compat-315
 
-# Diff: what changed?
-labeille compat diff compat-314/compat_* compat-315/compat_*
+# Compare: what changed?
+labeille compat compare compat-314/compat_* compat-315/compat_*
 ```
 
 ### Source mode for unreleased code

--- a/src/labeille/compat_cli.py
+++ b/src/labeille/compat_cli.py
@@ -3,7 +3,7 @@
 Subcommands:
     labeille compat survey    Run a C extension compatibility survey
     labeille compat show      Display results from a saved survey
-    labeille compat diff      Compare two surveys
+    labeille compat compare   Compare two surveys
     labeille compat patterns  List built-in error classification patterns
 """
 
@@ -296,14 +296,14 @@ def show(
 
 
 # ---------------------------------------------------------------------------
-# compat diff
+# compat compare
 # ---------------------------------------------------------------------------
 
 
 @compat.command()
 @click.argument("survey_a", type=click.Path(exists=True, path_type=Path))
 @click.argument("survey_b", type=click.Path(exists=True, path_type=Path))
-def diff(survey_a: Path, survey_b: Path) -> None:
+def compare(survey_a: Path, survey_b: Path) -> None:
     """Compare two compatibility surveys (A = baseline, B = new)."""
     from labeille.compat import (
         diff_surveys,

--- a/tests/test_compat_cli.py
+++ b/tests/test_compat_cli.py
@@ -23,7 +23,7 @@ class TestCompatCLIGroup(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("survey", result.output)
         self.assertIn("show", result.output)
-        self.assertIn("diff", result.output)
+        self.assertIn("compare", result.output)
         self.assertIn("patterns", result.output)
 
 
@@ -223,12 +223,12 @@ class TestShowCommand(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# compat diff
+# compat compare
 # ---------------------------------------------------------------------------
 
 
-class TestDiffCommand(unittest.TestCase):
-    """Tests for compat diff command."""
+class TestCompareCommand(unittest.TestCase):
+    """Tests for compat compare command."""
 
     def _create_survey_dir(self, tmpdir: str, sid: str, results: list[dict[str, Any]]) -> str:
         survey_dir = Path(tmpdir) / sid
@@ -251,16 +251,16 @@ class TestDiffCommand(unittest.TestCase):
         )
         return str(survey_dir)
 
-    def test_diff_no_changes(self) -> None:
+    def test_compare_no_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             a = self._create_survey_dir(tmpdir, "a", [{"package": "x", "status": "build_ok"}])
             b = self._create_survey_dir(tmpdir, "b", [{"package": "x", "status": "build_ok"}])
             runner = CliRunner()
-            result = runner.invoke(compat, ["diff", a, b])
+            result = runner.invoke(compat, ["compare", a, b])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("No differences found", result.output)
 
-    def test_diff_with_regression(self) -> None:
+    def test_compare_with_regression(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             a = self._create_survey_dir(tmpdir, "a", [{"package": "x", "status": "build_ok"}])
             b = self._create_survey_dir(
@@ -269,7 +269,7 @@ class TestDiffCommand(unittest.TestCase):
                 [{"package": "x", "status": "build_fail", "primary_category": "removed_c_api"}],
             )
             runner = CliRunner()
-            result = runner.invoke(compat, ["diff", a, b])
+            result = runner.invoke(compat, ["compare", a, b])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("1 regressions", result.output)
 


### PR DESCRIPTION
## Summary
- Rename `compat diff` CLI command to `compat compare` for vocabulary consistency with `bench compare` and `analyze compare`
- Update tests, docs (README.md, doc/compat.md) to use new command name
- Internal function names (`diff_surveys`, `format_compat_diff`) unchanged

## Test plan
- [x] All 2007 tests pass
- [x] ruff format/check clean
- [x] mypy strict clean

Closes #156

Generated with [Claude Code](https://claude.com/claude-code)