### PR TITLE
fix: miscellaneous silent failure and error handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Extension probe script now reports `walk_error` and `skipped_modules` instead of silently passing.
 - Guard all `yaml.safe_load` call sites against `YAMLError`: add `safe_load_yaml` utility to `io_utils.py`, protect `registry.py`, `registry_ops.py`, `analyze_cli.py`, `migrations.py`, and `bench/config.py`.
 - Add 120-second timeout to git subprocess calls in `registry sync` to prevent indefinite hangs.
+- Add `ignore_errors=True` to `shutil.rmtree` in venv refresh to prevent cleanup failures masking results.
+- Log `PermissionError` at WARNING in `kill_process_group` instead of silently ignoring.
+- Add `from None` to exception chains in `bench_cli.py` for cleaner tracebacks.
+- Include exception details in connection error log in `resolve.py`.
+- Guard rename in `shield_source_dir` finally block against missing source file.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -862,7 +862,7 @@ def track_show(series_name: str, last_n: int | None, tracking_dir: Path) -> None
     try:
         series = load_series(series_dir)
     except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.")
+        raise click.ClickException(f"Series '{series_name}' not found.") from None
 
     click.echo(f"Series: {series.series_id}")
     if series.description:
@@ -1001,7 +1001,7 @@ def track_trend(
     try:
         series = load_series(series_dir)
     except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.")
+        raise click.ClickException(f"Series '{series_name}' not found.") from None
 
     trend = analyze_series_trends(
         series,
@@ -1051,7 +1051,7 @@ def track_alert(
     try:
         series = load_series(series_dir)
     except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.")
+        raise click.ClickException(f"Series '{series_name}' not found.") from None
 
     trend = analyze_series_trends(series, series_dir, condition=condition)
 

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -131,8 +131,10 @@ def kill_process_group(pid: int) -> None:
     try:
         pgid = os.getpgid(pid)
         os.killpg(pgid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
+    except ProcessLookupError:
         pass
+    except (PermissionError, OSError) as exc:
+        log.warning("Could not kill process group for PID %d: %s", pid, exc)
 
 
 def run_in_process_group(

--- a/src/labeille/repo_ops.py
+++ b/src/labeille/repo_ops.py
@@ -372,7 +372,8 @@ def shield_source_dir(
     try:
         yield
     finally:
-        shield_path.rename(src_path)
+        if shield_path.exists():
+            shield_path.rename(src_path)
 
 
 _SELF_INSTALL_RE = re.compile(

--- a/src/labeille/resolve.py
+++ b/src/labeille/resolve.py
@@ -290,8 +290,8 @@ def fetch_pypi_metadata(
             resp = session.get(url, timeout=timeout, headers={"User-Agent": _USER_AGENT})
         else:
             resp = requests.get(url, timeout=timeout, headers={"User-Agent": _USER_AGENT})
-    except requests.ConnectionError:
-        log.error("Connection error fetching %s", package_name)
+    except requests.ConnectionError as exc:
+        log.error("Connection error fetching %s: %s", package_name, exc)
         return None
     except requests.Timeout:
         log.error("Timeout fetching %s", package_name)

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -833,7 +833,7 @@ def _setup_venv(
 
     if venv_existed and config.refresh_venvs:
         log.info("Refreshing venv for %s at %s", pkg.package, venv_dir)
-        shutil.rmtree(venv_dir)
+        shutil.rmtree(venv_dir, ignore_errors=True)
         venv_existed = False
 
     installer = resolve_installer(config.installer)


### PR DESCRIPTION
## Summary
- Add `ignore_errors=True` to `shutil.rmtree` in venv refresh to prevent cleanup masking results
- Log `PermissionError` at WARNING in `kill_process_group` instead of silently ignoring
- Add `from None` to 3 exception chains in `bench_cli.py` for cleaner tracebacks
- Include exception details in connection error log in `resolve.py`
- Guard rename in `shield_source_dir` finally block against missing source file

## Test plan
- [x] All 2064 tests pass
- [x] ruff/mypy clean

Closes #190

Generated with [Claude Code](https://claude.com/claude-code)