### PR TITLE
fix: add timeout to git subprocess calls in registry sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add warning logs for silent failures in `runner.py` (JIT check), `scan_deps.py` (dir scan), and `bisect.py` (deps install).
 - Extension probe script now reports `walk_error` and `skipped_modules` instead of silently passing.
 - Guard all `yaml.safe_load` call sites against `YAMLError`: add `safe_load_yaml` utility to `io_utils.py`, protect `registry.py`, `registry_ops.py`, `analyze_cli.py`, `migrations.py`, and `bench/config.py`.
+- Add 120-second timeout to git subprocess calls in `registry sync` to prevent indefinite hangs.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/registry_cli.py
+++ b/src/labeille/registry_cli.py
@@ -682,11 +682,16 @@ def sync_cmd(
     if (target / ".git").is_dir():
         # Existing clone — pull.
         click.echo(f"Updating registry at {target}...")
-        result = subprocess.run(
-            ["git", "-C", str(target), "pull", "--ff-only"],
-            capture_output=not verbose,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(target), "pull", "--ff-only"],
+                capture_output=not verbose,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            click.echo("Pull timed out after 120 seconds.", err=True)
+            sys.exit(1)
         if result.returncode != 0:
             click.echo(f"Pull failed (exit {result.returncode}).", err=True)
             if not verbose and result.stderr:
@@ -708,11 +713,16 @@ def sync_cmd(
         # Fresh clone.
         click.echo(f"Cloning laruche registry into {target}...")
         target.parent.mkdir(parents=True, exist_ok=True)
-        result = subprocess.run(
-            ["git", "clone", url, str(target)],
-            capture_output=not verbose,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "clone", url, str(target)],
+                capture_output=not verbose,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            click.echo("Clone timed out after 120 seconds.", err=True)
+            sys.exit(1)
         if result.returncode != 0:
             click.echo(f"Clone failed (exit {result.returncode}).", err=True)
             if not verbose and result.stderr:

--- a/tests/test_registry_sync.py
+++ b/tests/test_registry_sync.py
@@ -87,6 +87,26 @@ class TestSyncCmd(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Pull failed", result.output)
 
+    @unittest.mock.patch("subprocess.run")
+    def test_clone_timeout(self, mock_run: unittest.mock.MagicMock) -> None:
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(["git", "clone"], 120)
+        result = self.runner.invoke(registry, ["sync", "--registry-dir", str(self.target)])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("timed out", result.output)
+
+    @unittest.mock.patch("subprocess.run")
+    def test_pull_timeout(self, mock_run: unittest.mock.MagicMock) -> None:
+        import subprocess
+
+        self.target.mkdir(parents=True)
+        (self.target / ".git").mkdir()
+        mock_run.side_effect = subprocess.TimeoutExpired(["git", "pull"], 120)
+        result = self.runner.invoke(registry, ["sync", "--registry-dir", str(self.target)])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("timed out", result.output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add 120-second timeout to `git clone` and `git pull` in `registry sync`
- Handle `TimeoutExpired` with user-friendly error message and non-zero exit

## Test plan
- [x] 2 new tests for clone/pull timeout scenarios
- [x] All 2064 tests pass
- [x] ruff/mypy clean

Closes #188

Generated with [Claude Code](https://claude.com/claude-code)