### PR TITLE
fix: wire up setup_logging for ignored --verbose flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Extract `_HOST_LABELS` and `_INSTALL_LABELS` to module-level constants in `analyze_cli.py`, removing duplicates between terminal and markdown formatters.
 - Migrate `RunMeta.from_dict` and `PackageResult.from_dict` in `analyze.py` to use `dataclass_from_dict` utility.
 - Use `safe_load_yaml` in `migrations.py` instead of duplicating the YAML load-and-validate pattern.
+- Wire up `setup_logging` for `--verbose` flags in `analyze registry`, `analyze run`, and `registry sync` commands that previously accepted but ignored the flag.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -41,6 +41,7 @@ from labeille.formatting import (
     format_table,
     truncate,
 )
+from labeille.logging import setup_logging
 from labeille.registry import (
     PackageEntry,
     RegistrySchemaError,
@@ -121,6 +122,8 @@ def registry_cmd(
     verbose: bool,
 ) -> None:
     """Analyze registry composition and generate reports."""
+    setup_logging(verbose=verbose)
+
     from labeille.registry import Index, default_registry_dir, load_index
 
     if registry_dir is None:
@@ -659,6 +662,8 @@ def run_cmd(
     no_reproduce: bool,
 ) -> None:
     """Analyze a single run."""
+    setup_logging(verbose=verbose, quiet=quiet)
+
     from labeille.registry import default_registry_dir
 
     if registry_dir is None:

--- a/src/labeille/registry_cli.py
+++ b/src/labeille/registry_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import click
 
 from labeille.cli_utils import parse_csv_list
+from labeille.logging import setup_logging
 from labeille.registry_ops import (
     PROTECTED_FIELDS,
     PROTECTED_INDEX_FIELDS,
@@ -670,6 +671,8 @@ def sync_cmd(
     The registry is stored at ~/.local/share/labeille/registry/ by
     default, or wherever --registry-dir points.
     """
+    setup_logging(verbose=verbose)
+
     import subprocess
 
     from labeille.registry import LARUCHE_REPO_URL, default_registry_dir


### PR DESCRIPTION
## Summary
- Wire up `setup_logging(verbose=verbose)` in `analyze registry`, `analyze run`, and `registry sync` commands
- Previously these commands accepted `--verbose` but silently ignored it

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes
- [x] All 2068 tests pass

Closes #214

Generated with [Claude Code](https://claude.com/claude-code)