### PR TITLE
fix: add safe YAML loading and guard all yaml.safe_load sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Narrow `except Exception` to specific types in `analyze_cli.py` and `ft/compat.py`.
 - Add warning logs for silent failures in `runner.py` (JIT check), `scan_deps.py` (dir scan), and `bisect.py` (deps install).
 - Extension probe script now reports `walk_error` and `skipped_modules` instead of silently passing.
+- Guard all `yaml.safe_load` call sites against `YAMLError`: add `safe_load_yaml` utility to `io_utils.py`, protect `registry.py`, `registry_ops.py`, `analyze_cli.py`, `migrations.py`, and `bench/config.py`.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -207,14 +207,18 @@ def _load_all_packages(
     filters: list[FieldFilter] = [parse_where(e) for e in where_exprs]
     packages: list[PackageEntry] = []
 
-    import yaml
+    from labeille.io_utils import safe_load_yaml
 
     for f in sorted(packages_dir.glob("*.yaml")):
         if filters:
-            raw = yaml.safe_load(f.read_text(encoding="utf-8"))
-            if not isinstance(raw, dict) or not matches(raw, filters):
+            raw = safe_load_yaml(f)
+            if raw is None or not matches(raw, filters):
                 continue
-        pkg = load_package(f.stem, registry_dir)
+        try:
+            pkg = load_package(f.stem, registry_dir)
+        except (OSError, ValueError, KeyError) as exc:
+            click.echo(f"Warning: skipping {f.stem}: {exc}", err=True)
+            continue
         packages.append(pkg)
 
     return packages

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -321,7 +321,10 @@ def load_profile(profile_path: Path) -> dict[str, Any]:
         raise FileNotFoundError(f"Profile not found: {profile_path}")
 
     text = profile_path.read_text(encoding="utf-8")
-    data = yaml.safe_load(text)
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in profile {profile_path}: {exc}") from exc
 
     if not isinstance(data, dict):
         raise ValueError(f"Profile must be a YAML mapping, got {type(data).__name__}")

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator, TypeVar
 
+import yaml
+
 from labeille.logging import get_logger
 
 log = get_logger("io_utils")
@@ -48,6 +50,24 @@ def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> N
 def utc_now_iso() -> str:
     """Return the current UTC time as an ISO 8601 string with Z suffix."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def safe_load_yaml(path: Path) -> dict[str, Any] | None:
+    """Load a YAML file, returning ``None`` on parse errors.
+
+    Catches ``yaml.YAMLError`` and logs a warning so that a single
+    malformed file does not crash batch operations.  Returns ``None``
+    if the file cannot be parsed or does not contain a YAML mapping.
+    """
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        log.warning("Skipping %s: malformed YAML: %s", path.name, exc)
+        return None
+    if not isinstance(data, dict):
+        log.warning("Skipping %s: expected YAML mapping, got %s", path.name, type(data).__name__)
+        return None
+    return data
 
 
 def write_meta_json(path: Path, data: dict[str, Any]) -> None:

--- a/src/labeille/migrations.py
+++ b/src/labeille/migrations.py
@@ -205,7 +205,12 @@ def execute_migration(
     results: list[MigrationResult] = []
 
     for f in files:
-        raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+        try:
+            raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            log.warning("Skipping %s: malformed YAML: %s", f.name, exc)
+            skipped_count += 1
+            continue
         if not isinstance(raw, dict):
             skipped_count += 1
             continue

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -244,7 +244,10 @@ def load_index(registry_path: Path) -> Index:
     index_file = registry_path / "index.yaml"
     if not index_file.exists():
         return Index()
-    data = yaml.safe_load(index_file.read_text(encoding="utf-8"))
+    try:
+        data = yaml.safe_load(index_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RegistrySchemaError(f"Malformed index.yaml: {exc}") from exc
     if not isinstance(data, dict):
         return Index()
     packages = [_dict_to_index_entry(p) for p in data.get("packages", []) if isinstance(p, dict)]
@@ -314,9 +317,13 @@ def load_package(name: str, registry_path: Path) -> PackageEntry:
 
     Raises:
         FileNotFoundError: If the package YAML file does not exist.
+        RegistrySchemaError: If the YAML is malformed.
     """
     p = package_path(name, registry_path)
-    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RegistrySchemaError(f"Malformed YAML in {p.name}: {exc}") from exc
     if not isinstance(data, dict):
         return PackageEntry(package=name)
     return _dict_to_package(data)

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -12,6 +12,7 @@ from typing import Any, get_type_hints
 
 import yaml
 
+from labeille.io_utils import safe_load_yaml
 from labeille.registry import (
     IndexEntry,
     PackageEntry,
@@ -189,8 +190,8 @@ def _filter_files(
     if filters:
         filtered = []
         for f in result:
-            data = yaml.safe_load(f.read_text(encoding="utf-8"))
-            if isinstance(data, dict) and matches(data, filters):
+            data = safe_load_yaml(f)
+            if data is not None and matches(data, filters):
                 filtered.append(f)
         result = filtered
 
@@ -472,7 +473,11 @@ def batch_set_field(
     for f in files:
         lines = _read_lines(f)
         # Parse for filtering and type detection only.
-        raw = yaml.safe_load("".join(lines))
+        try:
+            raw = yaml.safe_load("".join(lines))
+        except yaml.YAMLError as exc:
+            errors.append(f"{f.name}: malformed YAML: {exc}")
+            continue
         if not isinstance(raw, dict):
             errors.append(f"{f.name}: invalid YAML")
             continue
@@ -597,7 +602,11 @@ def validate_registry(
     issues: list[ValidationIssue] = []
 
     for f in files:
-        raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+        try:
+            raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            issues.append(ValidationIssue(f.name, "error", f"malformed YAML: {exc}"))
+            continue
         if not isinstance(raw, dict):
             issues.append(ValidationIssue(f.name, "error", "file does not contain a YAML mapping"))
             continue

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from labeille.io_utils import atomic_write_text, utc_now_iso
+from labeille.io_utils import atomic_write_text, safe_load_yaml, utc_now_iso
 
 
 class TestAtomicWriteText(unittest.TestCase):
@@ -87,6 +87,45 @@ class TestUtcNowIso(unittest.TestCase):
         result = utc_now_iso()
         # Should not contain a dot (microsecond separator)
         self.assertNotIn(".", result)
+
+
+class TestSafeLoadYaml(unittest.TestCase):
+    """Tests for safe_load_yaml."""
+
+    def test_valid_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "test.yaml"
+            p.write_text("key: value\n", encoding="utf-8")
+            result = safe_load_yaml(p)
+            self.assertEqual(result, {"key": "value"})
+
+    def test_malformed_yaml_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.yaml"
+            p.write_text(":\n  - :\n    bad: [unterminated\n", encoding="utf-8")
+            result = safe_load_yaml(p)
+            self.assertIsNone(result)
+
+    def test_non_dict_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "list.yaml"
+            p.write_text("- item1\n- item2\n", encoding="utf-8")
+            result = safe_load_yaml(p)
+            self.assertIsNone(result)
+
+    def test_empty_file_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "empty.yaml"
+            p.write_text("", encoding="utf-8")
+            result = safe_load_yaml(p)
+            self.assertIsNone(result)
+
+    def test_scalar_yaml_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "scalar.yaml"
+            p.write_text("just a string\n", encoding="utf-8")
+            result = safe_load_yaml(p)
+            self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -178,6 +178,15 @@ class TestPackageIO(unittest.TestCase):
         self.assertIsNone(loaded.import_name)
         self.assertEqual(loaded.skip_versions, {})
 
+    def test_load_malformed_yaml_raises(self) -> None:
+        import labeille.registry
+
+        p = self.registry / "packages" / "badpkg.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(":\n  bad: [unterminated\n", encoding="utf-8")
+        with self.assertRaises(labeille.registry.RegistrySchemaError):
+            load_package("badpkg", self.registry)
+
 
 class TestIndexIO(unittest.TestCase):
     def setUp(self) -> None:
@@ -237,6 +246,14 @@ class TestIndexIO(unittest.TestCase):
             self.assertEqual(got.extension_type, orig.extension_type)
             self.assertEqual(got.enriched, orig.enriched)
             self.assertEqual(got.skip, orig.skip)
+
+    def test_load_malformed_index_raises(self) -> None:
+        import labeille.registry
+
+        index_file = self.registry / "index.yaml"
+        index_file.write_text(":\n  bad: [unterminated\n", encoding="utf-8")
+        with self.assertRaises(labeille.registry.RegistrySchemaError):
+            load_index(self.registry)
 
 
 class TestIndexSorting(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `safe_load_yaml()` utility to `io_utils.py` that catches `yaml.YAMLError` and returns `None`
- Guard 8 unprotected `yaml.safe_load` call sites with context-appropriate error handling
- Fix test isolation issue from `importlib.reload` causing class identity mismatch

## Test plan
- [x] 5 new tests for `safe_load_yaml` (valid, malformed, non-dict, empty, scalar)
- [x] 2 new tests for malformed YAML in `load_package` and `load_index`
- [x] All 2062 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #186

Generated with [Claude Code](https://claude.com/claude-code)