### PR TITLE
fix: improve error handling across batch operations and data paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Deduplicate `extract_minor_version`: move canonical implementation to `io_utils.py`, delegate from `runner.py` and `analyze.py`.
 - Delegate `format_signal_name` in `formatting.py` to `crash.signal_name` instead of duplicating signal conversion logic.
 - Replace inline JSON write in `bench/tracking.py` with `write_meta_json`.
+- Guard `_read_lines` call sites in `registry_ops.py` against `OSError`/`UnicodeDecodeError` to prevent batch operations from crashing on corrupt files.
+- Promote `list_installed_packages` error log from `info` to `warning` in `runner.py`.
+- Promote `iter_jsonl` per-line error log from `debug` to `warning` in `io_utils.py`.
+- Guard build log `write_text` in `compat.py` against `OSError` to prevent filesystem errors from aborting runs.
+- Catch `CalledProcessError` and `TimeoutExpired` from git clone/fetch in `bisect.py` to provide clear error messages.
+- Include exception details in malformed series warning in `bench/tracking.py`.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench/tracking.py
+++ b/src/labeille/bench/tracking.py
@@ -255,8 +255,8 @@ def list_series(tracking_dir: Path) -> list[TrackingSeries]:
         try:
             series = load_series(entry)
             result.append(series)
-        except (ValueError, FileNotFoundError):
-            log.warning("Skipping malformed series in %s", entry)
+        except (ValueError, FileNotFoundError) as exc:
+            log.warning("Skipping malformed series in %s: %s", entry, exc)
             skipped += 1
     if skipped:
         log.warning("Skipped %d malformed series", skipped)

--- a/src/labeille/bisect.py
+++ b/src/labeille/bisect.py
@@ -368,17 +368,20 @@ def run_bisect(config: BisectConfig) -> BisectResult:
     try:
         # Clone at full depth (bisect needs the full history).
         log.info("Cloning %s (full depth) for bisect...", config.package)
-        if repo_dir.exists():
-            subprocess.run(
-                ["git", "fetch", "origin"],
-                capture_output=True,
-                text=True,
-                cwd=str(repo_dir),
-                timeout=120,
-                check=True,
-            )
-        else:
-            _clone_full(repo_url, repo_dir)
+        try:
+            if repo_dir.exists():
+                subprocess.run(
+                    ["git", "fetch", "origin"],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(repo_dir),
+                    timeout=120,
+                    check=True,
+                )
+            else:
+                _clone_full(repo_url, repo_dir)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            raise ValueError(f"Failed to clone/fetch {repo_url}: {exc}") from exc
 
         # Resolve symbolic refs to full hashes.
         good_hash = _resolve_rev(repo_dir, config.good_rev)

--- a/src/labeille/compat.py
+++ b/src/labeille/compat.py
@@ -818,10 +818,13 @@ def _survey_package(
         # Save build logs.
         logs_dir = output_dir / "build_logs"
         logs_dir.mkdir(exist_ok=True)
-        if install_proc.stderr:
-            (logs_dir / f"{pkg.name}.stderr").write_text(install_proc.stderr, encoding="utf-8")
-        if install_proc.stdout:
-            (logs_dir / f"{pkg.name}.stdout").write_text(install_proc.stdout, encoding="utf-8")
+        try:
+            if install_proc.stderr:
+                (logs_dir / f"{pkg.name}.stderr").write_text(install_proc.stderr, encoding="utf-8")
+            if install_proc.stdout:
+                (logs_dir / f"{pkg.name}.stdout").write_text(install_proc.stdout, encoding="utf-8")
+        except OSError as exc:
+            log.warning("Could not save build logs for %s: %s", pkg.name, exc)
 
         # Check install result.
         result.exit_code = install_proc.returncode

--- a/src/labeille/io_utils.py
+++ b/src/labeille/io_utils.py
@@ -147,7 +147,7 @@ def iter_jsonl(
                 data = json.loads(line)
                 yield deserialize(data)
             except (json.JSONDecodeError, KeyError, TypeError) as exc:
-                log.debug("Skipping malformed JSONL line in %s: %s", path.name, exc)
+                log.warning("Skipping malformed JSONL line in %s: %s", path.name, exc)
                 skipped += 1
     if skipped:
         log.warning("Skipped %d malformed line(s) in %s", skipped, path)

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -162,7 +162,12 @@ def _list_package_files(registry_dir: Path) -> list[Path]:
 
 
 def _read_lines(path: Path) -> list[str]:
-    """Read a file as a list of lines (preserving newlines)."""
+    """Read a file as a list of lines (preserving newlines).
+
+    Raises:
+        OSError: If the file cannot be read.
+        UnicodeDecodeError: If the file is not valid UTF-8.
+    """
     text = path.read_text(encoding="utf-8")
     # splitlines(True) keeps line endings
     return text.splitlines(True)
@@ -242,7 +247,11 @@ def batch_add_field(
     sample_diffs: list[tuple[str, str, str]] = []
 
     for f in files:
-        lines = _read_lines(f)
+        try:
+            lines = _read_lines(f)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"{f.name}: {exc}")
+            continue
         if has_field(lines, field_name):
             if lenient:
                 skipped.append(f.name)
@@ -334,7 +343,11 @@ def batch_remove_field(
     sample_diffs: list[tuple[str, str, str]] = []
 
     for f in files:
-        lines = _read_lines(f)
+        try:
+            lines = _read_lines(f)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"{f.name}: {exc}")
+            continue
         if not has_field(lines, field_name):
             if lenient:
                 skipped.append(f.name)
@@ -396,7 +409,11 @@ def batch_rename_field(
     sample_diffs: list[tuple[str, str, str]] = []
 
     for f in files:
-        lines = _read_lines(f)
+        try:
+            lines = _read_lines(f)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"{f.name}: {exc}")
+            continue
         has_old = has_field(lines, old_name)
         has_new = has_field(lines, new_name)
 
@@ -471,7 +488,11 @@ def batch_set_field(
     sample_diffs: list[tuple[str, str, str]] = []
 
     for f in files:
-        lines = _read_lines(f)
+        try:
+            lines = _read_lines(f)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"{f.name}: {exc}")
+            continue
         # Parse for filtering and type detection only.
         try:
             raw = yaml.safe_load("".join(lines))

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -452,7 +452,7 @@ def get_installed_packages(
             packages = json.loads(proc.stdout)
             return {p["name"]: p["version"] for p in packages}
     except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError, OSError) as exc:
-        log.info("Could not list installed packages: %s", exc)
+        log.warning("Could not list installed packages: %s", exc)
     return {}
 
 


### PR DESCRIPTION
## Summary
- Guard `_read_lines` call sites in `registry_ops.py` against `OSError`/`UnicodeDecodeError` so corrupt files don't crash batch operations
- Promote error logs from `info`/`debug` to `warning` for data-loss conditions (`list_installed_packages`, `iter_jsonl`)
- Guard build log `write_text` in `compat.py` against filesystem errors
- Catch `CalledProcessError`/`TimeoutExpired` from git clone/fetch in `bisect.py`
- Include exception details in malformed series warning in `bench/tracking.py`

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #204

Generated with [Claude Code](https://claude.com/claude-code)