### PR TITLE
refactor: standardize subprocess lifecycle and JSONL patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import_and_extras`.
 - Rename `compat diff` to `compat compare` for CLI vocabulary consistency.
+- Extract `run_in_process_group()` into `io_utils.py` as a shared subprocess lifecycle utility, used by both `runner.py` and `bench/timing.py`.
+- `bench/results.py` `append_package_result` now uses shared `append_jsonl` instead of raw `open()`.
 
 ### Fixed
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.
 - Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
+- Add missing `encoding="utf-8"` to `bench_cli.py` export `write_text()` call.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -29,7 +29,7 @@ from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.stats import DescriptiveStats, describe, detect_outliers
 from labeille.bench.system import PythonProfile, SystemProfile
 from labeille.bench.timing import PerTestTimings
-from labeille.io_utils import load_jsonl, write_meta_json
+from labeille.io_utils import append_jsonl, load_jsonl, write_meta_json
 from labeille.logging import get_logger
 
 log = get_logger("bench.results")
@@ -440,5 +440,4 @@ def append_package_result(
     Used for incremental writing during long benchmark runs so
     that results are preserved if the process is interrupted.
     """
-    with open(results_path, "a", encoding="utf-8") as f:
-        f.write(result.to_jsonl_line() + "\n")
+    append_jsonl(results_path, result.to_dict())

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from labeille.io_utils import kill_process_group
+from labeille.io_utils import run_in_process_group
 from labeille.logging import get_logger
 
 log = get_logger("bench.timing")
@@ -103,27 +103,14 @@ def run_timed(
     wall_start = time.monotonic()
 
     timed_out = False
-    proc = subprocess.Popen(
-        command if isinstance(command, list) else command,
-        shell=isinstance(command, str),
-        cwd=str(cwd) if cwd else None,
-        env=run_env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
     try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-        exit_code = proc.returncode
-    except subprocess.TimeoutExpired:
+        completed = run_in_process_group(command, cwd=cwd, env=run_env, timeout=timeout)
+        stdout, stderr = completed.stdout or "", completed.stderr or ""
+        exit_code = completed.returncode
+    except subprocess.TimeoutExpired as exc:
         timed_out = True
-        kill_process_group(proc.pid)
-        try:
-            stdout, stderr = proc.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            stdout, stderr = proc.communicate()
+        stdout = str(exc.stdout) if exc.stdout else ""
+        stderr = str(exc.stderr) if exc.stderr else ""
         exit_code = -1
 
     wall_time = time.monotonic() - wall_start

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -791,7 +791,7 @@ def export(result_dir: Path, fmt: str, output: Path | None) -> None:
         text = export_markdown(meta, results, anomaly_report=anomaly_report)
 
     if output:
-        output.write_text(text)
+        output.write_text(text, encoding="utf-8")
         click.echo(f"Exported to {output}")
     else:
         click.echo(text)

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -104,3 +105,53 @@ def kill_process_group(pid: int) -> None:
         os.killpg(pgid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError, OSError):
         pass
+
+
+def run_in_process_group(
+    cmd: str | list[str],
+    *,
+    cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command in its own process group with timeout enforcement.
+
+    On timeout, kills the entire process group (not just the immediate
+    child) to prevent orphaned grandchild processes from accumulating.
+
+    Args:
+        cmd: Shell command string or argument list.
+        cwd: Working directory.
+        env: Environment variables.
+        timeout: Timeout in seconds.
+
+    Returns:
+        A :class:`~subprocess.CompletedProcess` with stdout, stderr, and returncode.
+
+    Raises:
+        subprocess.TimeoutExpired: If the command exceeds the timeout.
+            The exception's ``stdout`` and ``stderr`` attributes contain any
+            partial output captured before the timeout.
+    """
+    shell = isinstance(cmd, str)
+    proc = subprocess.Popen(
+        cmd,
+        shell=shell,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+    except subprocess.TimeoutExpired:
+        kill_process_group(proc.pid)
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+        raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -29,7 +29,12 @@ from pathlib import Path
 from typing import Any
 
 from labeille.crash import detect_crash
-from labeille.io_utils import append_jsonl, kill_process_group, utc_now_iso, write_meta_json
+from labeille.io_utils import (
+    append_jsonl,
+    run_in_process_group,
+    utc_now_iso,
+    write_meta_json,
+)
 from labeille.logging import get_logger
 from labeille.registry import Index, PackageEntry, load_index, load_package, package_exists
 
@@ -326,45 +331,10 @@ def _run_in_process_group(
 ) -> subprocess.CompletedProcess[str]:
     """Run a command in its own process group.
 
-    On timeout, kills the entire process group (not just the immediate
-    child) to prevent orphaned grandchild processes from accumulating.
-
-    Args:
-        cmd: The shell command to run.
-        cwd: Working directory.
-        env: Environment variables.
-        timeout: Timeout in seconds.
-
-    Returns:
-        A :class:`~subprocess.CompletedProcess` with stdout, stderr, and returncode.
-
-    Raises:
-        subprocess.TimeoutExpired: If the command exceeds the timeout.
-            The exception's ``stdout`` and ``stderr`` attributes contain any
-            partial output captured before the timeout.
+    Thin wrapper around :func:`~labeille.io_utils.run_in_process_group`
+    preserving the existing call-site signatures.
     """
-    proc = subprocess.Popen(
-        cmd,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=cwd,
-        env=env,
-        start_new_session=True,
-    )
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-        return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
-    except subprocess.TimeoutExpired:
-        kill_process_group(proc.pid)
-        # Wait for the process to actually terminate and collect output.
-        try:
-            stdout, stderr = proc.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            stdout, stderr = proc.communicate()
-        raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
+    return run_in_process_group(cmd, cwd=cwd, env=env, timeout=timeout)
 
 
 def _rewrite_install_command(


### PR DESCRIPTION
## Summary
- Extract `run_in_process_group()` into `io_utils.py` as shared subprocess lifecycle utility (Popen + communicate + kill_process_group + fallback), replacing near-identical code in `runner.py` and `bench/timing.py`.
- Standardize `bench/results.py` `append_package_result` to use shared `append_jsonl` instead of raw `open()`.
- Fix missing `encoding="utf-8"` in `bench_cli.py` export `write_text()` call.

## Test plan
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy strict passes (0 errors)
- [x] All 2007 tests pass

Closes #158

Generated with [Claude Code](https://claude.com/claude-code)