### PR TITLE
fix: add exc_info=True to log.error() calls missing tracebacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Use `atomic_write_text` for `bench/results.py` JSONL batch write and remove unused `to_jsonl_line`/`from_jsonl_line` methods.
 - Use `dataclass_from_dict` in `BenchIteration.from_dict` instead of inline field-filtering reimplementation.
 - Use `load_json_file` in `bench/tracking.py` `load_series` instead of inline JSON parsing.
+- Add `exc_info=True` to 14 `log.error()` calls inside `except` blocks across `runner.py`, `resolve.py`, `bench/runner.py`, and `ft/runner.py` to preserve tracebacks for debugging.
+- Explicitly set `import_ok = False` in `ft/compat.py` `JSONDecodeError`, `KeyError`, and `OSError` handlers for robustness.
 
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -629,7 +629,7 @@ class BenchRunner:
             else:
                 raise OSError(f"No repo URL for {pkg.package}")
         except (OSError, subprocess.SubprocessError) as exc:
-            log.error("Failed to clone %s: %s", pkg.package, exc)
+            log.error("Failed to clone %s: %s", pkg.package, exc, exc_info=True)
             return None
         setup["clone_duration"] = time.monotonic() - clone_start
         setup["repo_dir"] = repo_dir
@@ -660,6 +660,7 @@ class BenchRunner:
                     pkg.package,
                     cond_name,
                     exc,
+                    exc_info=True,
                 )
                 return None
             setup[f"venv_{cond_name}"] = time.monotonic() - venv_start
@@ -693,7 +694,9 @@ class BenchRunner:
                     )
                     return None
             except (OSError, subprocess.SubprocessError) as exc:
-                log.error("Install failed for %s/%s: %s", pkg.package, cond_name, exc)
+                log.error(
+                    "Install failed for %s/%s: %s", pkg.package, cond_name, exc, exc_info=True
+                )
                 return None
             setup[f"install_{cond_name}"] = time.monotonic() - install_start
 

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -330,10 +330,13 @@ def probe_gil_fallback(
         compat.import_ok = False
     except json.JSONDecodeError as exc:
         compat.probe_error = f"Probe output not valid JSON: {exc}"
+        compat.import_ok = False
     except KeyError as exc:
         compat.probe_error = f"Probe output missing field: {exc}"
+        compat.import_ok = False
     except (FileNotFoundError, OSError) as exc:
         compat.probe_error = f"Could not run probe: {exc}"
+        compat.import_ok = False
 
     return compat
 

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -537,7 +537,7 @@ def _clone_and_align_ft(
         else:
             raise OSError(f"No repo URL for {pkg.package}")
     except (OSError, subprocess.SubprocessError) as exc:
-        log.error("Failed to clone/pull %s: %s", pkg.package, exc)
+        log.error("Failed to clone/pull %s: %s", pkg.package, exc, exc_info=True)
         result.install_ok = False
         result.install_error = f"Clone failed: {exc}"
         result.categorize()
@@ -616,7 +616,7 @@ def _create_venv_and_install_ft(
     try:
         create_venv(config.target_python, venv_dir)
     except (OSError, subprocess.SubprocessError) as exc:
-        log.error("Venv creation failed for %s: %s", pkg.package, exc)
+        log.error("Venv creation failed for %s: %s", pkg.package, exc, exc_info=True)
         result.install_ok = False
         result.install_error = f"Venv creation failed: {exc}"
         result.categorize()

--- a/src/labeille/resolve.py
+++ b/src/labeille/resolve.py
@@ -292,13 +292,13 @@ def fetch_pypi_metadata(
         else:
             resp = requests.get(url, timeout=timeout, headers={"User-Agent": _USER_AGENT})
     except requests.ConnectionError as exc:
-        log.error("Connection error fetching %s: %s", package_name, exc)
+        log.error("Connection error fetching %s: %s", package_name, exc, exc_info=True)
         return None
     except requests.Timeout:
-        log.error("Timeout fetching %s", package_name)
+        log.error("Timeout fetching %s", package_name, exc_info=True)
         return None
     except requests.RequestException as exc:
-        log.error("Request error fetching %s: %s", package_name, exc)
+        log.error("Request error fetching %s: %s", package_name, exc, exc_info=True)
         return None
 
     if resp.status_code == 404:
@@ -315,7 +315,7 @@ def fetch_pypi_metadata(
         data: dict[str, Any] = resp.json()
         return data
     except (ValueError, requests.JSONDecodeError):
-        log.error("Invalid JSON response for %s", package_name)
+        log.error("Invalid JSON response for %s", package_name, exc_info=True)
         return None
 
 

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -170,7 +170,7 @@ def save_crash_stderr(run_dir: Path, package_name: str, stderr: str) -> None:
         crash_file.parent.mkdir(parents=True, exist_ok=True)
         crash_file.write_text(stderr, encoding="utf-8")
     except OSError as exc:
-        log.error("Could not save crash stderr for %s: %s", package_name, exc)
+        log.error("Could not save crash stderr for %s: %s", package_name, exc, exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -656,7 +656,7 @@ def _ensure_repo(
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
             result.status = "clone_error"
             result.error_message = f"Clone failed: {exc}"
-            log.error("Clone failed for %s: %s", pkg.package, exc)
+            log.error("Clone failed for %s: %s", pkg.package, exc, exc_info=True)
             return False
 
     clone_dur = round(time.monotonic() - clone_start, 2)
@@ -716,13 +716,13 @@ def _run_install(
         result.status = "install_error"
         result.error_message = f"Install timed out{label}"
         result.install_duration_seconds = round(time.monotonic() - install_start, 2)
-        log.error("Install timed out for %s%s", pkg.package, label)
+        log.error("Install timed out for %s%s", pkg.package, label, exc_info=True)
         return None
     except OSError as exc:
         result.status = "install_error"
         result.error_message = f"Install failed{label}: {exc}"
         result.install_duration_seconds = round(time.monotonic() - install_start, 2)
-        log.error("Install failed for %s%s: %s", pkg.package, label, exc)
+        log.error("Install failed for %s%s: %s", pkg.package, label, exc, exc_info=True)
         return None
 
     result.install_duration_seconds = round(time.monotonic() - install_start, 2)
@@ -848,7 +848,7 @@ def _setup_venv(
         except (subprocess.CalledProcessError, OSError) as exc:
             result.status = "error"
             result.error_message = f"Venv creation failed: {exc}"
-            log.error("Venv creation failed for %s: %s", pkg.package, exc)
+            log.error("Venv creation failed for %s: %s", pkg.package, exc, exc_info=True)
             return None
         log.debug("Venv created for %s in %.2fs", pkg.package, time.monotonic() - venv_start)
 
@@ -968,12 +968,12 @@ def _check_import(
         except subprocess.TimeoutExpired:
             result.status = "install_error"
             result.error_message = "Package installed but import timed out"
-            log.error("Import check timed out for %s", pkg.package)
+            log.error("Import check timed out for %s", pkg.package, exc_info=True)
             return False
         except OSError as exc:
             result.status = "install_error"
             result.error_message = f"Import check OSError: {exc}"
-            log.error("Import check failed for %s: %s", pkg.package, exc)
+            log.error("Import check failed for %s: %s", pkg.package, exc, exc_info=True)
             return False
 
     return True


### PR DESCRIPTION
## Summary
- Add `exc_info=True` to 14 `log.error()` calls inside `except` blocks across `runner.py`, `resolve.py`, `bench/runner.py`, and `ft/runner.py`
- Explicitly set `import_ok = False` in `ft/compat.py` `JSONDecodeError`, `KeyError`, and `OSError` handlers

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes
- [x] All 2068 tests pass

Closes #218

Generated with [Claude Code](https://claude.com/claude-code)