### PR TITLE
refactor: extract shared CLI parsing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import`.
 - Split `_check_import_and_extras` into `_check_import` and `_install_extra_deps` for single-responsibility.
 - Rename `compat diff` to `compat compare` for CLI vocabulary consistency.
+- Extract `parse_env_pairs()` and `parse_csv_list()` CLI helpers to eliminate duplicated parsing across `cli.py`, `registry_cli.py`, `compat_cli.py`, `bench_cli.py`, and `ft_cli.py`.
 - Extract `run_in_process_group()` into `io_utils.py` as a shared subprocess lifecycle utility, used by both `runner.py` and `bench/timing.py`.
 - `bench/results.py` `append_package_result` now uses shared `append_jsonl` instead of raw `open()`.
 

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -17,6 +17,7 @@ from typing import Any
 import click
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
+from labeille.cli_utils import parse_csv_list
 from labeille.logging import setup_logging
 
 
@@ -98,9 +99,7 @@ def _build_bench_config(params: dict[str, Any]) -> Any:
         "wait_for_stability": wait_for_stability,
         "alternate": alternate,
         "interleave": interleave,
-        "packages_filter": (
-            [p.strip() for p in packages.split(",") if p.strip()] if packages else None
-        ),
+        "packages_filter": parse_csv_list(packages) or None,
         "top_n": top_n,
         "adaptive": adaptive or None,
         "adaptive_threshold": adaptive_threshold,
@@ -129,7 +128,7 @@ def _build_bench_config(params: dict[str, Any]) -> Any:
             config.venvs_dir = work_dir / "venvs"
         config.results_dir = results_dir
         if packages:
-            config.packages_filter = [p.strip() for p in packages.split(",") if p.strip()]
+            config.packages_filter = parse_csv_list(packages)
         if top_n:
             config.top_n = top_n
 
@@ -140,7 +139,7 @@ def _build_bench_config(params: dict[str, Any]) -> Any:
 
     # Apply shared options.
     if extra_deps:
-        config.default_extra_deps = [d.strip() for d in extra_deps.split(",") if d.strip()]
+        config.default_extra_deps = parse_csv_list(extra_deps)
     if test_command_suffix:
         config.default_test_command_suffix = test_command_suffix
 

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from labeille.scan_deps import ScanResult
 
 from labeille import __version__
+from labeille.cli_utils import parse_csv_list, parse_env_pairs
 from labeille.logging import setup_logging
 from labeille.resolve import (
     merge_inputs,
@@ -348,13 +349,7 @@ def run_cmd(
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Target Python: {python_version}")
 
-    # Parse env pairs.
-    env_overrides: dict[str, str] = {}
-    for pair in env_pairs:
-        if "=" not in pair:
-            raise click.UsageError(f"Invalid --env format (expected KEY=VALUE): {pair}")
-        key, _, value = pair.partition("=")
-        env_overrides[key] = value
+    env_overrides = parse_env_pairs(env_pairs)
 
     # Parse packages filter (supports name@revision syntax).
     packages_filter: list[str] | None = None
@@ -433,7 +428,7 @@ def run_cmd(
         cli_args=sys.argv[1:],
         clone_depth_override=effective_clone_depth,
         revision_overrides=revision_overrides,
-        extra_deps=[d.strip() for d in extra_deps.split(",") if d.strip()] if extra_deps else [],
+        extra_deps=parse_csv_list(extra_deps),
         test_command_override=test_command_override,
         test_command_suffix=test_command_suffix,
         repo_overrides=repo_overrides,
@@ -724,17 +719,8 @@ def bisect_cmd(
     if registry_dir is None:
         registry_dir = default_registry_dir()
 
-    # Parse env pairs.
-    env_overrides: dict[str, str] = {}
-    for pair in env_pairs:
-        if "=" not in pair:
-            raise click.UsageError(f"Invalid --env format (expected KEY=VALUE): {pair}")
-        key, _, value = pair.partition("=")
-        env_overrides[key] = value
-
-    parsed_extra_deps = (
-        [d.strip() for d in extra_deps.split(",") if d.strip()] if extra_deps else []
-    )
+    env_overrides = parse_env_pairs(env_pairs)
+    parsed_extra_deps = parse_csv_list(extra_deps)
 
     config = BisectConfig(
         package=package,

--- a/src/labeille/cli_utils.py
+++ b/src/labeille/cli_utils.py
@@ -1,0 +1,29 @@
+"""Shared CLI parsing helpers.
+
+Small utilities used by multiple CLI modules (``cli.py``, ``registry_cli.py``,
+``bench_cli.py``, ``ft_cli.py``, ``compat_cli.py``).  Lives in its own module
+to avoid circular imports — ``cli.py`` registers subcommand groups from those
+modules at import time.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def parse_env_pairs(env_pairs: tuple[str, ...]) -> dict[str, str]:
+    """Parse KEY=VALUE environment variable pairs from CLI --env options."""
+    result: dict[str, str] = {}
+    for pair in env_pairs:
+        if "=" not in pair:
+            raise click.UsageError(f"Invalid --env format (expected KEY=VALUE): {pair}")
+        key, _, value = pair.partition("=")
+        result[key] = value
+    return result
+
+
+def parse_csv_list(csv: str | None) -> list[str]:
+    """Parse a comma-separated string into a list, stripping whitespace."""
+    if not csv:
+        return []
+    return [item.strip() for item in csv.split(",") if item.strip()]

--- a/src/labeille/compat_cli.py
+++ b/src/labeille/compat_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import click
 
+from labeille.cli_utils import parse_csv_list
 from labeille.logging import setup_logging
 
 
@@ -174,7 +175,7 @@ def survey(
     # Parse inline packages.
     package_names: list[str] | None = None
     if packages_csv:
-        package_names = [p.strip() for p in packages_csv.split(",") if p.strip()]
+        package_names = parse_csv_list(packages_csv)
 
     # Extract minor version for skip_versions filtering.
     from labeille.runner import extract_python_minor_version

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import click
 
+from labeille.cli_utils import parse_csv_list
+
 
 @click.group()
 def ft() -> None:
@@ -195,16 +197,14 @@ def run(
         iterations=iterations,
         timeout=timeout,
         stall_threshold=stall_threshold,
-        packages_filter=(
-            [p.strip() for p in packages.split(",") if p.strip()] if packages else None
-        ),
+        packages_filter=parse_csv_list(packages) or None,
         top_n=top_n,
         registry_dir=registry_dir,
         repos_dir=repos_dir,
         venvs_dir=venvs_dir,
         results_dir=results_dir,
         env_overrides=env_overrides,
-        extra_deps=([d.strip() for d in extra_deps.split(",") if d.strip()] if extra_deps else []),
+        extra_deps=parse_csv_list(extra_deps),
         test_command_suffix=test_command_suffix,
         test_command_override=test_command_override,
         detect_extensions=detect_extensions,

--- a/src/labeille/registry_cli.py
+++ b/src/labeille/registry_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import click
 
+from labeille.cli_utils import parse_csv_list
 from labeille.registry_ops import (
     PROTECTED_FIELDS,
     PROTECTED_INDEX_FIELDS,
@@ -219,9 +220,7 @@ def add_field_cmd(
     """Add a new field to package YAML files."""
     registry_dir = _auto_detect_registry(registry_dir)
     filters = _parse_filters(where_exprs)
-    packages_list = (
-        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
-    )
+    packages_list = parse_csv_list(packages_csv) or None
 
     parsed_default = parse_default_value(default_value, field_type)
     value_text = format_yaml_value(parsed_default, field_type)
@@ -287,9 +286,7 @@ def remove_field_cmd(
         sys.exit(1)
 
     filters = _parse_filters(where_exprs)
-    packages_list = (
-        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
-    )
+    packages_list = parse_csv_list(packages_csv) or None
 
     result = batch_remove_field(
         registry_dir,
@@ -340,9 +337,7 @@ def rename_field_cmd(
     """Rename a field in package YAML files."""
     registry_dir = _auto_detect_registry(registry_dir)
     filters = _parse_filters(where_exprs)
-    packages_list = (
-        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
-    )
+    packages_list = parse_csv_list(packages_csv) or None
 
     result = batch_rename_field(
         registry_dir,
@@ -406,9 +401,7 @@ def set_field_cmd(
     """Set a field to a specific value on matching packages."""
     registry_dir = _auto_detect_registry(registry_dir)
     filters = _parse_filters(where_exprs)
-    packages_list = (
-        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
-    )
+    packages_list = parse_csv_list(packages_csv) or None
 
     if not select_all and not filters and not packages_list:
         raise click.UsageError(
@@ -455,9 +448,7 @@ def validate_cmd(
     """Check YAML files against the PackageEntry schema."""
     registry_dir = _auto_detect_registry(registry_dir)
     filters = _parse_filters(where_exprs)
-    packages_list = (
-        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
-    )
+    packages_list = parse_csv_list(packages_csv) or None
 
     from labeille.registry_ops import _list_package_files, _filter_files
 


### PR DESCRIPTION
## Summary
- Extract `parse_env_pairs()` and `parse_csv_list()` into new `cli_utils.py` module to eliminate duplicated parsing logic
- Replace 2 env-pair parsing sites in `cli.py` and 10 CSV list parsing sites across `cli.py`, `registry_cli.py`, `compat_cli.py`, `bench_cli.py`, and `ft_cli.py`
- Separate module avoids circular imports since `cli.py` registers subcommand groups at import time

## Test plan
- [x] ruff format — no changes needed
- [x] ruff check — all checks passed
- [x] mypy strict — no issues (50 source files)
- [x] 2027 tests pass, 0 failures

Closes #168

Generated with [Claude Code](https://claude.com/claude-code)