### PR TITLE
refactor: remove deprecated extract_python_minor_version wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Remove 3 unnecessary private re-exports (`_EXTRAS_RE`, `_SELF_INSTALL_RE`, `_TAG_PATTERNS`) from `runner.py`.
 - Move `dataclass_from_dict` imports from method bodies to module level across 9 files.
 - Deduplicate `extract_minor_version`: move canonical implementation to `io_utils.py`, delegate from `runner.py` and `analyze.py`.
+- Remove deprecated `extract_python_minor_version` wrapper from `runner.py`; callers in `cli.py` and `compat_cli.py` now use `io_utils.extract_minor_version` directly.
 - Delegate `format_signal_name` in `formatting.py` to `crash.signal_name` instead of duplicating signal conversion logic.
 - Replace inline JSON write in `bench/tracking.py` with `write_meta_json`.
 - Guard `_read_lines` call sites in `registry_ops.py` against `OSError`/`UnicodeDecodeError` to prevent batch operations from crashing on corrupt files.

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -322,7 +322,7 @@ def run_cmd(
     install_from: str,
 ) -> None:
     """Run test suites against a JIT-enabled Python build and detect crashes."""
-    from labeille.io_utils import generate_run_id
+    from labeille.io_utils import extract_minor_version, generate_run_id
     from labeille.registry import default_registry_dir
 
     if registry_dir is None:
@@ -330,7 +330,6 @@ def run_cmd(
 
     from labeille.runner import (
         RunnerConfig,
-        extract_python_minor_version,
         run_all,
         validate_target_python,
     )
@@ -413,7 +412,7 @@ def run_cmd(
         skip_extensions=skip_extensions,
         skip_completed=skip_completed,
         force_run=force_run,
-        target_python_version=extract_python_minor_version(python_version),
+        target_python_version=extract_minor_version(python_version),
         stop_after_crash=stop_after_crash,
         env_overrides=env_overrides,
         dry_run=dry_run,

--- a/src/labeille/compat_cli.py
+++ b/src/labeille/compat_cli.py
@@ -178,9 +178,9 @@ def survey(
         package_names = parse_csv_list(packages_csv)
 
     # Extract minor version for skip_versions filtering.
-    from labeille.runner import extract_python_minor_version
+    from labeille.io_utils import extract_minor_version
 
-    minor_ver = extract_python_minor_version(python_version)
+    minor_ver = extract_minor_version(python_version)
 
     # Resolve inputs.
     packages = resolve_compat_inputs(

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -1170,18 +1170,6 @@ def _run_package_inner(
 # ---------------------------------------------------------------------------
 
 
-def extract_python_minor_version(version_string: str) -> str:
-    """Extract the ``major.minor`` version from a full Python version string.
-
-    For example, ``"3.15.0a5+ (heads/main:abc1234)"`` returns ``"3.15"``.
-
-    .. deprecated:: Use :func:`labeille.io_utils.extract_minor_version` directly.
-    """
-    from labeille.io_utils import extract_minor_version
-
-    return extract_minor_version(version_string)
-
-
 def filter_packages(
     index: Index,
     registry_dir: Path,

--- a/tests/test_compat_cli.py
+++ b/tests/test_compat_cli.py
@@ -65,7 +65,7 @@ class TestSurveyCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
     @patch("labeille.runner.validate_target_python", return_value="3.15.0a5")
-    @patch("labeille.runner.extract_python_minor_version", return_value="3.15")
+    @patch("labeille.io_utils.extract_minor_version", return_value="3.15")
     @patch("labeille.compat.resolve_compat_inputs", return_value=[])
     def test_no_packages_found(
         self,
@@ -84,7 +84,7 @@ class TestSurveyCommand(unittest.TestCase):
 
     @patch("labeille.compat.run_compat_survey")
     @patch("labeille.compat.resolve_compat_inputs")
-    @patch("labeille.runner.extract_python_minor_version", return_value="3.15")
+    @patch("labeille.io_utils.extract_minor_version", return_value="3.15")
     @patch("labeille.runner.validate_target_python", return_value="3.15.0a5")
     def test_runs_survey(
         self,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -29,7 +29,6 @@ from labeille.runner import (
     check_jit_enabled,
     checkout_revision,
     create_run_dir,
-    extract_python_minor_version,
     filter_packages,
     get_package_version,
     load_completed_packages,
@@ -1717,26 +1716,6 @@ class TestCancelEvent(unittest.TestCase):
         pkg = _make_package()
         result = run_package(pkg, self.config, self.run_dir, self.env, cancel_event=None)
         self.assertEqual(result.status, "pass")
-
-
-class TestExtractPythonMinorVersion(unittest.TestCase):
-    def test_full_version_string(self) -> None:
-        self.assertEqual(extract_python_minor_version("3.15.0a5+"), "3.15")
-
-    def test_release_version(self) -> None:
-        self.assertEqual(extract_python_minor_version("3.14.2"), "3.14")
-
-    def test_version_with_build_info(self) -> None:
-        self.assertEqual(extract_python_minor_version("3.15.0a5+ (heads/main:abc1234)"), "3.15")
-
-    def test_short_version(self) -> None:
-        self.assertEqual(extract_python_minor_version("3.15"), "3.15")
-
-    def test_empty_string(self) -> None:
-        self.assertEqual(extract_python_minor_version(""), "")
-
-    def test_malformed_version(self) -> None:
-        self.assertEqual(extract_python_minor_version("not-a-version"), "not-a-version")
 
 
 class TestPullRepo(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Remove deprecated `extract_python_minor_version` wrapper from `runner.py`
- Update `cli.py` and `compat_cli.py` to import `extract_minor_version` from `io_utils` directly
- Remove 6 duplicate tests from `test_runner.py` (already covered in `test_io_utils.py`)

## Test plan
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy strict passes (50 source files)
- [x] All 2160 tests pass

Closes #238

Generated with [Claude Code](https://claude.com/claude-code)