### PR TITLE
fix: standardize exception variable naming to exc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Fix `IndexEntry.package` attribute access (should be `.name`) in `ft/runner.py:_select_packages`.
 - Add missing `encoding="utf-8"` to `bench_cli.py` export `write_text()` call.
 - Import check `OSError` now sets `install_error` status instead of silently continuing.
+- Standardize exception variable naming from `as e:` to `as exc:` in `ft/compat.py`, `registry_ops.py`, and `registry_cli.py` (5 instances).
 - Raise compat survey clone/build failure log levels from `debug` to `warning` for visibility.
 - Rename `from_dict` parameter `d` → `data` in `CompatResult` and `CompatMeta` for consistency.
 - Bisect extra deps install failure now returns `skip` step instead of silently continuing.

--- a/src/labeille/ft/compat.py
+++ b/src/labeille/ft/compat.py
@@ -196,12 +196,12 @@ def probe_package(package_name):
     try:
         pkg = importlib.import_module(package_name)
         result["import_ok"] = True
-    except ImportError as e:
-        result["import_error"] = str(e)
+    except ImportError as exc:
+        result["import_error"] = str(exc)
         print(json.dumps(result))
         return
-    except Exception as e:
-        result["import_error"] = f"{type(e).__name__}: {e}"
+    except Exception as exc:
+        result["import_error"] = f"{type(exc).__name__}: {exc}"
         print(json.dumps(result))
         return
 

--- a/src/labeille/registry_cli.py
+++ b/src/labeille/registry_cli.py
@@ -56,8 +56,8 @@ def _parse_filters(where_exprs: tuple[str, ...]) -> list[FieldFilter]:
     for expr in where_exprs:
         try:
             filters.append(parse_where(expr))
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
     return filters
 
 

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -266,8 +266,8 @@ def batch_add_field(
             else:
                 # Append before the last field
                 new_lines = _append_field(lines, field_name, value_text)
-        except ValueError as e:
-            errors.append(f"{f.name}: {e}")
+        except ValueError as exc:
+            errors.append(f"{f.name}: {exc}")
             continue
 
         if dry_run:
@@ -536,8 +536,8 @@ def batch_set_field(
 
         try:
             new_lines = set_field_value(lines, field_name, formatted)
-        except ValueError as e:
-            errors.append(f"{f.name}: {e}")
+        except ValueError as exc:
+            errors.append(f"{f.name}: {exc}")
             continue
 
         if dry_run:


### PR DESCRIPTION
## Summary
- Rename 5 instances of `except ... as e:` to `as exc:` across ft/compat.py, registry_ops.py, and registry_cli.py
- Aligns with the 83+ existing uses of `exc` in the codebase

## Test plan
- [x] All 2166 tests pass
- [x] mypy strict — no issues
- [x] ruff format/check — clean

Closes #236

Generated with [Claude Code](https://claude.com/claude-code)