### PR TITLE
refactor: use clean_env and append_jsonl for pattern consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Replace `RepoHostStats`, `InstallComplexity`, `CompatBlockers` dataclasses with `dict[str, int]` counters on `RegistryReport`, eliminating `getattr`/`setattr` usage.
 - Replace `Any` type annotations with concrete types in `ft/export.py`, `ft/compare.py`, `ft/display.py`.
 - Simplify `_build_bench_config` by splitting into `_build_base_config` and `_apply_config_overrides`, eliminating `locals()` dict unpacking via `@click.pass_context`.
+- Use `clean_env()` in `bench/system.py` instead of inline env dict construction for pattern consistency.
+- Use `append_jsonl()` in `migrations.py` instead of raw `open()`/`json.dumps` for pattern consistency.
 
 ### Fixed
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -748,13 +748,11 @@ def capture_python_profile(
     """
     profile = PythonProfile(path=str(python_path))
 
-    run_env = dict(os.environ)
+    from labeille.runner import clean_env
+
+    run_env = clean_env(ASAN_OPTIONS="detect_leaks=0")
     if env:
         run_env.update(env)
-    # Don't let host PYTHONHOME/PYTHONPATH contaminate the probe.
-    run_env.pop("PYTHONHOME", None)
-    run_env.pop("PYTHONPATH", None)
-    run_env["ASAN_OPTIONS"] = "detect_leaks=0"
 
     try:
         proc = subprocess.run(

--- a/src/labeille/migrations.py
+++ b/src/labeille/migrations.py
@@ -155,8 +155,9 @@ def append_migration_log(registry_dir: Path, entry: MigrationLogEntry) -> None:
         "files_modified": entry.files_modified,
         "files_skipped": entry.files_skipped,
     }
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(data) + "\n")
+    from labeille.io_utils import append_jsonl
+
+    append_jsonl(path, data)
 
 
 def has_been_applied(registry_dir: Path, migration_name: str) -> bool:


### PR DESCRIPTION
## Summary
- Replace inline env dict construction in `bench/system.py` with `clean_env()` from `runner.py`
- Replace raw JSONL writing in `migrations.py` with `append_jsonl()` from `io_utils.py`

## Test plan
- [x] All 2064 tests pass
- [x] ruff/mypy clean

Closes #192

Generated with [Claude Code](https://claude.com/claude-code)