### PR TITLE
test: add io_utils test coverage for 8 untested functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `test_cli_utils.py` with 14 tests for `parse_env_pairs` and `parse_csv_list`.
 - Add 12 behavioral tests for `ft compare`, `ft report`, and `ft export` CLI commands.
 - Add `test_repo_ops.py` with 31 tests for `clone_repo`, `pull_repo`, `checkout_revision`, `parse_package_specs`, and `parse_repo_overrides`.
+- Add 35 tests to `test_io_utils.py` for `load_yaml_strict`, `iter_jsonl`, `load_jsonl`, `append_jsonl`, `dataclass_from_dict`, `extract_minor_version`, `generate_run_id`, and `write_meta_json`.
 
 ### Documentation
 - Update CLAUDE.md: fix stale test count (546 → 2068) and add 13 missing modules to architecture section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 ## Testing notes
 - Integration tests mock `fetch_pypi_metadata` to avoid network calls
 - Runner tests mock `subprocess.run` and `clone_repo` extensively
-- 2099 tests total across 49 test files
+- 2134 tests total across 49 test files
 
 ## Enriching packages
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from labeille.io_utils import atomic_write_text, safe_load_yaml, utc_now_iso
+from labeille.io_utils import (
+    append_jsonl,
+    atomic_write_text,
+    dataclass_from_dict,
+    extract_minor_version,
+    generate_run_id,
+    iter_jsonl,
+    load_jsonl,
+    load_yaml_strict,
+    safe_load_yaml,
+    utc_now_iso,
+    write_meta_json,
+)
 
 
 class TestAtomicWriteText(unittest.TestCase):
@@ -167,6 +181,276 @@ class TestLoadJsonFile(unittest.TestCase):
             p = Path(tmp) / "missing.json"
             with self.assertRaises(OSError):
                 load_json_file(p)
+
+
+class TestLoadYamlStrict(unittest.TestCase):
+    """Tests for load_yaml_strict."""
+
+    def test_valid_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "test.yaml"
+            p.write_text("key: value\ncount: 42\n", encoding="utf-8")
+            result = load_yaml_strict(p)
+            self.assertEqual(result, {"key": "value", "count": 42})
+
+    def test_malformed_yaml_raises_valueerror(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.yaml"
+            p.write_text(":\n  - :\n    bad: [unterminated\n", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_yaml_strict(p)
+            self.assertIn("Invalid YAML", str(ctx.exception))
+
+    def test_non_dict_raises_valueerror(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "list.yaml"
+            p.write_text("- item1\n- item2\n", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_yaml_strict(p)
+            self.assertIn("Expected YAML mapping", str(ctx.exception))
+
+    def test_empty_file_raises_valueerror(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "empty.yaml"
+            p.write_text("", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_yaml_strict(p)
+            self.assertIn("Expected YAML mapping", str(ctx.exception))
+
+    def test_scalar_raises_valueerror(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "scalar.yaml"
+            p.write_text("just a string\n", encoding="utf-8")
+            with self.assertRaises(ValueError) as ctx:
+                load_yaml_strict(p)
+            self.assertIn("Expected YAML mapping", str(ctx.exception))
+
+
+class TestIterJsonl(unittest.TestCase):
+    """Tests for iter_jsonl."""
+
+    def test_valid_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text(
+                '{"name": "a", "val": 1}\n{"name": "b", "val": 2}\n',
+                encoding="utf-8",
+            )
+            results = list(iter_jsonl(p, lambda d: d))
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0]["name"], "a")
+            self.assertEqual(results[1]["name"], "b")
+
+    def test_skips_malformed_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text(
+                '{"name": "a"}\n{truncated\n{"name": "b"}\n',
+                encoding="utf-8",
+            )
+            results = list(iter_jsonl(p, lambda d: d))
+            self.assertEqual(len(results), 2)
+
+    def test_skips_blank_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text('{"x": 1}\n\n\n{"x": 2}\n', encoding="utf-8")
+            results = list(iter_jsonl(p, lambda d: d))
+            self.assertEqual(len(results), 2)
+
+    def test_deserialize_error_skipped(self) -> None:
+        def bad_deserialize(d: dict) -> str:  # type: ignore[type-arg]
+            return d["missing_key"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text('{"name": "a"}\n', encoding="utf-8")
+            results = list(iter_jsonl(p, bad_deserialize))
+            self.assertEqual(results, [])
+
+    def test_empty_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "empty.jsonl"
+            p.write_text("", encoding="utf-8")
+            results = list(iter_jsonl(p, lambda d: d))
+            self.assertEqual(results, [])
+
+
+class TestLoadJsonl(unittest.TestCase):
+    """Tests for load_jsonl."""
+
+    def test_returns_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text('{"a": 1}\n{"a": 2}\n', encoding="utf-8")
+            results = load_jsonl(p, lambda d: d)
+            self.assertIsInstance(results, list)
+            self.assertEqual(len(results), 2)
+
+    def test_with_custom_deserializer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text('{"val": 10}\n{"val": 20}\n', encoding="utf-8")
+            results = load_jsonl(p, lambda d: d["val"] * 2)
+            self.assertEqual(results, [20, 40])
+
+
+class TestAppendJsonl(unittest.TestCase):
+    """Tests for append_jsonl."""
+
+    def test_creates_file_if_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "new.jsonl"
+            append_jsonl(p, {"key": "value"})
+            self.assertTrue(p.exists())
+            content = p.read_text(encoding="utf-8")
+            self.assertEqual(json.loads(content.strip()), {"key": "value"})
+
+    def test_appends_to_existing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "existing.jsonl"
+            p.write_text('{"a": 1}\n', encoding="utf-8")
+            append_jsonl(p, {"a": 2})
+            lines = p.read_text(encoding="utf-8").strip().split("\n")
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[1]), {"a": 2})
+
+    def test_each_append_is_one_line(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "multi.jsonl"
+            append_jsonl(p, {"x": 1})
+            append_jsonl(p, {"x": 2})
+            append_jsonl(p, {"x": 3})
+            lines = [ln for ln in p.read_text(encoding="utf-8").split("\n") if ln.strip()]
+            self.assertEqual(len(lines), 3)
+
+
+class TestDataclassFromDict(unittest.TestCase):
+    """Tests for dataclass_from_dict."""
+
+    def test_basic_creation(self) -> None:
+        @dataclass
+        class Point:
+            x: int
+            y: int
+
+        result = dataclass_from_dict(Point, {"x": 1, "y": 2})
+        self.assertEqual(result.x, 1)
+        self.assertEqual(result.y, 2)
+
+    def test_ignores_unknown_keys(self) -> None:
+        @dataclass
+        class Simple:
+            name: str
+
+        result = dataclass_from_dict(Simple, {"name": "test", "extra": 42, "other": True})
+        self.assertEqual(result.name, "test")
+
+    def test_missing_required_field_raises(self) -> None:
+        @dataclass
+        class Required:
+            name: str
+            value: int
+
+        with self.assertRaises(TypeError):
+            dataclass_from_dict(Required, {"name": "test"})
+
+    def test_with_defaults(self) -> None:
+        @dataclass
+        class WithDefault:
+            name: str
+            count: int = 0
+
+        result = dataclass_from_dict(WithDefault, {"name": "test"})
+        self.assertEqual(result.count, 0)
+
+
+class TestExtractMinorVersion(unittest.TestCase):
+    """Tests for extract_minor_version."""
+
+    def test_full_version_string(self) -> None:
+        self.assertEqual(extract_minor_version("3.15.0a5+ (heads/main:abc1234)"), "3.15")
+
+    def test_release_version(self) -> None:
+        self.assertEqual(extract_minor_version("3.13.2"), "3.13")
+
+    def test_simple_major_minor(self) -> None:
+        self.assertEqual(extract_minor_version("3.14"), "3.14")
+
+    def test_alpha_suffix(self) -> None:
+        self.assertEqual(extract_minor_version("3.15a1"), "3.15")
+
+    def test_single_component_returns_original(self) -> None:
+        self.assertEqual(extract_minor_version("3"), "3")
+
+    def test_non_numeric_major_returns_original(self) -> None:
+        self.assertEqual(extract_minor_version("abc.15.0"), "abc.15.0")
+
+    def test_empty_string_returns_original(self) -> None:
+        self.assertEqual(extract_minor_version(""), "")
+
+    def test_strips_whitespace(self) -> None:
+        self.assertEqual(extract_minor_version("  3.14.1  "), "3.14")
+
+
+class TestGenerateRunId(unittest.TestCase):
+    """Tests for generate_run_id."""
+
+    def test_starts_with_prefix(self) -> None:
+        result = generate_run_id("bench")
+        self.assertTrue(result.startswith("bench_"))
+
+    def test_format_matches_pattern(self) -> None:
+        result = generate_run_id("ft")
+        self.assertRegex(result, r"^ft_\d{8}_\d{6}$")
+
+    def test_different_prefix(self) -> None:
+        result = generate_run_id("test_run")
+        self.assertTrue(result.startswith("test_run_"))
+
+    def test_uses_utc(self) -> None:
+        with patch("labeille.io_utils.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 11, 14, 30, 45, tzinfo=timezone.utc)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = generate_run_id("run")
+            mock_dt.now.assert_called_once_with(timezone.utc)
+            self.assertEqual(result, "run_20260311_143045")
+
+
+class TestWriteMetaJson(unittest.TestCase):
+    """Tests for write_meta_json."""
+
+    def test_writes_valid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "meta.json"
+            write_meta_json(p, {"run_id": "test_001", "count": 5})
+            content = p.read_text(encoding="utf-8")
+            data = json.loads(content)
+            self.assertEqual(data["run_id"], "test_001")
+            self.assertEqual(data["count"], 5)
+
+    def test_output_is_indented(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "meta.json"
+            write_meta_json(p, {"key": "value"})
+            content = p.read_text(encoding="utf-8")
+            self.assertIn("  ", content)
+
+    def test_output_ends_with_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "meta.json"
+            write_meta_json(p, {"key": "value"})
+            content = p.read_text(encoding="utf-8")
+            self.assertTrue(content.endswith("\n"))
+
+    def test_overwrites_existing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "meta.json"
+            write_meta_json(p, {"old": True})
+            write_meta_json(p, {"new": True})
+            data = json.loads(p.read_text(encoding="utf-8"))
+            self.assertNotIn("old", data)
+            self.assertIn("new", data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add 35 tests covering `load_yaml_strict`, `iter_jsonl`, `load_jsonl`, `append_jsonl`, `dataclass_from_dict`, `extract_minor_version`, `generate_run_id`, and `write_meta_json`
- Tests verify error handling (malformed YAML/JSONL, missing keys), edge cases (empty files, unknown dict keys), and correct output formats
- Update CLAUDE.md test count (2099 → 2134)

## Test plan
- [x] All 2134 tests pass
- [x] mypy strict — no issues
- [x] ruff format/check — clean

Closes #228

Generated with [Claude Code](https://claude.com/claude-code)