### PR TITLE
refactor: unify run ID generation across subsystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Extract `parse_env_pairs()` and `parse_csv_list()` CLI helpers to eliminate duplicated parsing across `cli.py`, `registry_cli.py`, `compat_cli.py`, `bench_cli.py`, and `ft_cli.py`.
 - Decompose `generate_registry_report` (190 lines) into focused helpers: `_accumulate_package_stats`, `_analyze_compat_blockers`, `_analyze_per_version`, `_analyze_download_tiers`.
 - Decompose `_print_run_summary` (180 lines) into 7 section formatters for readability.
+- Unify run ID generation with `generate_run_id()` in `io_utils.py` — all subsystems now use UTC with consistent format.
 - Extract `run_in_process_group()` into `io_utils.py` as a shared subprocess lifecycle utility, used by both `runner.py` and `bench/timing.py`.
 - `bench/results.py` `append_package_result` now uses shared `append_jsonl` instead of raw `open()`.
 

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -10,13 +10,13 @@ Handles:
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.results import ConditionDef
+from labeille.io_utils import generate_run_id
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +92,7 @@ class BenchConfig:
 
     def __post_init__(self) -> None:
         if not self.bench_id:
-            self.bench_id = f"bench_{time.strftime('%Y%m%d_%H%M%S')}"
+            self.bench_id = generate_run_id("bench")
 
     @property
     def total_iterations(self) -> int:

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -322,8 +322,7 @@ def run_cmd(
     install_from: str,
 ) -> None:
     """Run test suites against a JIT-enabled Python build and detect crashes."""
-    from datetime import datetime, timezone
-
+    from labeille.io_utils import generate_run_id
     from labeille.registry import default_registry_dir
 
     if registry_dir is None:
@@ -385,7 +384,7 @@ def run_cmd(
 
     # Generate run ID.
     if run_id is None:
-        run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+        run_id = generate_run_id("run")
 
     # --work-dir sets both --repos-dir and --venvs-dir as defaults.
     if work_dir is not None:

--- a/src/labeille/compat.py
+++ b/src/labeille/compat.py
@@ -16,12 +16,17 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 from labeille.crash import detect_crash
-from labeille.io_utils import append_jsonl, load_jsonl, utc_now_iso, write_meta_json
+from labeille.io_utils import (
+    append_jsonl,
+    generate_run_id,
+    load_jsonl,
+    utc_now_iso,
+    write_meta_json,
+)
 from labeille.logging import get_logger
 from labeille.runner import (
     InstallerBackend,
@@ -889,7 +894,7 @@ def run_compat_survey(
     installer = resolve_installer(installer_preference)
     patterns = get_patterns(extra_patterns_file)
 
-    survey_id = f"compat-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    survey_id = generate_run_id("compat")
     survey_dir = output_dir / survey_id
     survey_dir.mkdir(parents=True, exist_ok=True)
     (survey_dir / "build_logs").mkdir()

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -32,7 +32,7 @@ from labeille.ft.results import (
     append_ft_result,
     save_ft_run,
 )
-from labeille.io_utils import kill_process_group, utc_now_iso
+from labeille.io_utils import generate_run_id, kill_process_group, utc_now_iso
 from labeille.logging import get_logger
 from labeille.resolve import fetch_pypi_metadata
 from labeille.runner import (
@@ -985,7 +985,7 @@ def run_ft(config: FTRunConfig) -> list[FTPackageResult]:
         for warn in stability.warnings:
             log.warning("Stability: %s", warn)
 
-    run_id = time.strftime("ft_%Y%m%d_%H%M%S")
+    run_id = generate_run_id("ft")
     output_dir = config.results_dir / run_id
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -18,6 +18,14 @@ log = get_logger("io_utils")
 T = TypeVar("T")
 
 
+def generate_run_id(prefix: str) -> str:
+    """Generate a UTC-timestamped run ID with a consistent format.
+
+    Format: ``{prefix}_{YYYYMMDD}_{HHMMSS}`` (always UTC).
+    """
+    return f"{prefix}_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+
+
 def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
     """Write content to a file atomically using a temp file and os.replace.
 


### PR DESCRIPTION
## Summary
- Add `generate_run_id(prefix)` to `io_utils.py` — always UTC, consistent `prefix_YYYYMMDD_HHMMSS` format
- Replace 4 different ID generation patterns (2 local time, 2 UTC with different separators)
- Eliminates timezone bugs when comparing runs across subsystems

## Test plan
- [x] ruff format/check — clean
- [x] mypy strict — no issues
- [x] 2055 tests pass, 0 failures

Closes #178

Generated with [Claude Code](https://claude.com/claude-code)