### PR TITLE
fix: add load_json_file utility and guard json.loads call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `from None` to exception chains in `bench_cli.py` for cleaner tracebacks.
 - Include exception details in connection error log in `resolve.py`.
 - Guard rename in `shield_source_dir` finally block against missing source file.
+- Add `load_json_file` utility to `io_utils.py` and guard 5 unprotected `json.loads` call sites against `JSONDecodeError`.
+- Add `JSONDecodeError` to exception handling in `bench/system.py` Python profile probe.
+- Add `KeyError` handling for missing probe output fields in `ft/compat.py`.
+- Include exception details in schema.yaml parse warning in `registry.py`.
+- Catch `ValueError` from malformed `tracking.json` in `bench_cli.py` track commands.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -7,12 +7,11 @@ analysis functions that operate on loaded data.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from labeille.io_utils import load_jsonl, utc_now_iso
+from labeille.io_utils import load_json_file, load_jsonl, utc_now_iso
 from labeille.registry import Index, PackageEntry
 
 
@@ -157,7 +156,10 @@ class RunData:
         meta_file = self.run_dir / "run_meta.json"
         if not meta_file.exists():
             return RunMeta(run_id=self.run_id)
-        data = json.loads(meta_file.read_text(encoding="utf-8"))
+        try:
+            data = load_json_file(meta_file)
+        except ValueError:
+            return RunMeta(run_id=self.run_id)
         return RunMeta.from_dict(data)
 
     def _load_results(self) -> list[PackageResult]:

--- a/src/labeille/bench/results.py
+++ b/src/labeille/bench/results.py
@@ -29,7 +29,7 @@ from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.stats import DescriptiveStats, describe, detect_outliers
 from labeille.bench.system import PythonProfile, SystemProfile
 from labeille.bench.timing import PerTestTimings
-from labeille.io_utils import append_jsonl, load_jsonl, write_meta_json
+from labeille.io_utils import append_jsonl, load_json_file, load_jsonl, write_meta_json
 from labeille.logging import get_logger
 
 log = get_logger("bench.results")
@@ -421,7 +421,7 @@ def load_bench_run(
     if not meta_path.exists():
         raise FileNotFoundError(f"No bench_meta.json in {run_dir}")
 
-    meta = BenchMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
+    meta = BenchMeta.from_dict(load_json_file(meta_path))
 
     results_path = run_dir / "bench_results.jsonl"
     results: list[BenchPackageResult] = []

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -779,7 +779,7 @@ def capture_python_profile(
                 proc.returncode,
                 proc.stderr.strip()[:200],
             )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, json.JSONDecodeError) as exc:
         log.warning("Could not profile Python at %s: %s", python_path, exc)
 
     return profile

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -201,7 +201,7 @@ def load_series(series_dir: Path) -> TrackingSeries:
     """
     tracking_file = series_dir / "tracking.json"
     if not tracking_file.exists():
-        raise FileNotFoundError(f"No tracking.json found in {series_dir}")
+        raise FileNotFoundError(f"Series not found: no tracking.json in {series_dir}")
 
     text = tracking_file.read_text(encoding="utf-8")
     try:

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -861,8 +861,8 @@ def track_show(series_name: str, last_n: int | None, tracking_dir: Path) -> None
     series_dir = tracking_dir / series_name
     try:
         series = load_series(series_dir)
-    except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.") from None
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from None
 
     click.echo(f"Series: {series.series_id}")
     if series.description:
@@ -1000,8 +1000,8 @@ def track_trend(
     series_dir = tracking_dir / series_name
     try:
         series = load_series(series_dir)
-    except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.") from None
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from None
 
     trend = analyze_series_trends(
         series,
@@ -1050,8 +1050,8 @@ def track_alert(
     series_dir = tracking_dir / series_name
     try:
         series = load_series(series_dir)
-    except FileNotFoundError:
-        raise click.ClickException(f"Series '{series_name}' not found.") from None
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from None
 
     trend = analyze_series_trends(series, series_dir, condition=condition)
 

--- a/src/labeille/compat.py
+++ b/src/labeille/compat.py
@@ -8,7 +8,6 @@ the labeille registry.
 
 from __future__ import annotations
 
-import json
 import re
 import subprocess
 import tempfile
@@ -23,6 +22,7 @@ from labeille.crash import detect_crash
 from labeille.io_utils import (
     append_jsonl,
     generate_run_id,
+    load_json_file,
     load_jsonl,
     utc_now_iso,
     write_meta_json,
@@ -954,7 +954,7 @@ def load_compat_survey(survey_dir: Path) -> CompatSurvey:
     meta_path = survey_dir / "compat_meta.json"
     if not meta_path.exists():
         raise FileNotFoundError(f"compat_meta.json not found in {survey_dir}")
-    meta = CompatMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
+    meta = CompatMeta.from_dict(load_json_file(meta_path))
 
     jsonl_path = survey_dir / "compat_results.jsonl"
     results: list[CompatResult] = []

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -331,6 +331,8 @@ def probe_gil_fallback(
         compat.import_ok = False
     except json.JSONDecodeError as exc:
         compat.probe_error = f"Probe output not valid JSON: {exc}"
+    except KeyError as exc:
+        compat.probe_error = f"Probe output missing field: {exc}"
     except (FileNotFoundError, OSError) as exc:
         compat.probe_error = f"Could not run probe: {exc}"
 

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from labeille.io_utils import append_jsonl, load_jsonl, write_meta_json
+from labeille.io_utils import append_jsonl, load_json_file, load_jsonl, write_meta_json
 from labeille.logging import get_logger
 
 log = get_logger("ft.results")
@@ -580,6 +580,6 @@ def load_ft_run(
     if not results_path.exists():
         raise FileNotFoundError(f"No ft_results.jsonl in {results_dir}")
 
-    meta = FTRunMeta.from_dict(json.loads(meta_path.read_text(encoding="utf-8")))
+    meta = FTRunMeta.from_dict(load_json_file(meta_path))
     results = load_jsonl(results_path, FTPackageResult.from_dict)
     return meta, results

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -79,6 +79,22 @@ def write_meta_json(path: Path, data: dict[str, Any]) -> None:
     atomic_write_text(path, json.dumps(data, indent=2) + "\n")
 
 
+def load_json_file(path: Path) -> dict[str, Any]:
+    """Read and parse a JSON file.
+
+    Raises:
+        ValueError: If the file contains invalid JSON or is not a dict.
+        OSError: If the file cannot be read.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path.name}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected JSON object in {path.name}, got {type(data).__name__}")
+    return data
+
+
 def iter_jsonl(
     path: Path,
     deserialize: Callable[[dict[str, Any]], T],

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -70,8 +70,8 @@ def check_registry_schema(registry_path: Path) -> None:
 
     try:
         data = yaml.safe_load(schema_file.read_text(encoding="utf-8"))
-    except (yaml.YAMLError, OSError):
-        log.warning("Could not parse schema.yaml in %s", registry_path)
+    except (yaml.YAMLError, OSError) as exc:
+        log.warning("Could not parse schema.yaml in %s: %s", registry_path, exc)
         return
 
     if not isinstance(data, dict):

--- a/src/labeille/resolve.py
+++ b/src/labeille/resolve.py
@@ -8,7 +8,6 @@ workflow: read inputs, query PyPI, update the registry.
 
 from __future__ import annotations
 
-import json
 import re
 import threading
 import time
@@ -223,7 +222,9 @@ def read_packages_from_json(path: Path, top_n: int | None = None) -> list[Packag
     Returns:
         A list of PackageInput entries with download counts.
     """
-    data = json.loads(path.read_text(encoding="utf-8"))
+    from labeille.io_utils import load_json_file
+
+    data = load_json_file(path)
     rows: list[dict[str, Any]] = data.get("rows", [])
     entries = [
         PackageInput(

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -128,5 +128,46 @@ class TestSafeLoadYaml(unittest.TestCase):
             self.assertIsNone(result)
 
 
+class TestLoadJsonFile(unittest.TestCase):
+    """Tests for load_json_file."""
+
+    def test_valid_json(self) -> None:
+        from labeille.io_utils import load_json_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "test.json"
+            p.write_text('{"key": "value"}', encoding="utf-8")
+            result = load_json_file(p)
+            self.assertEqual(result, {"key": "value"})
+
+    def test_malformed_json_raises_valueerror(self) -> None:
+        from labeille.io_utils import load_json_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.json"
+            p.write_text("{truncated", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_json_file(p)
+            self.assertIn("Invalid JSON", str(ctx.exception))
+
+    def test_non_dict_json_raises_valueerror(self) -> None:
+        from labeille.io_utils import load_json_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "list.json"
+            p.write_text("[1, 2, 3]", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_json_file(p)
+            self.assertIn("Expected JSON object", str(ctx.exception))
+
+    def test_missing_file_raises_oserror(self) -> None:
+        from labeille.io_utils import load_json_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "missing.json"
+            with self.assertRaises(OSError):
+                load_json_file(p)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `load_json_file()` utility to `io_utils.py` — the read counterpart to `write_meta_json`
- Guard 5 unprotected `json.loads(path.read_text())` sites across `analyze.py`, `ft/results.py`, `bench/results.py`, `compat.py`, `resolve.py`
- Add `JSONDecodeError` to exception handling in `bench/system.py` Python profile probe
- Add `KeyError` handling for missing probe fields in `ft/compat.py`
- Include exception details in `registry.py` schema.yaml parse warning
- Catch `ValueError` from malformed `tracking.json` in `bench_cli.py` track commands

## Test plan
- [x] 4 new tests for `load_json_file` (valid, malformed, non-dict, missing)
- [x] All 2068 tests pass
- [x] ruff/mypy clean

Closes #194

Generated with [Claude Code](https://claude.com/claude-code)