### PR TITLE
fix: replace getattr with direct attribute access on typed dataclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Guard build log `write_text` in `compat.py` against `OSError` to prevent filesystem errors from aborting runs.
 - Catch `CalledProcessError` and `TimeoutExpired` from git clone/fetch in `bisect.py` to provide clear error messages.
 - Include exception details in malformed series warning in `bench/tracking.py`.
+- Replace `getattr` with direct attribute access on typed dataclass objects in `analyze.py`, `summary.py`, `bench/runner.py`, and `ft/runner.py`.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -779,8 +779,8 @@ def _compute_status_changes(old_run: RunData, new_run: RunData) -> list[StatusCh
                     new_status=r.status,
                     old_detail=result_detail(old_r),
                     new_detail=result_detail(r),
-                    old_commit=getattr(old_r, "git_revision", None),
-                    new_commit=getattr(r, "git_revision", None),
+                    old_commit=old_r.git_revision,
+                    new_commit=r.git_revision,
                 )
             )
 
@@ -940,8 +940,8 @@ def compare_runs(
         if ra is None or rb is None:
             continue  # shouldn't happen, but satisfies type checker
 
-        commit_a = getattr(ra, "git_revision", None)
-        commit_b = getattr(rb, "git_revision", None)
+        commit_a = ra.git_revision
+        commit_b = rb.git_revision
 
         result.package_details.append(
             PackageComparison(

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -610,7 +610,7 @@ class BenchRunner:
         setup: dict[str, Any] = {}
 
         # Clone the repo.
-        if not getattr(pkg, "repo", None):
+        if not pkg.repo:
             log.warning("Package '%s' has no repo URL, skipping", pkg.package)
             return None
 
@@ -670,9 +670,7 @@ class BenchRunner:
                 resolve_env(cond, self.config.default_env),
                 venv_dir,
             )
-            install_cmd = (
-                cond.install_command or getattr(pkg, "install_command", None) or "pip install -e ."
-            )
+            install_cmd = cond.install_command or pkg.install_command or "pip install -e ."
 
             install_start = time.monotonic()
             try:
@@ -740,7 +738,7 @@ class BenchRunner:
         venv_path = venvs[cond.name]
 
         # Resolve the test command.
-        registry_cmd = getattr(pkg, "test_command", None)
+        registry_cmd = pkg.test_command or None
         test_cmd = resolve_test_command(
             registry_cmd,
             cond,
@@ -750,7 +748,7 @@ class BenchRunner:
         # Per-test timing: modify command if enabled.
         per_test_enabled = False
         if self.config.per_test_timing:
-            test_framework = getattr(pkg, "test_framework", "") or ""
+            test_framework = pkg.test_framework or ""
             test_cmd, per_test_enabled = prepare_per_test_command(test_cmd, test_framework)
 
         # Apply resource constraints.

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -557,7 +557,7 @@ def _clone_and_align_ft(
     except (subprocess.TimeoutExpired, OSError) as exc:
         log.debug("Could not capture git revision for %s: %s", pkg.package, exc)
 
-    import_name = getattr(pkg, "import_name", None) or pkg.package.replace("-", "_")
+    import_name = pkg.import_name or pkg.package.replace("-", "_")
     source_layout = "unknown"
 
     if config.install_from == "sdist":
@@ -887,7 +887,7 @@ def run_package_ft(
                     pkg.package,
                     venv_python=venv_python,
                     repo_dir=repo_dir if config.install_from != "sdist" else None,
-                    import_name=getattr(pkg, "import_name", None),
+                    import_name=pkg.import_name,
                     env=env,
                 )
                 result.extension_compat = compat.to_dict()

--- a/src/labeille/summary.py
+++ b/src/labeille/summary.py
@@ -219,7 +219,7 @@ def format_summary(
 
     # Run header
     parts.append("")
-    install_from = getattr(config, "install_from", "source")
+    install_from = config.install_from or "source"
     parts.append(
         _format_run_header(
             config.run_id, python_version, jit_enabled, total_duration, install_from


### PR DESCRIPTION
## Summary
- Replace `getattr(obj, 'field', default)` with direct attribute access where the field is a known dataclass attribute
- Affects `analyze.py` (4 sites), `summary.py` (1), `bench/runner.py` (4), `ft/runner.py` (2)
- Improves type safety — mypy can now verify these field accesses

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes

Closes #206

Generated with [Claude Code](https://claude.com/claude-code)