### PR TITLE
fix: address silent failures and overly broad exception handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Import check `OSError` now sets `install_error` status instead of silently continuing.
 - Raise compat survey clone/build failure log levels from `debug` to `warning` for visibility.
 - Rename `from_dict` parameter `d` → `data` in `CompatResult` and `CompatMeta` for consistency.
+- Bisect extra deps install failure now returns `skip` step instead of silently continuing.
+- Narrow `except Exception` to specific types in `analyze_cli.py` and `ft/compat.py`.
+- Add warning logs for silent failures in `runner.py` (JIT check), `scan_deps.py` (dir scan), and `bisect.py` (deps install).
+- Extension probe script now reports `walk_error` and `skipped_modules` instead of silently passing.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -41,7 +41,12 @@ from labeille.formatting import (
     format_table,
     truncate,
 )
-from labeille.registry import PackageEntry, load_package, package_exists
+from labeille.registry import (
+    PackageEntry,
+    RegistrySchemaError,
+    load_package,
+    package_exists,
+)
 
 
 @click.group()
@@ -154,7 +159,7 @@ def registry_cmd(
             index = load_index(registry_dir)
         except FileNotFoundError:
             pass
-        except Exception as exc:
+        except (OSError, RegistrySchemaError) as exc:
             click.echo(
                 f"Warning: could not load index ({exc}); download tier coverage will be omitted.",
                 err=True,

--- a/src/labeille/bisect.py
+++ b/src/labeille/bisect.py
@@ -263,8 +263,14 @@ def test_revision(repo_dir: Path, commit: str, config: BisectConfig) -> BisectSt
                     timeout=config.timeout,
                     installer=installer,
                 )
-            except (subprocess.TimeoutExpired, OSError):
-                pass
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                log.warning("Extra deps install failed at %s: %s", short, exc)
+                return BisectStep(
+                    commit=commit,
+                    commit_short=short,
+                    status="skip",
+                    detail=f"extra deps install failed: {exc}",
+                )
 
         # Run tests.
         test_cmd = config.test_command or "python -m pytest"

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -225,9 +225,10 @@ def probe_package(package_name):
                 to_check.append(modname)
                 if len(to_check) > 200:  # Safety limit.
                     break
-        except (ImportError, OSError, AttributeError):
-            pass
+        except (ImportError, OSError, AttributeError) as e:
+            result["walk_error"] = f"{type(e).__name__}: {e}"
 
+    skipped_modules = []
     for modname in to_check:
         if modname in checked:
             continue
@@ -243,7 +244,9 @@ def probe_package(package_name):
                     "file": filepath,
                 })
         except (ImportError, OSError):
-            pass  # Some submodules may not be importable.
+            skipped_modules.append(modname)
+    if skipped_modules:
+        result["skipped_modules"] = skipped_modules
 
     print(json.dumps(result))
 
@@ -549,7 +552,7 @@ def assess_extension_compat(
                 compat.is_pure_python = not scan.has_any_declaration
                 if scan.has_any_declaration:
                     compat.all_extensions_compatible = scan.all_not_used
-        except Exception as exc:
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
             log.warning("Source scan failed for %s: %s", package_name, exc)
 
     return compat

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -229,7 +229,8 @@ def check_jit_enabled(python_path: Path) -> bool:
             env=clean_env(PYTHON_JIT="1", ASAN_OPTIONS="detect_leaks=0"),
         )
         return proc.stdout.strip() == "True"
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        log.warning("Could not check JIT availability: %s", exc)
         return False
 
 

--- a/src/labeille/scan_deps.py
+++ b/src/labeille/scan_deps.py
@@ -744,8 +744,8 @@ def _auto_detect_test_dirs(repo_root: Path, package_name: str = "") -> list[Path
         for d in repo_root.iterdir():
             if d.is_dir() and (d.name.endswith("_test") or d.name.endswith("_tests")):
                 found.append(d)
-    except OSError:
-        pass
+    except OSError as exc:
+        log.warning("Could not scan root-level dirs in %s: %s", repo_root, exc)
 
     # 2b: Test subdirs inside the package directory.
     if pkg_norm:


### PR DESCRIPTION
## Summary
- Bisect extra deps install failure now returns `skip` step instead of silently continuing (prevents incorrect bisect results)
- Narrow `except Exception` to specific types in `analyze_cli.py` and `ft/compat.py`
- Add warning logs for silent failures in `runner.py`, `scan_deps.py`, `bisect.py`
- Extension probe script now reports `walk_error` and `skipped_modules` for diagnostic visibility

## Test plan
- [x] ruff format/check — clean
- [x] mypy strict — no issues (50 source files)
- [x] 2027 tests pass, 0 failures

Closes #174

Generated with [Claude Code](https://claude.com/claude-code)