### PR TITLE
refactor: replace Any with concrete types in ft subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Extract `run_in_process_group()` into `io_utils.py` as a shared subprocess lifecycle utility, used by both `runner.py` and `bench/timing.py`.
 - `bench/results.py` `append_package_result` now uses shared `append_jsonl` instead of raw `open()`.
 - Replace `RepoHostStats`, `InstallComplexity`, `CompatBlockers` dataclasses with `dict[str, int]` counters on `RegistryReport`, eliminating `getattr`/`setattr` usage.
+- Replace `Any` type annotations with concrete types in `ft/export.py`, `ft/compare.py`, `ft/display.py`.
 
 ### Fixed
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.

--- a/src/labeille/ft/compare.py
+++ b/src/labeille/ft/compare.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from labeille.ft.results import FTPackageResult, FTRunSummary
+
 
 @dataclass
 class PackageTransition:
@@ -94,8 +96,8 @@ class FTComparisonResult:
 
 
 def compare_ft_runs(
-    results_a: list[Any],
-    results_b: list[Any],
+    results_a: list[FTPackageResult],
+    results_b: list[FTPackageResult],
     *,
     label_a: str = "run_a",
     label_b: str = "run_b",
@@ -114,8 +116,6 @@ def compare_ft_runs(
     Returns:
         FTComparisonResult with all transitions and statistics.
     """
-    from labeille.ft.results import FTRunSummary
-
     comp = FTComparisonResult(label_a=label_a, label_b=label_b)
 
     # Index results by package name.
@@ -193,7 +193,7 @@ def compare_ft_runs(
     return comp
 
 
-def _classify_transition(ra: Any, rb: Any) -> str:
+def _classify_transition(ra: FTPackageResult, rb: FTPackageResult) -> str:
     """Classify a transition as improvement, regression, or unchanged.
 
     Uses category severity and pass rate to determine direction.
@@ -220,7 +220,7 @@ def _classify_transition(ra: Any, rb: Any) -> str:
     return "regression"
 
 
-def _describe_transition(ra: Any, rb: Any, direction: str) -> str:
+def _describe_transition(ra: FTPackageResult, rb: FTPackageResult, direction: str) -> str:
     """Generate a human-readable description of a transition."""
     parts = [f"{ra.category.value} → {rb.category.value}"]
 

--- a/src/labeille/ft/display.py
+++ b/src/labeille/ft/display.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from labeille.ft.results import FailureCategory
+from labeille.ft.analysis import FlakinessProfile, TriageEntry
+from labeille.ft.compare import FTComparisonResult
+from labeille.ft.results import FailureCategory, FTPackageResult
 
 
 def format_compatibility_summary(
@@ -99,7 +101,7 @@ def format_compatibility_summary(
 
 
 def format_package_table(
-    results: list[Any],
+    results: list[FTPackageResult],
     *,
     sort_by: str = "category",
     max_rows: int | None = None,
@@ -183,7 +185,7 @@ def format_package_table(
 
 
 def format_triage_list(
-    triage: list[Any],
+    triage: list[TriageEntry],
     *,
     max_entries: int = 20,
 ) -> str:
@@ -198,8 +200,6 @@ def format_triage_list(
          3. aiohttp        ~ intermittent (score: 35)  severity:intermittent
          ...
     """
-    from labeille.ft.results import FailureCategory
-
     lines = ["Investigation Priority", "──────────────────────"]
 
     for i, entry in enumerate(triage[:max_entries], 1):
@@ -216,7 +216,7 @@ def format_triage_list(
     return "\n".join(lines)
 
 
-def format_flakiness_profile(profile: Any) -> str:
+def format_flakiness_profile(profile: FlakinessProfile) -> str:
     """Format a single flakiness profile for display.
 
     Output::
@@ -268,7 +268,7 @@ def format_flakiness_profile(profile: Any) -> str:
 
 
 def format_ft_comparison(
-    comp: Any,
+    comp: FTComparisonResult,
     *,
     label_a: str = "",
     label_b: str = "",

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import csv
 import io
 import json
-from typing import Any
+from labeille.ft.analysis import FTAnalysisReport, analyze_ft_run
+from labeille.ft.results import FailureCategory, FTPackageResult, FTRunMeta, FTRunSummary
 
 
 def export_csv(
-    results: list[Any],
+    results: list[FTPackageResult],
 ) -> str:
     """Export results as CSV with one row per package.
 
@@ -80,7 +81,7 @@ def export_csv(
 
 
 def export_json(
-    results: list[Any],
+    results: list[FTPackageResult],
     *,
     indent: int = 2,
 ) -> str:
@@ -95,8 +96,8 @@ def export_json(
 
 
 def generate_report(
-    meta: Any,
-    results: list[Any],
+    meta: FTRunMeta,
+    results: list[FTPackageResult],
     *,
     format: str = "markdown",
 ) -> str:
@@ -113,9 +114,6 @@ def generate_report(
     Returns:
         The formatted report as a string.
     """
-    from labeille.ft.analysis import analyze_ft_run
-    from labeille.ft.results import FTRunSummary
-
     summary = FTRunSummary.compute(results)
     analysis = analyze_ft_run(results)
 
@@ -148,7 +146,7 @@ def generate_report(
     return "\n".join(lines)
 
 
-def _report_header_md(meta: Any, summary: Any) -> list[str]:
+def _report_header_md(meta: FTRunMeta, summary: FTRunSummary) -> list[str]:
     lines = [
         "# Free-Threading Compatibility Report",
         "",
@@ -182,7 +180,7 @@ def _report_header_md(meta: Any, summary: Any) -> list[str]:
     return lines
 
 
-def _report_summary_table_md(summary: Any) -> list[str]:
+def _report_summary_table_md(summary: FTRunSummary) -> list[str]:
     lines = [
         "## Summary",
         "",
@@ -216,8 +214,7 @@ def _report_summary_table_md(summary: Any) -> list[str]:
     return lines
 
 
-def _report_crashes_md(results: list[Any]) -> list[str]:
-    from labeille.ft.results import FailureCategory
+def _report_crashes_md(results: list[FTPackageResult]) -> list[str]:
 
     crash_pkgs = [r for r in results if r.category == FailureCategory.CRASH]
     if not crash_pkgs:
@@ -242,8 +239,7 @@ def _report_crashes_md(results: list[Any]) -> list[str]:
     return lines
 
 
-def _report_deadlocks_md(results: list[Any]) -> list[str]:
-    from labeille.ft.results import FailureCategory
+def _report_deadlocks_md(results: list[FTPackageResult]) -> list[str]:
 
     deadlock_pkgs = [r for r in results if r.category == FailureCategory.DEADLOCK]
     if not deadlock_pkgs:
@@ -270,8 +266,9 @@ def _report_deadlocks_md(results: list[Any]) -> list[str]:
     return lines
 
 
-def _report_intermittent_md(results: list[Any], analysis: Any) -> list[str]:
-    from labeille.ft.results import FailureCategory
+def _report_intermittent_md(
+    results: list[FTPackageResult], analysis: FTAnalysisReport
+) -> list[str]:
 
     intermittent = [r for r in results if r.category == FailureCategory.INTERMITTENT]
     if not intermittent:
@@ -301,7 +298,7 @@ def _report_intermittent_md(results: list[Any], analysis: Any) -> list[str]:
     return lines
 
 
-def _report_tsan_md(results: list[Any]) -> list[str]:
+def _report_tsan_md(results: list[FTPackageResult]) -> list[str]:
     tsan_pkgs = [r for r in results if r.tsan_warning_iterations > 0]
     if not tsan_pkgs:
         return []
@@ -326,7 +323,7 @@ def _report_tsan_md(results: list[Any]) -> list[str]:
     return lines
 
 
-def _report_extensions_md(results: list[Any]) -> list[str]:
+def _report_extensions_md(results: list[FTPackageResult]) -> list[str]:
     ext_pkgs = [
         r
         for r in results
@@ -343,7 +340,7 @@ def _report_extensions_md(results: list[Any]) -> list[str]:
     ]
 
     for r in sorted(ext_pkgs, key=lambda r: r.package):
-        ext = r.extension_compat
+        ext = r.extension_compat or {}
         fallback = "Yes" if ext.get("gil_fallback_active") else "No"
         scan = ext.get("source_scan", {})
         if scan and scan.get("declarations"):
@@ -357,7 +354,7 @@ def _report_extensions_md(results: list[Any]) -> list[str]:
     return lines
 
 
-def _report_footer_md(meta: Any) -> list[str]:
+def _report_footer_md(meta: FTRunMeta) -> list[str]:
     lines = [
         "---",
         "",


### PR DESCRIPTION
## Summary
- Replace `Any` type annotations with concrete types (`FTPackageResult`, `FTRunMeta`, `FTRunSummary`, `FTAnalysisReport`, `FlakinessProfile`, `TriageEntry`, `FTComparisonResult`) across `ft/export.py`, `ft/compare.py`, `ft/display.py`
- Move lazy imports to module level (no circular import risk)
- Fix mypy union-attr error for `extension_compat` access

## Test plan
- [x] All 2055 tests pass
- [x] ruff format and check pass
- [x] mypy strict passes

Closes #182

Generated with [Claude Code](https://claude.com/claude-code)