### PR TITLE
refactor: extract dataclass_from_dict utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Include exception details in schema.yaml parse warning in `registry.py`.
 - Catch `ValueError` from malformed `tracking.json` in `bench_cli.py` track commands.
 - Surface skipped-package counts in `ft/runner.py`, `bench/runner.py`, and `bench/tracking.py` so users know when results are incomplete.
+- Extract `dataclass_from_dict` utility to `io_utils.py` and deduplicate 13 identical `from_dict` implementations across `bench/` and `ft/` modules.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench/anomaly.py
+++ b/src/labeille/bench/anomaly.py
@@ -56,8 +56,9 @@ class PackageAnomaly:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PackageAnomaly:
         """Deserialize from a dict."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass

--- a/src/labeille/bench/constraints.py
+++ b/src/labeille/bench/constraints.py
@@ -71,8 +71,9 @@ class ResourceConstraints:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ResourceConstraints:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
     @property
     def has_any(self) -> bool:

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -84,9 +84,9 @@ class SystemProfile:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SystemProfile:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        filtered = {k: v for k, v in data.items() if k in known}
-        return cls(**filtered)
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
     def to_json(self, indent: int = 2) -> str:
         """Serialize to a JSON string."""
@@ -125,9 +125,9 @@ class PythonProfile:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PythonProfile:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        filtered = {k: v for k, v in data.items() if k in known}
-        return cls(**filtered)
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -257,8 +257,9 @@ class TestTiming:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TestTiming:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -66,8 +66,9 @@ class TrackingRunEntry:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrackingRunEntry:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass

--- a/src/labeille/bench/trends.py
+++ b/src/labeille/bench/trends.py
@@ -89,8 +89,9 @@ class PackageTrend:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PackageTrend:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass
@@ -128,8 +129,9 @@ class RegressionAlert:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RegressionAlert:
         """Deserialize from a dict, ignoring unknown fields."""
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -41,8 +41,9 @@ class ExtensionInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExtensionInfo:
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass
@@ -59,8 +60,9 @@ class ModGilDeclaration:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ModGilDeclaration:
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -143,9 +143,9 @@ class IterationOutcome:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> IterationOutcome:
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        filtered = {k: v for k, v in data.items() if k in known}
-        return cls(**filtered)
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass
@@ -408,8 +408,9 @@ class FTRunMeta:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTRunMeta:
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 @dataclass
@@ -498,8 +499,9 @@ class FTRunSummary:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTRunSummary:
-        known = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in data.items() if k in known})
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -95,6 +95,19 @@ def load_json_file(path: Path) -> dict[str, Any]:
     return data
 
 
+def dataclass_from_dict(cls: type[T], data: dict[str, Any]) -> T:
+    """Create a dataclass instance from a dict, ignoring unknown keys.
+
+    Filters *data* to only the fields defined on *cls*, so that
+    forward-compatible JSON (with extra keys from newer versions)
+    deserializes without error.
+    """
+    from dataclasses import fields as dc_fields
+
+    known = {f.name for f in dc_fields(cls)}  # type: ignore[arg-type]
+    return cls(**{k: v for k, v in data.items() if k in known})
+
+
 def iter_jsonl(
     path: Path,
     deserialize: Callable[[dict[str, Any]], T],


### PR DESCRIPTION
## Summary
- Extract `dataclass_from_dict` utility to `io_utils.py` that filters dict keys to known dataclass fields before construction.
- Migrate all 13 identical `from_dict` implementations across `bench/` and `ft/` modules to use the shared utility.
- Eliminates duplicated pattern: `known = {f.name for f in cls.__dataclass_fields__.values()}; return cls(**{...})`

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes
- [x] All existing `from_dict` deserialization behavior preserved

Closes #198

Generated with [Claude Code](https://claude.com/claude-code)