### PR TITLE
fix: replace Any annotations with concrete types and add Literal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Use `append_jsonl()` in `migrations.py` instead of raw `open()`/`json.dumps` for pattern consistency.
 
 ### Fixed
+- Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` in `bench/runner.py`.
+- Replace `list[Any]` with `list[PackageEntry]` in `bench/runner.py` `_run_sequential` and `_run_interleaved`.
+- Replace `cond: Any` with `BenchConditionResult` in `bench/compare.py` `_collect_call_durations`.
+- Replace `Any` return/param types with `BenchConfig` in `bench_cli.py` `_build_base_config` and `_apply_config_overrides`.
+- Add `Literal` types for `BisectStep.status`, `BisectConfig.installer`, `PackageAnomaly.anomaly_type`/`severity`, `ValidationError.severity`, `BenchConfig.installer`, and `analyze.PackageResult.status`.
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.
 - Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
 - Add missing `encoding="utf-8"` to `bench_cli.py` export `write_text()` call.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from labeille.io_utils import dataclass_from_dict, load_json_file, load_jsonl, utc_now_iso
 from labeille.registry import Index, PackageEntry
@@ -53,7 +53,9 @@ class PackageResult:
     repo: str | None = None
     package_version: str | None = None
     git_revision: str | None = None
-    status: str = "error"
+    status: Literal[
+        "pass", "fail", "crash", "timeout", "install_error", "clone_error", "error"
+    ] = "error"
     exit_code: int = -1
     signal: int | None = None
     crash_signature: str | None = None

--- a/src/labeille/bench/anomaly.py
+++ b/src/labeille/bench/anomaly.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from labeille.io_utils import dataclass_from_dict
 
@@ -34,9 +34,8 @@ class PackageAnomaly:
 
     package: str
     condition: str
-    anomaly_type: str
-    # One of: "high_cv", "bimodal", "outlier_heavy", "status_mixed", "trend"
-    severity: str  # "info", "warning", "error"
+    anomaly_type: Literal["high_cv", "bimodal", "outlier_heavy", "status_mixed", "trend"]
+    severity: Literal["info", "warning", "error"]
     metric_value: float  # The value that triggered the anomaly
     threshold: float  # The threshold it exceeded
     description: str  # Human-readable explanation

--- a/src/labeille/bench/compare.py
+++ b/src/labeille/bench/compare.py
@@ -10,6 +10,7 @@ import statistics as _stats
 from dataclasses import dataclass, field
 
 from labeille.bench.results import (
+    BenchConditionResult,
     BenchMeta,
     BenchPackageResult,
 )
@@ -346,7 +347,7 @@ def compare_per_test(
 
     # Collect per-test call durations across measured iterations.
     def _collect_call_durations(
-        cond: Any,
+        cond: BenchConditionResult,
     ) -> dict[str, list[float]]:
         durations: dict[str, list[float]] = {}
         for it in cond.measured_iterations:

--- a/src/labeille/bench/config.py
+++ b/src/labeille/bench/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from labeille.bench.constraints import ResourceConstraints
 from labeille.bench.results import ConditionDef
@@ -85,7 +85,7 @@ class BenchConfig:
     run_dangerously_as_root: bool = False  # Allow running as root (for containers)
 
     # Installer backend
-    installer: str = "auto"
+    installer: Literal["auto", "uv", "pip"] = "auto"
 
     # CLI provenance
     cli_args: list[str] = field(default_factory=list)
@@ -124,7 +124,7 @@ class ValidationError:
 
     field: str
     message: str
-    severity: str = "error"  # "error" or "warning"
+    severity: Literal["error", "warning"] = "error"
 
 
 def validate_config(config: BenchConfig) -> list[ValidationError]:

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -23,6 +23,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -122,7 +123,7 @@ class BenchProgress:
 
 
 # Type alias for the progress callback.
-ProgressCallback = Any  # Callable[[BenchProgress], None] | None
+ProgressCallback = Callable[[BenchProgress], None] | None
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +147,9 @@ class BenchRunner:
         progress_callback: ProgressCallback = None,
     ) -> None:
         self.config = config
-        self.progress: Any = progress_callback or self._default_progress
+        self.progress: Callable[[BenchProgress], None] = (
+            progress_callback or self._default_progress
+        )
         self._meta: BenchMeta | None = None
         self._results: list[BenchPackageResult] = []
 
@@ -340,7 +343,7 @@ class BenchRunner:
 
     def _run_sequential(
         self,
-        packages: list[Any],
+        packages: list[PackageEntry],
         results_path: Path,
     ) -> list[BenchPackageResult]:
         """Run benchmarks sequentially: all iterations of one package
@@ -360,7 +363,7 @@ class BenchRunner:
 
     def _run_interleaved(
         self,
-        packages: list[Any],
+        packages: list[PackageEntry],
         results_path: Path,
     ) -> list[BenchPackageResult]:
         """Run benchmarks interleaved: iteration 1 of all packages,

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
+
+if TYPE_CHECKING:
+    from labeille.bench.config import BenchConfig
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
 from labeille.cli_utils import parse_csv_list
@@ -31,7 +34,7 @@ def bench() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_base_config(ctx: click.Context) -> Any:
+def _build_base_config(ctx: click.Context) -> BenchConfig:
     """Build a BenchConfig from Click context parameters.
 
     Creates the initial config from either a YAML profile or CLI defaults,
@@ -109,7 +112,7 @@ def _build_base_config(ctx: click.Context) -> Any:
     return config
 
 
-def _apply_config_overrides(config: Any, ctx: click.Context) -> Any:
+def _apply_config_overrides(config: BenchConfig, ctx: click.Context) -> BenchConfig:
     """Apply shared CLI overrides and finalize a BenchConfig.
 
     Handles test overrides, env vars, adaptive settings, resource

--- a/src/labeille/bisect.py
+++ b/src/labeille/bisect.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from labeille.crash import detect_crash
 from labeille.logging import get_logger
@@ -48,7 +49,7 @@ class BisectConfig:
     env_overrides: dict[str, str] = field(default_factory=dict)
     work_dir: Path | None = None
     verbose: bool = False
-    installer: str = "auto"
+    installer: Literal["auto", "uv", "pip"] = "auto"
 
 
 @dataclass
@@ -57,7 +58,7 @@ class BisectStep:
 
     commit: str
     commit_short: str
-    status: str  # "good", "bad", "skip"
+    status: Literal["good", "bad", "skip"]
     detail: str = ""
     crash_signature: str | None = None
     duration_seconds: float = 0.0

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -735,7 +735,7 @@ def bisect_cmd(
         env_overrides=env_overrides,
         work_dir=work_dir,
         verbose=verbose,
-        installer=installer,
+        installer=installer,  # type: ignore[arg-type]  # Click Choice returns str
     )
 
     click.echo(f"Bisecting {package}: good={good_rev} bad={bad_rev}")


### PR DESCRIPTION
## Summary
- Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` and fix `list[Any]` → `list[PackageEntry]` in bench/runner.py
- Replace `cond: Any` → `BenchConditionResult` and `Any` return/param types → `BenchConfig` in bench_cli.py
- Add `Literal` types for 6 string fields with closed value sets across bisect.py, bench/anomaly.py, bench/config.py, and analyze.py

## Test plan
- [x] mypy strict passes (0 errors)
- [x] Full test suite passes (2099 tests)
- [x] ruff format/check clean

Closes #224

Generated with [Claude Code](https://claude.com/claude-code)