### PR TITLE
fix: surface skipped-package counts in batch run summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `KeyError` handling for missing probe output fields in `ft/compat.py`.
 - Include exception details in schema.yaml parse warning in `registry.py`.
 - Catch `ValueError` from malformed `tracking.json` in `bench_cli.py` track commands.
+- Surface skipped-package counts in `ft/runner.py`, `bench/runner.py`, and `bench/tracking.py` so users know when results are incomplete.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -317,15 +317,20 @@ class BenchRunner:
             names = [n for n in names if n not in skip_set]
 
         # Load each package.
+        skipped = 0
         for name in sorted(names):
             if name not in index_names:
                 log.warning("Package '%s' not in registry, skipping", name)
+                skipped += 1
                 continue
             try:
                 entry = load_package(name, self.config.registry_dir)
                 packages.append(entry)
             except (OSError, ValueError, KeyError) as exc:
                 log.warning("Failed to load package '%s': %s", name, exc)
+                skipped += 1
+        if skipped:
+            log.warning("Skipped %d package(s) due to load errors", skipped)
 
         # Apply top_n.
         if self.config.top_n and len(packages) > self.config.top_n:

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -247,6 +247,7 @@ def list_series(tracking_dir: Path) -> list[TrackingSeries]:
         return []
 
     result: list[TrackingSeries] = []
+    skipped = 0
     for entry in sorted(tracking_dir.iterdir()):
         if not entry.is_dir():
             continue
@@ -258,6 +259,9 @@ def list_series(tracking_dir: Path) -> list[TrackingSeries]:
             result.append(series)
         except (ValueError, FileNotFoundError):
             log.warning("Skipping malformed series in %s", entry)
+            skipped += 1
+    if skipped:
+        log.warning("Skipped %d malformed series", skipped)
 
     return result
 

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -1090,6 +1090,7 @@ def _select_packages(index: Index, config: FTRunConfig) -> list[PackageEntry]:
 
     # Load full PackageEntry objects for enriched packages.
     packages = []
+    skipped = 0
     for entry in index.packages:
         if not entry.enriched:
             continue
@@ -1100,6 +1101,9 @@ def _select_packages(index: Index, config: FTRunConfig) -> list[PackageEntry]:
             packages.append(pkg)
         except (OSError, ValueError, KeyError) as exc:
             log.warning("Could not load package %s, skipping: %s", entry.name, exc)
+            skipped += 1
+    if skipped:
+        log.warning("Skipped %d package(s) due to load errors", skipped)
 
     if config.packages_filter:
         names = set(config.packages_filter)


### PR DESCRIPTION
## Summary
- Track and log skip counts in `ft/runner.py`, `bench/runner.py`, and `bench/tracking.py`
- Users now see a WARNING summary when packages are dropped due to load errors

## Test plan
- [x] All 2068 tests pass
- [x] ruff/mypy clean

Closes #196

Generated with [Claude Code](https://claude.com/claude-code)