### PR TITLE
fix: import check OSError now sets install_error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.
 - Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
 - Add missing `encoding="utf-8"` to `bench_cli.py` export `write_text()` call.
+- Import check `OSError` now sets `install_error` status instead of silently continuing.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -972,7 +972,10 @@ def _check_import_and_extras(
                 log.error("Import check timed out for %s", pkg.package)
                 return False
             except OSError as exc:
-                log.warning("Import check failed for %s: %s (continuing)", pkg.package, exc)
+                result.status = "install_error"
+                result.error_message = f"Import check OSError: {exc}"
+                log.error("Import check failed for %s: %s", pkg.package, exc)
+                return False
 
     if config.extra_deps and not venv_existed:
         extra_cmd = f"pip install {' '.join(config.extra_deps)}"


### PR DESCRIPTION
## Summary
- Fix silent error handling in `runner.py:_check_import_and_extras` where an `OSError` during import verification was caught but didn't set error status or return False, causing the test run to continue as if the import succeeded.

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes (0 errors)
- [x] All 2027 tests pass

Closes #162

Generated with [Claude Code](https://claude.com/claude-code)