### PR TITLE
refactor: migrate registry_cli.py from sys.exit(1) to click.ClickException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Catch `CalledProcessError` and `TimeoutExpired` from git clone/fetch in `bisect.py` to provide clear error messages.
 - Include exception details in malformed series warning in `bench/tracking.py`.
 - Replace `getattr` with direct attribute access on typed dataclass objects in `analyze.py`, `summary.py`, `bench/runner.py`, and `ft/runner.py`.
+- Migrate `registry_cli.py` from `sys.exit(1)` to `raise click.ClickException(...)` for validation errors and sync failures, matching the rest of the CLI surface.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/registry_cli.py
+++ b/src/labeille/registry_cli.py
@@ -282,8 +282,7 @@ def remove_field_cmd(
     registry_dir = _auto_detect_registry(registry_dir)
 
     if field_name in PROTECTED_FIELDS:
-        click.echo(f"Error: '{field_name}' is a protected field and cannot be removed.")
-        sys.exit(1)
+        raise click.ClickException(f"'{field_name}' is a protected field and cannot be removed.")
 
     filters = _parse_filters(where_exprs)
     packages_list = parse_csv_list(packages_csv) or None
@@ -531,8 +530,9 @@ def remove_index_field_cmd(
     registry_dir = _auto_detect_registry(registry_dir)
 
     if field_name in PROTECTED_INDEX_FIELDS:
-        click.echo(f"Error: '{field_name}' is a protected index field and cannot be removed.")
-        sys.exit(1)
+        raise click.ClickException(
+            f"'{field_name}' is a protected index field and cannot be removed."
+        )
 
     result = remove_index_field_op(registry_dir, field_name, dry_run=not apply)
 
@@ -592,24 +592,22 @@ def migrate_cmd(
         return
 
     if migration_name is None:
-        click.echo("Error: missing MIGRATION_NAME. Use --list to see available migrations.")
-        sys.exit(1)
+        raise click.ClickException(
+            "Missing MIGRATION_NAME. Use --list to see available migrations."
+        )
 
     migration = get_migration(migration_name)
     if migration is None:
-        click.echo(f"Error: unknown migration '{migration_name}'.")
         available = list_migrations()
-        if available:
-            click.echo("Available migrations:")
-            for m in available:
-                click.echo(f"  {m.name}")
-        sys.exit(1)
+        names = ", ".join(m.name for m in available) if available else "none"
+        raise click.ClickException(f"Unknown migration '{migration_name}'. Available: {names}")
 
     if has_been_applied(registry_dir, migration_name):
         date = get_applied_date(registry_dir, migration_name)
-        click.echo(f"Error: migration '{migration_name}' was already applied on {date}.")
-        click.echo("To re-run, manually remove the entry from registry/migrations.log.")
-        sys.exit(1)
+        raise click.ClickException(
+            f"Migration '{migration_name}' was already applied on {date}. "
+            f"To re-run, manually remove the entry from registry/migrations.log."
+        )
 
     result = execute_migration(migration, registry_dir, dry_run=not apply)
 
@@ -690,25 +688,24 @@ def sync_cmd(
                 timeout=120,
             )
         except subprocess.TimeoutExpired:
-            click.echo("Pull timed out after 120 seconds.", err=True)
-            sys.exit(1)
+            raise click.ClickException("Pull timed out after 120 seconds.")
         if result.returncode != 0:
-            click.echo(f"Pull failed (exit {result.returncode}).", err=True)
+            detail = ""
             if not verbose and result.stderr:
-                click.echo(result.stderr.strip(), err=True)
-            click.echo(f"Try: cd {target} && git pull --rebase", err=True)
-            sys.exit(1)
+                detail = f"\n{result.stderr.strip()}"
+            raise click.ClickException(
+                f"Pull failed (exit {result.returncode}).{detail}\n"
+                f"Try: cd {target} && git pull --rebase"
+            )
         click.echo("Registry updated.")
     elif target.exists() and any(target.iterdir()):
         # Directory exists but isn't a git repo.
-        click.echo(
+        raise click.ClickException(
             f"Directory {target} exists but is not a git repository.\n"
             f"If this is a manually managed registry, use --registry-dir "
             f"to point labeille at it.\n"
-            f"To use laruche, remove {target} and re-run this command.",
-            err=True,
+            f"To use laruche, remove {target} and re-run this command."
         )
-        sys.exit(1)
     else:
         # Fresh clone.
         click.echo(f"Cloning laruche registry into {target}...")
@@ -721,11 +718,10 @@ def sync_cmd(
                 timeout=120,
             )
         except subprocess.TimeoutExpired:
-            click.echo("Clone timed out after 120 seconds.", err=True)
-            sys.exit(1)
+            raise click.ClickException("Clone timed out after 120 seconds.")
         if result.returncode != 0:
-            click.echo(f"Clone failed (exit {result.returncode}).", err=True)
+            detail = ""
             if not verbose and result.stderr:
-                click.echo(result.stderr.strip(), err=True)
-            sys.exit(1)
+                detail = f"\n{result.stderr.strip()}"
+            raise click.ClickException(f"Clone failed (exit {result.returncode}).{detail}")
         click.echo(f"Registry cloned to {target}.")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -556,7 +556,7 @@ class TestMigrateCLI(unittest.TestCase):
             ["migrate", "nonexistent-migration", "--registry-dir", str(self.registry_dir)],
         )
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("unknown migration", result.output)
+        self.assertIn("Unknown migration", result.output)
 
     def test_migrate_no_name_no_list(self) -> None:
         result = self.runner.invoke(

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -542,7 +542,7 @@ class TestMigrateCli(unittest.TestCase):
             ["migrate", "--registry-dir", str(self.registry)],
         )
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("missing MIGRATION_NAME", result.output)
+        self.assertIn("Missing MIGRATION_NAME", result.output)
 
     def test_unknown_migration(self) -> None:
         result = self.runner.invoke(
@@ -550,7 +550,7 @@ class TestMigrateCli(unittest.TestCase):
             ["migrate", "nonexistent_migration", "--registry-dir", str(self.registry)],
         )
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("unknown migration", result.output)
+        self.assertIn("Unknown migration", result.output)
 
 
 class TestSyncCli(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Replace `click.echo("Error: ...") + sys.exit(1)` with `raise click.ClickException(...)` for 10 error sites in `registry_cli.py`
- Covers: protected field checks, missing migration names, unknown migrations, already-applied migrations, sync failures/timeouts
- 12 post-output `sys.exit(1)` calls remain intentionally for dry-run/apply error exit codes

## Test plan
- [x] All 2068 tests pass
- [x] ruff format/check clean
- [x] mypy strict passes
- [x] Updated test assertions for capitalization changes

Closes #208

Generated with [Claude Code](https://claude.com/claude-code)