### PR TITLE
refactor: deduplicate utilities and clean up imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Surface skipped-package counts in `ft/runner.py`, `bench/runner.py`, and `bench/tracking.py` so users know when results are incomplete.
 - Extract `dataclass_from_dict` utility to `io_utils.py` and deduplicate 13 identical `from_dict` implementations across `bench/` and `ft/` modules.
 - Use `atomic_write_text` for `ft/results.py` JSONL output and `runner.py` summary file to prevent corruption on interruption.
+- Remove 3 unnecessary private re-exports (`_EXTRAS_RE`, `_SELF_INSTALL_RE`, `_TAG_PATTERNS`) from `runner.py`.
+- Move `dataclass_from_dict` imports from method bodies to module level across 9 files.
+- Deduplicate `extract_minor_version`: move canonical implementation to `io_utils.py`, delegate from `runner.py` and `analyze.py`.
+- Delegate `format_signal_name` in `formatting.py` to `crash.signal_name` instead of duplicating signal conversion logic.
+- Replace inline JSON write in `bench/tracking.py` with `write_meta_json`.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -172,20 +172,11 @@ class RunData:
 def extract_minor_version(version_string: str) -> str:
     """Extract major.minor from a full Python version string.
 
-    See also :func:`labeille.runner.extract_python_minor_version` which
-    handles the same task in the runner context.
+    Delegates to :func:`labeille.io_utils.extract_minor_version`.
     """
-    parts = version_string.strip().split(".")
-    if len(parts) >= 2:
-        minor = ""
-        for ch in parts[1]:
-            if ch.isdigit():
-                minor += ch
-            else:
-                break
-        if parts[0].isdigit() and minor:
-            return f"{parts[0]}.{minor}"
-    return version_string
+    from labeille.io_utils import extract_minor_version as _extract
+
+    return _extract(version_string)
 
 
 class ResultsStore:

--- a/src/labeille/bench/anomaly.py
+++ b/src/labeille/bench/anomaly.py
@@ -18,6 +18,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Any
 
+from labeille.io_utils import dataclass_from_dict
+
 from labeille.bench.results import BenchConditionResult, BenchPackageResult
 
 
@@ -56,8 +58,6 @@ class PackageAnomaly:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PackageAnomaly:
         """Deserialize from a dict."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/bench/constraints.py
+++ b/src/labeille/bench/constraints.py
@@ -22,6 +22,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+from labeille.io_utils import dataclass_from_dict
 from labeille.logging import get_logger
 
 log = get_logger("bench.constraints")
@@ -71,8 +72,6 @@ class ResourceConstraints:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ResourceConstraints:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
     @property

--- a/src/labeille/bench/system.py
+++ b/src/labeille/bench/system.py
@@ -20,7 +20,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from labeille.io_utils import utc_now_iso
+from labeille.io_utils import dataclass_from_dict, utc_now_iso
 from labeille.logging import get_logger
 
 log = get_logger("bench.system")
@@ -84,8 +84,6 @@ class SystemProfile:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SystemProfile:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
     def to_json(self, indent: int = 2) -> str:
@@ -125,8 +123,6 @@ class PythonProfile:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PythonProfile:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/bench/timing.py
+++ b/src/labeille/bench/timing.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from labeille.io_utils import run_in_process_group
+from labeille.io_utils import dataclass_from_dict, run_in_process_group
 from labeille.logging import get_logger
 
 log = get_logger("bench.timing")
@@ -257,8 +257,6 @@ class TestTiming:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TestTiming:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from labeille.bench.results import BenchMeta, BenchPackageResult, load_bench_run
-from labeille.io_utils import utc_now_iso
+from labeille.io_utils import dataclass_from_dict, utc_now_iso
 from labeille.logging import get_logger
 
 log = get_logger("bench.tracking")
@@ -66,8 +66,6 @@ class TrackingRunEntry:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrackingRunEntry:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 
@@ -226,13 +224,12 @@ def save_series(series: TrackingSeries, series_dir: Path) -> None:
         series: The series to save.
         series_dir: Path to the series directory.
     """
-    from labeille.io_utils import atomic_write_text
+    from labeille.io_utils import write_meta_json
 
     series_dir.mkdir(parents=True, exist_ok=True)
     tracking_file = series_dir / "tracking.json"
 
-    text = json.dumps(series.to_dict(), indent=2) + "\n"
-    atomic_write_text(tracking_file, text)
+    write_meta_json(tracking_file, series.to_dict())
 
 
 def list_series(tracking_dir: Path) -> list[TrackingSeries]:

--- a/src/labeille/bench/trends.py
+++ b/src/labeille/bench/trends.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
+from labeille.io_utils import dataclass_from_dict
 from labeille.bench.tracking import (
     TrackingRunEntry,
     TrackingSeries,
@@ -89,8 +90,6 @@ class PackageTrend:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PackageTrend:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 
@@ -129,8 +128,6 @@ class RegressionAlert:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RegressionAlert:
         """Deserialize from a dict, ignoring unknown fields."""
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/formatting.py
+++ b/src/labeille/formatting.py
@@ -243,15 +243,13 @@ def format_signal_name(sig: int | None) -> str:
     """Convert a signal number to its name, e.g. 11 → 'SIGSEGV'.
 
     Returns ``""`` if *sig* is ``None``.
+    Delegates to :func:`labeille.crash.signal_name` for the conversion.
     """
     if sig is None:
         return ""
-    import signal as signal_module
+    from labeille.crash import signal_name
 
-    try:
-        return signal_module.Signals(sig).name
-    except (ValueError, AttributeError):
-        return f"SIG{sig}"
+    return signal_name(sig)
 
 
 def format_percentage(count: int, total: int) -> str:

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -21,6 +21,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
+from labeille.io_utils import dataclass_from_dict
 from labeille.logging import get_logger
 
 log = get_logger("ft.compat")
@@ -41,8 +42,6 @@ class ExtensionInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExtensionInfo:
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 
@@ -60,8 +59,6 @@ class ModGilDeclaration:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ModGilDeclaration:
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -22,6 +22,7 @@ from typing import Any, Literal
 from labeille.io_utils import (
     append_jsonl,
     atomic_write_text,
+    dataclass_from_dict,
     load_json_file,
     load_jsonl,
     write_meta_json,
@@ -149,8 +150,6 @@ class IterationOutcome:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> IterationOutcome:
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 
@@ -414,8 +413,6 @@ class FTRunMeta:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTRunMeta:
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 
@@ -505,8 +502,6 @@ class FTRunSummary:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTRunSummary:
-        from labeille.io_utils import dataclass_from_dict
-
         return dataclass_from_dict(cls, data)
 
 

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -108,6 +108,25 @@ def dataclass_from_dict(cls: type[T], data: dict[str, Any]) -> T:
     return cls(**{k: v for k, v in data.items() if k in known})
 
 
+def extract_minor_version(version_string: str) -> str:
+    """Extract ``major.minor`` from a full Python version string.
+
+    For example, ``"3.15.0a5+ (heads/main:abc1234)"`` returns ``"3.15"``.
+    Returns the original string if parsing fails.
+    """
+    parts = version_string.strip().split(".")
+    if len(parts) >= 2:
+        minor = ""
+        for ch in parts[1]:
+            if ch.isdigit():
+                minor += ch
+            else:
+                break
+        if parts[0].isdigit() and minor:
+            return f"{parts[0]}.{minor}"
+    return version_string
+
+
 def iter_jsonl(
     path: Path,
     deserialize: Callable[[dict[str, Any]], T],

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -47,9 +47,6 @@ from labeille.runner_models import RunOutput as RunOutput
 from labeille.runner_models import RunSummary as RunSummary
 
 # Re-export repo operations from repo_ops (preserves all existing imports).
-from labeille.repo_ops import _EXTRAS_RE as _EXTRAS_RE
-from labeille.repo_ops import _SELF_INSTALL_RE as _SELF_INSTALL_RE
-from labeille.repo_ops import _TAG_PATTERNS as _TAG_PATTERNS
 from labeille.repo_ops import _extract_extras as _extract_extras
 from labeille.repo_ops import _is_self_install_segment as _is_self_install_segment
 from labeille.repo_ops import build_sdist_install_commands as build_sdist_install_commands
@@ -1171,19 +1168,12 @@ def extract_python_minor_version(version_string: str) -> str:
     """Extract the ``major.minor`` version from a full Python version string.
 
     For example, ``"3.15.0a5+ (heads/main:abc1234)"`` returns ``"3.15"``.
+
+    .. deprecated:: Use :func:`labeille.io_utils.extract_minor_version` directly.
     """
-    parts = version_string.strip().split(".")
-    if len(parts) >= 2:
-        # The minor component may contain alpha/rc suffixes — strip non-digits.
-        minor = ""
-        for ch in parts[1]:
-            if ch.isdigit():
-                minor += ch
-            else:
-                break
-        if parts[0].isdigit() and minor:
-            return f"{parts[0]}.{minor}"
-    return version_string
+    from labeille.io_utils import extract_minor_version
+
+    return extract_minor_version(version_string)
 
 
 def filter_packages(


### PR DESCRIPTION
## Summary
- Remove 3 unused private re-exports (`_EXTRAS_RE`, `_SELF_INSTALL_RE`, `_TAG_PATTERNS`) from `runner.py`
- Move `extract_minor_version` to `io_utils.py`, delegate from `runner.py` and `analyze.py`
- Delegate `format_signal_name` to `crash.signal_name` instead of duplicating logic
- Replace inline JSON write in `bench/tracking.py` with `write_meta_json`
- Move `dataclass_from_dict` imports from 13 method bodies to module level across 9 files

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #202

Generated with [Claude Code](https://claude.com/claude-code)