### PR TITLE
fix: use atomic_write_text for ft results and runner summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Catch `ValueError` from malformed `tracking.json` in `bench_cli.py` track commands.
 - Surface skipped-package counts in `ft/runner.py`, `bench/runner.py`, and `bench/tracking.py` so users know when results are incomplete.
 - Extract `dataclass_from_dict` utility to `io_utils.py` and deduplicate 13 identical `from_dict` implementations across `bench/` and `ft/` modules.
+- Use `atomic_write_text` for `ft/results.py` JSONL output and `runner.py` summary file to prevent corruption on interruption.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -19,7 +19,13 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from labeille.io_utils import append_jsonl, load_json_file, load_jsonl, write_meta_json
+from labeille.io_utils import (
+    append_jsonl,
+    atomic_write_text,
+    load_json_file,
+    load_jsonl,
+    write_meta_json,
+)
 from labeille.logging import get_logger
 
 log = get_logger("ft.results")
@@ -534,9 +540,8 @@ def save_ft_run(
     write_meta_json(meta_path, meta.to_dict())
 
     results_path = results_dir / "ft_results.jsonl"
-    with results_path.open("w", encoding="utf-8") as f:
-        for r in results:
-            f.write(json.dumps(r.to_dict()) + "\n")
+    content = "".join(json.dumps(r.to_dict()) + "\n" for r in results)
+    atomic_write_text(results_path, content)
 
     summary = FTRunSummary.compute(results)
     summary_path = results_dir / "ft_summary.json"

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -31,6 +31,7 @@ from typing import Any
 from labeille.crash import detect_crash
 from labeille.io_utils import (
     append_jsonl,
+    atomic_write_text,
     run_in_process_group,
     utc_now_iso,
     write_meta_json,
@@ -1519,7 +1520,7 @@ def run_all(config: RunnerConfig) -> RunOutput:
         run_dir=run_dir,
         mode="verbose",
     )
-    (run_dir / "summary.txt").write_text(summary_text + "\n", encoding="utf-8")
+    atomic_write_text(run_dir / "summary.txt", summary_text + "\n")
     log.info("Run summary:\n%s", summary_text)
 
     return RunOutput(


### PR DESCRIPTION
## Summary
- Replace raw `write_text()` in `runner.py` summary file write with `atomic_write_text`
- Replace raw `open()`/`write()` loop in `ft/results.py` JSONL output with `atomic_write_text`
- Prevents corrupt output files if the process is interrupted mid-write

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #200

Generated with [Claude Code](https://claude.com/claude-code)