### PR TITLE
refactor: replace counter dataclasses with dict counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Unify run ID generation with `generate_run_id()` in `io_utils.py` — all subsystems now use UTC with consistent format.
 - Extract `run_in_process_group()` into `io_utils.py` as a shared subprocess lifecycle utility, used by both `runner.py` and `bench/timing.py`.
 - `bench/results.py` `append_package_result` now uses shared `append_jsonl` instead of raw `open()`.
+- Replace `RepoHostStats`, `InstallComplexity`, `CompatBlockers` dataclasses with `dict[str, int]` counters on `RegistryReport`, eliminating `getattr`/`setattr` usage.
 
 ### Fixed
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -311,45 +311,6 @@ class VersionAnalysis:
 
 
 @dataclass
-class RepoHostStats:
-    """Distribution of repository hosting."""
-
-    github: int = 0
-    gitlab: int = 0
-    bitbucket: int = 0
-    codeberg: int = 0
-    other: int = 0
-    no_repo: int = 0
-
-
-@dataclass
-class InstallComplexity:
-    """Install command complexity classification."""
-
-    simple_editable: int = 0
-    editable_with_extras: int = 0
-    multi_step: int = 0
-    custom: int = 0
-    has_git_fetch_tags: int = 0
-
-
-@dataclass
-class CompatBlockers:
-    """Known compatibility blockers from skip reasons."""
-
-    pyo3_rust: int = 0
-    cython: int = 0
-    meson: int = 0
-    cmake: int = 0
-    fortran: int = 0
-    c_api_removed: int = 0
-    no_python_support: int = 0
-    other_build: int = 0
-
-    packages_by_blocker: dict[str, list[str]] = field(default_factory=dict)
-
-
-@dataclass
 class DownloadTierCoverage:
     """Coverage of top-downloaded packages."""
 
@@ -372,9 +333,10 @@ class RegistryReport:
     by_extension_type: dict[str, tuple[int, int]] = field(default_factory=dict)
     by_skip_category: dict[str, int] = field(default_factory=dict)
     per_version: list[VersionAnalysis] = field(default_factory=list)
-    repo_hosts: RepoHostStats = field(default_factory=RepoHostStats)
-    install_complexity: InstallComplexity = field(default_factory=InstallComplexity)
-    compat_blockers: CompatBlockers = field(default_factory=CompatBlockers)
+    repo_hosts: dict[str, int] = field(default_factory=dict)
+    install_complexity: dict[str, int] = field(default_factory=dict)
+    compat_blockers: dict[str, int] = field(default_factory=dict)
+    packages_by_blocker: dict[str, list[str]] = field(default_factory=dict)
     by_test_framework: dict[str, int] = field(default_factory=dict)
     download_tiers: DownloadTierCoverage = field(default_factory=DownloadTierCoverage)
     notable: dict[str, int] = field(default_factory=dict)
@@ -530,20 +492,20 @@ def _accumulate_package_stats(report: RegistryReport, pkg: PackageEntry) -> None
 
     # Repo host.
     host = _classify_repo_host(pkg.repo)
-    current = getattr(report.repo_hosts, host)
-    setattr(report.repo_hosts, host, current + 1)
+    report.repo_hosts[host] = report.repo_hosts.get(host, 0) + 1
 
     # Install complexity (active only).
     if not is_skipped:
         complexity = _classify_install_complexity(pkg.install_command)
-        current_val = getattr(report.install_complexity, complexity)
-        setattr(report.install_complexity, complexity, current_val + 1)
+        report.install_complexity[complexity] = report.install_complexity.get(complexity, 0) + 1
         if (
             pkg.install_command
             and "git fetch" in pkg.install_command
             and "--tags" in pkg.install_command
         ):
-            report.install_complexity.has_git_fetch_tags += 1
+            report.install_complexity["has_git_fetch_tags"] = (
+                report.install_complexity.get("has_git_fetch_tags", 0) + 1
+            )
 
     # Test framework (active only).
     if not is_skipped:
@@ -570,7 +532,7 @@ def _accumulate_package_stats(report: RegistryReport, pkg: PackageEntry) -> None
 
 def _analyze_compat_blockers(
     packages: list[PackageEntry],
-    blockers: CompatBlockers,
+    report: RegistryReport,
     *,
     collect_package_lists: bool = False,
 ) -> None:
@@ -587,10 +549,9 @@ def _analyze_compat_blockers(
             blocker = _classify_compat_blocker(reason)
             if blocker and blocker not in seen:
                 seen.add(blocker)
-                current_val = getattr(blockers, blocker)
-                setattr(blockers, blocker, current_val + 1)
+                report.compat_blockers[blocker] = report.compat_blockers.get(blocker, 0) + 1
                 if collect_package_lists:
-                    blockers.packages_by_blocker.setdefault(blocker, []).append(pkg.package)
+                    report.packages_by_blocker.setdefault(blocker, []).append(pkg.package)
 
 
 def _analyze_per_version(
@@ -688,9 +649,7 @@ def generate_registry_report(
             globally_skipped.add(pkg.package)
         _accumulate_package_stats(report, pkg)
 
-    _analyze_compat_blockers(
-        packages, report.compat_blockers, collect_package_lists=collect_package_lists
-    )
+    _analyze_compat_blockers(packages, report, collect_package_lists=collect_package_lists)
     report.per_version = _analyze_per_version(
         packages, target_python_versions, version_skipped, globally_skipped
     )

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -364,10 +364,9 @@ def format_registry_detail(report: RegistryReport) -> str:
     lines: list[str] = [format_registry_summary(report), ""]
 
     # Compatibility blockers.
-    blockers = report.compat_blockers
     blocker_items: list[tuple[str, int]] = []
     for field_name, label in _BLOCKER_LABELS.items():
-        count = getattr(blockers, field_name)
+        count = report.compat_blockers.get(field_name, 0)
         if count > 0:
             blocker_items.append((label, count))
     if blocker_items:
@@ -377,14 +376,16 @@ def format_registry_detail(report: RegistryReport) -> str:
         lines.append("")
 
     # Repository hosting.
-    rh = report.repo_hosts
+    _HOST_LABELS = [
+        ("github", "GitHub"),
+        ("gitlab", "GitLab"),
+        ("bitbucket", "Bitbucket"),
+        ("codeberg", "Codeberg"),
+        ("no_repo", "No repo URL"),
+        ("other", "Other"),
+    ]
     host_items: list[tuple[str, int]] = [
-        ("GitHub", rh.github),
-        ("GitLab", rh.gitlab),
-        ("Bitbucket", rh.bitbucket),
-        ("Codeberg", rh.codeberg),
-        ("No repo URL", rh.no_repo),
-        ("Other", rh.other),
+        (label, report.repo_hosts.get(key, 0)) for key, label in _HOST_LABELS
     ]
     host_items = [(lb, ct) for lb, ct in host_items if ct > 0]
     if host_items:
@@ -394,22 +395,25 @@ def format_registry_detail(report: RegistryReport) -> str:
         lines.append("")
 
     # Install complexity.
+    _INSTALL_LABELS = [
+        ("simple_editable", "Simple editable"),
+        ("editable_with_extras", "Editable + extras"),
+        ("multi_step", "Multi-step"),
+        ("custom", "Custom"),
+    ]
     if report.active > 0:
-        ic = report.install_complexity
         install_items: list[tuple[str, int]] = [
-            ("Simple editable", ic.simple_editable),
-            ("Editable + extras", ic.editable_with_extras),
-            ("Multi-step", ic.multi_step),
-            ("Custom", ic.custom),
+            (label, report.install_complexity.get(key, 0)) for key, label in _INSTALL_LABELS
         ]
         lines.append(f"Install complexity ({report.active:,} active):")
         for label, count in install_items:
             if count > 0:
                 lines.append(f"  {label:<20s} {count:>5,}  ({_pct(count, report.active).strip()})")
-        if ic.has_git_fetch_tags > 0:
+        git_fetch_tags = report.install_complexity.get("has_git_fetch_tags", 0)
+        if git_fetch_tags > 0:
             lines.append(
-                f"  {'setuptools-scm fix':<20s} {ic.has_git_fetch_tags:>5,}  "
-                f"({_pct(ic.has_git_fetch_tags, report.active).strip()})"
+                f"  {'setuptools-scm fix':<20s} {git_fetch_tags:>5,}  "
+                f"({_pct(git_fetch_tags, report.active).strip()})"
             )
         lines.append("")
 
@@ -453,9 +457,9 @@ def format_registry_verbose(report: RegistryReport) -> str:
         lines.append("")
 
     # Per-blocker package lists.
-    if report.compat_blockers.packages_by_blocker:
+    if report.packages_by_blocker:
         lines.append("Packages by blocker:")
-        for blocker_key, pkg_list in sorted(report.compat_blockers.packages_by_blocker.items()):
+        for blocker_key, pkg_list in sorted(report.packages_by_blocker.items()):
             label = _BLOCKER_LABELS.get(blocker_key, blocker_key)
             lines.append(f"  {label} ({len(pkg_list)}):")
             display_pkgs = pkg_list[:20]
@@ -532,17 +536,17 @@ def export_registry_report_md(report: RegistryReport) -> str:
         lines.append("")
 
     # Compatibility blockers.
-    blocker_items: list[tuple[str, int]] = []
+    blocker_items_md: list[tuple[str, int]] = []
     for field_name, label in _BLOCKER_LABELS.items():
-        count = getattr(report.compat_blockers, field_name)
+        count = report.compat_blockers.get(field_name, 0)
         if count > 0:
-            blocker_items.append((label, count))
-    if blocker_items:
+            blocker_items_md.append((label, count))
+    if blocker_items_md:
         lines.append("## Compatibility Blockers")
         lines.append("")
         lines.append("| Technology | Packages |")
         lines.append("|-----------|--------:|")
-        for label, count in sorted(blocker_items, key=lambda x: -x[1]):
+        for label, count in sorted(blocker_items_md, key=lambda x: -x[1]):
             lines.append(f"| {label} | {count:,} |")
         lines.append("")
 
@@ -566,41 +570,45 @@ def export_registry_report_md(report: RegistryReport) -> str:
         lines.append("")
 
     # Repository hosting.
-    rh = report.repo_hosts
-    host_items: list[tuple[str, int]] = [
-        ("GitHub", rh.github),
-        ("GitLab", rh.gitlab),
-        ("Bitbucket", rh.bitbucket),
-        ("Codeberg", rh.codeberg),
-        ("No repo URL", rh.no_repo),
-        ("Other", rh.other),
+    _HOST_LABELS_MD = [
+        ("github", "GitHub"),
+        ("gitlab", "GitLab"),
+        ("bitbucket", "Bitbucket"),
+        ("codeberg", "Codeberg"),
+        ("no_repo", "No repo URL"),
+        ("other", "Other"),
     ]
-    host_items = [(lb, ct) for lb, ct in host_items if ct > 0]
-    if host_items:
+    host_items_md: list[tuple[str, int]] = [
+        (label, report.repo_hosts.get(key, 0)) for key, label in _HOST_LABELS_MD
+    ]
+    host_items_md = [(lb, ct) for lb, ct in host_items_md if ct > 0]
+    if host_items_md:
         lines.append("## Repository Hosting")
         lines.append("")
         lines.append("| Host | Count | Percentage |")
         lines.append("|------|------:|-----------:|")
-        for label, count in host_items:
+        for label, count in host_items_md:
             lines.append(f"| {label} | {count:,} | {_pct(count, report.total).strip()} |")
         lines.append("")
 
     # Install complexity.
+    _INSTALL_LABELS_MD = [
+        ("simple_editable", "Simple editable"),
+        ("editable_with_extras", "Editable + extras"),
+        ("multi_step", "Multi-step"),
+        ("custom", "Custom"),
+    ]
     if report.active > 0:
-        ic = report.install_complexity
-        install_items: list[tuple[str, int]] = [
-            ("Simple editable", ic.simple_editable),
-            ("Editable + extras", ic.editable_with_extras),
-            ("Multi-step", ic.multi_step),
-            ("Custom", ic.custom),
+        install_items_md: list[tuple[str, int]] = [
+            (label, report.install_complexity.get(key, 0)) for key, label in _INSTALL_LABELS_MD
         ]
-        install_items = [(lb, ct) for lb, ct in install_items if ct > 0]
-        if install_items:
+        install_items_md = [(lb, ct) for lb, ct in install_items_md if ct > 0]
+        if install_items_md:
             lines.append("## Install Complexity")
             lines.append("")
             lines.append("| Type | Count | % of Active |")
             lines.append("|------|------:|------------:|")
-            for label, count in install_items:
+            for label, count in install_items_md:
                 lines.append(f"| {label} | {count:,} | {_pct(count, report.active).strip()} |")
             lines.append("")
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1209,9 +1209,9 @@ class TestGenerateRegistryReport(unittest.TestCase):
         pkg_none.repo = None
         packages.append(pkg_none)
         report = generate_registry_report(packages)
-        self.assertEqual(report.repo_hosts.github, 1)
-        self.assertEqual(report.repo_hosts.gitlab, 1)
-        self.assertEqual(report.repo_hosts.no_repo, 1)
+        self.assertEqual(report.repo_hosts.get("github", 0), 1)
+        self.assertEqual(report.repo_hosts.get("gitlab", 0), 1)
+        self.assertEqual(report.repo_hosts.get("no_repo", 0), 1)
 
     def test_report_install_complexity(self) -> None:
         packages = [
@@ -1221,10 +1221,10 @@ class TestGenerateRegistryReport(unittest.TestCase):
             _make_pkg("d", install_command="make install"),
         ]
         report = generate_registry_report(packages)
-        self.assertEqual(report.install_complexity.simple_editable, 1)
-        self.assertEqual(report.install_complexity.editable_with_extras, 1)
-        self.assertEqual(report.install_complexity.multi_step, 1)
-        self.assertEqual(report.install_complexity.custom, 1)
+        self.assertEqual(report.install_complexity.get("simple_editable", 0), 1)
+        self.assertEqual(report.install_complexity.get("editable_with_extras", 0), 1)
+        self.assertEqual(report.install_complexity.get("multi_step", 0), 1)
+        self.assertEqual(report.install_complexity.get("custom", 0), 1)
 
     def test_report_install_git_fetch_tags(self) -> None:
         packages = [
@@ -1234,8 +1234,8 @@ class TestGenerateRegistryReport(unittest.TestCase):
             ),
         ]
         report = generate_registry_report(packages)
-        self.assertEqual(report.install_complexity.has_git_fetch_tags, 1)
-        self.assertEqual(report.install_complexity.multi_step, 1)
+        self.assertEqual(report.install_complexity.get("has_git_fetch_tags", 0), 1)
+        self.assertEqual(report.install_complexity.get("multi_step", 0), 1)
 
     def test_report_compat_blockers(self) -> None:
         packages = [
@@ -1244,9 +1244,9 @@ class TestGenerateRegistryReport(unittest.TestCase):
             _make_pkg("c", skip=True, skip_reason="meson build error"),
         ]
         report = generate_registry_report(packages)
-        self.assertEqual(report.compat_blockers.pyo3_rust, 1)
-        self.assertEqual(report.compat_blockers.cython, 1)
-        self.assertEqual(report.compat_blockers.meson, 1)
+        self.assertEqual(report.compat_blockers.get("pyo3_rust", 0), 1)
+        self.assertEqual(report.compat_blockers.get("cython", 0), 1)
+        self.assertEqual(report.compat_blockers.get("meson", 0), 1)
 
     def test_report_compat_blockers_dedup(self) -> None:
         """Package with same blocker in skip_reason and skip_versions counted once."""
@@ -1259,7 +1259,7 @@ class TestGenerateRegistryReport(unittest.TestCase):
             ),
         ]
         report = generate_registry_report(packages)
-        self.assertEqual(report.compat_blockers.pyo3_rust, 1)
+        self.assertEqual(report.compat_blockers.get("pyo3_rust", 0), 1)
 
     def test_report_compat_blockers_package_lists(self) -> None:
         packages = [
@@ -1267,8 +1267,8 @@ class TestGenerateRegistryReport(unittest.TestCase):
             _make_pkg("orjson", skip=True, skip_reason="maturin/Rust"),
         ]
         report = generate_registry_report(packages, collect_package_lists=True)
-        self.assertIn("pyo3_rust", report.compat_blockers.packages_by_blocker)
-        names = report.compat_blockers.packages_by_blocker["pyo3_rust"]
+        self.assertIn("pyo3_rust", report.packages_by_blocker)
+        names = report.packages_by_blocker["pyo3_rust"]
         self.assertIn("cryptography", names)
         self.assertIn("orjson", names)
 


### PR DESCRIPTION
## Summary
- Replace `RepoHostStats`, `InstallComplexity`, and `CompatBlockers` dataclasses with `dict[str, int]` fields on `RegistryReport`
- Eliminate `getattr`/`setattr` usage in `_accumulate_package_stats` and `_analyze_compat_blockers` for type-safe dict access
- Move `packages_by_blocker` to a top-level field on `RegistryReport`

## Test plan
- [x] All 2055 tests pass
- [x] ruff format and check pass
- [x] mypy strict passes

Closes #180

Generated with [Claude Code](https://claude.com/claude-code)