### PR TITLE
fix: address silent failures, consistency issues, and pattern divergences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Replace `cond: Any` with `BenchConditionResult` in `bench/compare.py` `_collect_call_durations`.
 - Replace `Any` return/param types with `BenchConfig` in `bench_cli.py` `_build_base_config` and `_apply_config_overrides`.
 - Add `Literal` types for `BisectStep.status`, `BisectConfig.installer`, `PackageAnomaly.anomaly_type`/`severity`, `ValidationError.severity`, `BenchConfig.installer`, and `analyze.PackageResult.status`.
+- Log warning in `runner.py:list_installed_packages` when pip exits with non-zero code instead of silently returning empty.
+- Raise `RegistrySchemaError` in `check_registry_schema` when `schema.yaml` exists but is corrupt instead of silently ignoring.
+- Set `import_ok = False` in `ft/runner.py` when extension compat check raises instead of leaving default `True`.
+- Remove dead `hasattr(result, "returncode")` guard in `bench/runner.py` — `install_with_fallback` always returns `CompletedProcess`.
+- Use `parse_env_pairs` in `ft_cli.py` and `bench_cli.py` instead of inline env parsing that silently drops malformed pairs.
+- Use `load_jsonl` in `migrations.py:read_migration_log` instead of hand-rolled JSONL parsing.
+- Add missing docstrings to 8 `to_dict` methods in `ft/analysis.py`, `ft/compare.py`, `ft/compat.py`.
+- Replace 21 `assertTrue(len(...))` with `assertGreater`/`assertGreaterEqual` in tests for better failure messages.
+- Convert `mkdtemp()` to `TemporaryDirectory()` in `test_ft_compat.py` for consistency.
 - Type `pkg: Any` parameters as `PackageEntry` in `bench/runner.py` and `ft/runner.py` for type safety.
 - Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
 - Add missing `encoding="utf-8"` to `bench_cli.py` export `write_text()` call.

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -688,7 +688,7 @@ class BenchRunner:
                     installer,
                 )
                 venv_python = venv_dir / "bin" / "python"  # refresh after possible recreate
-                if hasattr(result, "returncode") and result.returncode != 0:
+                if result.returncode != 0:
                     log.error(
                         "Install failed for %s/%s (exit %d)",
                         pkg.package,

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from labeille.bench.config import BenchConfig
 
 from labeille.bench.results import BenchMeta, BenchPackageResult
-from labeille.cli_utils import parse_csv_list
+from labeille.cli_utils import parse_csv_list, parse_env_pairs
 from labeille.logging import setup_logging
 
 
@@ -127,10 +127,7 @@ def _apply_config_overrides(config: BenchConfig, ctx: click.Context) -> BenchCon
     if p["test_command_suffix"]:
         config.default_test_command_suffix = p["test_command_suffix"]
 
-    for pair in p["env_pairs"]:
-        if "=" in pair:
-            k, v = pair.split("=", 1)
-            config.default_env[k] = v
+    config.default_env.update(parse_env_pairs(p["env_pairs"]))
 
     config.installer = p["installer"]
     if p["adaptive"]:

--- a/src/labeille/ft/analysis.py
+++ b/src/labeille/ft/analysis.py
@@ -37,6 +37,7 @@ class FlakyTest:
     statuses: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "test_id": self.test_id,
             "fail_count": self.fail_count,
@@ -65,6 +66,7 @@ class FlakinessProfile:
     pattern: str = "unknown"
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "package": self.package,
             "pass_rate": round(self.pass_rate, 4),
@@ -211,6 +213,7 @@ class GILComparisonResult:
         return self.gil_enabled_pass_rate == 1.0 and self.gil_disabled_pass_rate < 1.0
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "package": self.package,
             "gil_disabled_pass_rate": round(self.gil_disabled_pass_rate, 4),
@@ -306,6 +309,7 @@ class TriageEntry:
     monthly_downloads: int = 0
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "package": self.package,
             "priority_score": round(self.priority_score, 2),

--- a/src/labeille/ft/compare.py
+++ b/src/labeille/ft/compare.py
@@ -32,6 +32,7 @@ class PackageTransition:
     detail: str = ""  # Human-readable description
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "package": self.package,
             "old_category": self.old_category,
@@ -80,6 +81,7 @@ class FTComparisonResult:
         return self.compatible_count_b - self.compatible_count_a
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return {
             "label_a": self.label_a,
             "label_b": self.label_b,

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -38,6 +38,7 @@ class ExtensionInfo:
     triggered_gil_fallback: bool = False
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return asdict(self)
 
     @classmethod
@@ -55,6 +56,7 @@ class ModGilDeclaration:
     is_not_used: bool
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
         return asdict(self)
 
     @classmethod

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -895,6 +895,8 @@ def run_package_ft(
                 result.import_error = compat.import_error
             except (OSError, subprocess.SubprocessError, ValueError) as exc:
                 log.warning("Extension compat check failed for %s: %s", pkg.package, exc)
+                result.import_ok = False
+                result.import_error = f"Extension compat check failed: {exc}"
 
             if not result.import_ok:
                 result.categorize()

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from labeille.cli_utils import parse_csv_list
+from labeille.cli_utils import parse_csv_list, parse_env_pairs
 
 
 @click.group()
@@ -186,11 +186,7 @@ def run(
     if registry_dir is None:
         registry_dir = default_registry_dir()
 
-    env_overrides: dict[str, str] = {}
-    for pair in env_pairs:
-        if "=" in pair:
-            k, v = pair.split("=", 1)
-            env_overrides[k] = v
+    env_overrides = parse_env_pairs(env_pairs)
 
     config = FTRunConfig(
         target_python=target_python,

--- a/src/labeille/migrations.py
+++ b/src/labeille/migrations.py
@@ -8,7 +8,6 @@ accidental re-application.
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,7 +15,7 @@ from typing import Any, Callable
 
 import yaml
 
-from labeille.io_utils import atomic_write_text, safe_load_yaml, utc_now_iso
+from labeille.io_utils import atomic_write_text, load_jsonl, safe_load_yaml, utc_now_iso
 from labeille.logging import get_logger
 from labeille.registry import _dict_to_package, _package_to_dict
 
@@ -121,29 +120,22 @@ def _log_path(registry_dir: Path) -> Path:
     return registry_dir / "migrations.log"
 
 
+def _deserialize_log_entry(data: dict[str, Any]) -> MigrationLogEntry:
+    """Deserialize a migration log entry from a JSON dict."""
+    return MigrationLogEntry(
+        migration=data["migration"],
+        applied_at=data["applied_at"],
+        files_modified=data["files_modified"],
+        files_skipped=data["files_skipped"],
+    )
+
+
 def read_migration_log(registry_dir: Path) -> list[MigrationLogEntry]:
     """Read the migration log. Returns empty list if file doesn't exist."""
     path = _log_path(registry_dir)
     if not path.exists():
         return []
-    entries: list[MigrationLogEntry] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            data = json.loads(line)
-            entries.append(
-                MigrationLogEntry(
-                    migration=data["migration"],
-                    applied_at=data["applied_at"],
-                    files_modified=data["files_modified"],
-                    files_skipped=data["files_skipped"],
-                )
-            )
-        except (json.JSONDecodeError, KeyError):
-            log.warning("Skipping malformed migration log entry: %s", line)
-    return entries
+    return load_jsonl(path, _deserialize_log_entry)
 
 
 def append_migration_log(registry_dir: Path, entry: MigrationLogEntry) -> None:

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -71,8 +71,9 @@ def check_registry_schema(registry_path: Path) -> None:
     try:
         data = yaml.safe_load(schema_file.read_text(encoding="utf-8"))
     except (yaml.YAMLError, OSError) as exc:
-        log.warning("Could not parse schema.yaml in %s: %s", registry_path, exc)
-        return
+        raise RegistrySchemaError(
+            f"schema.yaml exists at {registry_path} but cannot be parsed: {exc}"
+        ) from exc
 
     if not isinstance(data, dict):
         return

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -451,6 +451,12 @@ def get_installed_packages(
         if proc.returncode == 0:
             packages = json.loads(proc.stdout)
             return {p["name"]: p["version"] for p in packages}
+        else:
+            log.warning(
+                "pip list exited %d: %s",
+                proc.returncode,
+                (proc.stderr or "").strip()[:200],
+            )
     except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError, OSError) as exc:
         log.warning("Could not list installed packages: %s", exc)
     return {}

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1304,12 +1304,12 @@ class TestGenerateRegistryReport(unittest.TestCase):
     def test_report_quality_warnings(self) -> None:
         packages = [_make_pkg("a", enriched=True, test_command="")]
         report = generate_registry_report(packages)
-        self.assertTrue(len(report.quality_warnings) > 0)
+        self.assertGreater(len(report.quality_warnings), 0)
 
     def test_report_generated_at(self) -> None:
         packages = [_make_pkg("a")]
         report = generate_registry_report(packages)
-        self.assertTrue(len(report.generated_at) > 0)
+        self.assertGreater(len(report.generated_at), 0)
 
     def test_report_empty_packages(self) -> None:
         report = generate_registry_report([])

--- a/tests/test_bench_anomaly.py
+++ b/tests/test_bench_anomaly.py
@@ -245,7 +245,7 @@ class TestDetectAnomalies(unittest.TestCase):
 
         # Test by_type.
         by_type = report.by_type
-        self.assertTrue(len(by_type) > 0)
+        self.assertGreater(len(by_type), 0)
 
         # Test affected_packages.
         self.assertIn("unstable", report.affected_packages)

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -162,7 +162,7 @@ class TestValidateConfig(unittest.TestCase):
         config.alternate = True
         errors = validate_config(config)
         warnings = [e for e in errors if e.severity == "warning"]
-        self.assertTrue(len(warnings) > 0)
+        self.assertGreater(len(warnings), 0)
 
     def test_validate_adaptive_threshold_positive(self) -> None:
         """Adaptive threshold must be positive."""

--- a/tests/test_bench_export.py
+++ b/tests/test_bench_export.py
@@ -107,7 +107,7 @@ class TestExportCSV(unittest.TestCase):
         output = export_csv(meta, results)
         reader = csv.reader(io.StringIO(output))
         rows = list(reader)
-        self.assertTrue(len(rows) > 1)
+        self.assertGreater(len(rows), 1)
         header_len = len(rows[0])
         for row in rows[1:]:
             self.assertEqual(len(row), header_len)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -296,7 +296,7 @@ class TestClassifyBuildOutput(unittest.TestCase):
     def test_detects_pyunicode_ready(self) -> None:
         stderr = "foo.c:42: error: implicit declaration of PyUnicode_READY\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "removed_c_api")
         self.assertEqual(matches[0].subcategory, "PyUnicode_READY")
         self.assertEqual(matches[0].since, "3.12")
@@ -304,51 +304,51 @@ class TestClassifyBuildOutput(unittest.TestCase):
     def test_detects_py_unicode(self) -> None:
         stderr = "error: unknown type name 'Py_UNICODE'\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].subcategory, "Py_UNICODE")
 
     def test_detects_tp_print(self) -> None:
         stderr = "error: 'PyTypeObject' has no member named 'tp_print'\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].subcategory, "tp_print")
 
     def test_detects_distutils_removed(self) -> None:
         stderr = "ModuleNotFoundError: No module named 'distutils'\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "setuptools_distutils")
 
     def test_detects_missing_header(self) -> None:
         stderr = "fatal error: openssl/ssl.h: No such file or directory\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "missing_system_lib")
         self.assertEqual(matches[0].subcategory, "missing_header")
 
     def test_detects_python_h_missing(self) -> None:
         stderr = "fatal error: Python.h: No such file or directory\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "python_header")
 
     def test_detects_linker_error(self) -> None:
         stderr = "undefined reference to `PyFoo_Bar'\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "compiler_error")
         self.assertEqual(matches[0].subcategory, "linker_error")
 
     def test_detects_pyo3(self) -> None:
         stderr = "error: PyO3 does not support Python 3.15\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "pyo3_incompatible")
 
     def test_detects_rust_error(self) -> None:
         stderr = "error[E0412]: cannot find type `PyObject`\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].subcategory, "rust_build_fail")
 
     def test_detects_cython_version(self) -> None:
@@ -399,30 +399,30 @@ class TestClassifyBuildOutput(unittest.TestCase):
     def test_case_insensitive(self) -> None:
         stderr = "Error: IMPLICIT DECLARATION OF PYUNICODE_READY\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
 
     def test_detects_ob_type_assignment(self) -> None:
         stderr = "error: assignment to read-only member 'ob_type'\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "changed_struct")
 
     def test_detects_missing_library(self) -> None:
         stderr = "cannot find -lssl\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].subcategory, "missing_library")
 
     def test_detects_cmake_error(self) -> None:
         stderr = "CMakeLists.txt error: something went wrong\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "build_backend")
 
     def test_detects_import_undefined_symbol(self) -> None:
         stderr = "ImportError: symbol PyFoo not found\n"
         matches = classify_build_output(stderr)
-        self.assertTrue(len(matches) >= 1)
+        self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].category, "import_failure")
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -89,7 +89,7 @@ class TestFormatTable(unittest.TestCase):
         # Count column should be right-aligned.
         for line in lines:
             # The count value in the last column.
-            self.assertTrue(len(line) > 0)
+            self.assertGreater(len(line), 0)
 
     def test_empty_rows(self) -> None:
         headers = ["Name", "Value"]

--- a/tests/test_ft_compat.py
+++ b/tests/test_ft_compat.py
@@ -197,13 +197,11 @@ class TestGuessImportName(unittest.TestCase):
 
 class TestScanSourceForModGil(unittest.TestCase):
     def setUp(self) -> None:
-        self.tmpdir = tempfile.mkdtemp()
-        self.repo = Path(self.tmpdir)
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
 
     def tearDown(self) -> None:
-        import shutil
-
-        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def _write_file(self, relpath: str, content: str) -> Path:
         p = self.repo / relpath
@@ -454,13 +452,11 @@ class TestProbeGilFallback(unittest.TestCase):
 
 class TestAssessExtensionCompat(unittest.TestCase):
     def setUp(self) -> None:
-        self.tmpdir = tempfile.mkdtemp()
-        self.repo = Path(self.tmpdir)
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
 
     def tearDown(self) -> None:
-        import shutil
-
-        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        self._tmpdir.cleanup()
 
     def _write_file(self, relpath: str, content: str) -> None:
         p = self.repo / relpath

--- a/tests/test_scan_deps.py
+++ b/tests/test_scan_deps.py
@@ -899,7 +899,7 @@ class TestParseInstallPackages(unittest.TestCase):
     def test_editable_install_with_extras(self) -> None:
         pkgs, extras = _parse_install_packages("pip install -e '.[test]'")
         self.assertEqual(pkgs, [])
-        self.assertTrue(len(extras) > 0)
+        self.assertGreater(len(extras), 0)
 
     def test_version_specifiers(self) -> None:
         pkgs, extras = _parse_install_packages("pip install foo>=1.0 bar==2.0")


### PR DESCRIPTION
## Summary
- Fix 4 silent failures: log on pip non-zero exit, raise on corrupt schema.yaml, set import_ok=False on ft compat failure, remove dead hasattr guard
- Add docstrings to 8 ft/ to_dict methods, replace 21 weak test assertions, convert mkdtemp to TemporaryDirectory
- Consolidate env parsing and JSONL loading to use shared utilities

## Test plan
- [x] mypy strict passes (0 errors)
- [x] Full test suite passes (2099 tests)
- [x] ruff format/check clean

Closes #226

Generated with [Claude Code](https://claude.com/claude-code)