### PR TITLE
docs: add missing help text to 21 CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add `exc_info=True` to 14 `log.error()` calls inside `except` blocks across `runner.py`, `resolve.py`, `bench/runner.py`, and `ft/runner.py` to preserve tracebacks for debugging.
 - Explicitly set `import_ok = False` in `ft/compat.py` `JSONDecodeError`, `KeyError`, and `OSError` handlers for robustness.
 
+### Documentation
+- Add missing `help=` text to 21 CLI options across `cli.py`, `analyze_cli.py`, `ft_cli.py`, `compat_cli.py`, and `bench_cli.py`.
+
 ### Tests
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.
 - Add CLI tests for `registry` subcommands: rename-field, set-field (--all, --where, --packages), validate (--packages filter), migrate (list, unknown, missing name), sync (clone, pull, failure, non-git), add-index-field, remove-index-field, and group help.

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -102,7 +102,13 @@ _registry_dir_option = click.option(
     default=None,
     help="Write output to file (default: stdout).",
 )
-@click.option("--where", "where_exprs", type=str, multiple=True)
+@click.option(
+    "--where",
+    "where_exprs",
+    type=str,
+    multiple=True,
+    help="Filter expression (e.g. 'has_c_extension=true'). Repeatable.",
+)
 @click.option(
     "--python-version",
     "python_versions",
@@ -646,6 +652,7 @@ _STATUS_ORDER: dict[str, int] = {
     type=click.Choice(["summary", "table", "full"]),
     default="summary",
     show_default=True,
+    help="Output detail level.",
 )
 @click.option("-q", "--quiet", is_flag=True)
 @click.option("-v", "--verbose", is_flag=True)
@@ -1190,15 +1197,18 @@ def _print_comparison(
 
 @analyze.command("history")
 @_results_dir_option
-@click.option("--last", "last_n", type=int, default=10, show_default=True)
+@click.option("--last", "last_n", type=int, default=10, show_default=True, help="Number of runs.")
 @click.option(
     "--format",
     "fmt",
     type=click.Choice(["table", "timeline"]),
     default="table",
     show_default=True,
+    help="Output format.",
 )
-@click.option("--python-version", type=str, default=None)
+@click.option(
+    "--python-version", type=str, default=None, help="Filter to a specific Python version."
+)
 def history_cmd(
     results_dir: Path,
     last_n: int,
@@ -1349,7 +1359,7 @@ def _print_history_timeline(history: HistoryAnalysis) -> None:
 @_results_dir_option
 @_registry_dir_option
 @click.argument("package_name")
-@click.option("--last", "last_n", type=int, default=None)
+@click.option("--last", "last_n", type=int, default=None, help="Limit to the last N runs.")
 def package_cmd(
     results_dir: Path,
     registry_dir: Path | None,

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -984,6 +984,7 @@ def track_list(tracking_dir: Path) -> None:
     "--tracking-dir",
     type=click.Path(path_type=Path),
     default="results/tracking",
+    help="Directory containing tracking series data.",
 )
 def track_trend(
     series_name: str,
@@ -1032,6 +1033,7 @@ def track_trend(
     "--tracking-dir",
     type=click.Path(path_type=Path),
     default="results/tracking",
+    help="Directory containing tracking series data.",
 )
 def track_alert(
     series_name: str,

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -54,9 +54,19 @@ _register_subcommands()
 
 @main.command()
 @click.argument("packages", nargs=-1)
-@click.option("--from-file", "from_file", type=click.Path(exists=True, path_type=Path))
-@click.option("--from-json", "from_json", type=click.Path(exists=True, path_type=Path))
-@click.option("--top", "top_n", type=int, default=None)
+@click.option(
+    "--from-file",
+    "from_file",
+    type=click.Path(exists=True, path_type=Path),
+    help="File with one package name per line.",
+)
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.Path(exists=True, path_type=Path),
+    help="JSON file with package metadata (e.g. top-pypi-packages.json).",
+)
+@click.option("--top", "top_n", type=int, default=None, help="Resolve only the top N packages.")
 @click.option(
     "--registry-dir",
     type=click.Path(path_type=Path),
@@ -64,7 +74,13 @@ _register_subcommands()
     help="Registry directory (default: ~/.local/share/labeille/registry/).",
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be done without making changes.")
-@click.option("--timeout", type=float, default=10.0, show_default=True)
+@click.option(
+    "--timeout",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="PyPI API request timeout in seconds.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Show detailed output.")
 @click.option("-q", "--quiet", is_flag=True, help="Only show errors.")
 @click.option(
@@ -72,6 +88,7 @@ _register_subcommands()
     type=click.Path(path_type=Path),
     default=Path("labeille-resolve.log"),
     show_default=True,
+    help="Path to the log file.",
 )
 @click.option(
     "--workers",
@@ -162,28 +179,49 @@ def resolve(
     type=click.Path(path_type=Path),
     default=Path("results"),
     show_default=True,
+    help="Output directory for test results.",
 )
-@click.option("--top", "top_n", type=int, default=None)
-@click.option("--packages", "packages_csv", type=str, default=None)
-@click.option("--skip-extensions", is_flag=True)
+@click.option(
+    "--top", "top_n", type=int, default=None, help="Test only the top N packages by downloads."
+)
+@click.option(
+    "--packages",
+    "packages_csv",
+    type=str,
+    default=None,
+    help="Comma-separated list of package names (supports pkg@revision).",
+)
+@click.option("--skip-extensions", is_flag=True, help="Skip packages with C extensions.")
 @click.option("--skip-completed", is_flag=True, help="Resume: skip already-tested packages.")
 @click.option(
     "--force-run",
     is_flag=True,
     help="Override skip and skip_versions flags; run all selected packages.",
 )
-@click.option("--stop-after-crash", type=int, default=None)
-@click.option("--timeout", type=int, default=600, show_default=True)
+@click.option(
+    "--stop-after-crash",
+    type=int,
+    default=None,
+    help="Stop after N crashes are detected.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Test suite timeout in seconds.",
+)
 @click.option("--env", "env_pairs", type=str, multiple=True, help="KEY=VALUE env var.")
-@click.option("--run-id", type=str, default=None)
-@click.option("--dry-run", is_flag=True)
-@click.option("-v", "--verbose", is_flag=True)
+@click.option("--run-id", type=str, default=None, help="Custom run identifier.")
+@click.option("--dry-run", is_flag=True, help="Show what would be done without running tests.")
+@click.option("-v", "--verbose", is_flag=True, help="Show detailed output.")
 @click.option("-q", "--quiet", is_flag=True, help="Only show crashes.")
 @click.option(
     "--log-file",
     type=click.Path(path_type=Path),
     default=Path("labeille-run.log"),
     show_default=True,
+    help="Path to the log file.",
 )
 @click.option("--keep-work-dirs", is_flag=True, help="Don't clean up working directories.")
 @click.option(
@@ -671,7 +709,13 @@ def _print_human_format(result: ScanResult, install_command: str | None) -> None
     default=None,
     help="Only count crashes matching this substring.",
 )
-@click.option("--timeout", type=int, default=600, show_default=True)
+@click.option(
+    "--timeout",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Test suite timeout in seconds.",
+)
 @click.option(
     "--extra-deps",
     type=str,

--- a/src/labeille/compat_cli.py
+++ b/src/labeille/compat_cli.py
@@ -85,7 +85,13 @@ def compat() -> None:
     show_default=True,
     help="Output directory for survey results.",
 )
-@click.option("--timeout", type=int, default=600, show_default=True)
+@click.option(
+    "--timeout",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Build timeout in seconds per package.",
+)
 @click.option(
     "--workers",
     type=int,
@@ -248,6 +254,7 @@ def survey(
     type=click.Choice(["table", "markdown"]),
     default="table",
     show_default=True,
+    help="Output format.",
 )
 @click.option(
     "--category",

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -237,6 +237,7 @@ def run(
     "sort_by",
     type=click.Choice(["category", "pass_rate", "name"]),
     default="category",
+    help="Sort results by the given field.",
 )
 @click.option("--limit", default=None, type=int, help="Maximum packages to show.")
 def show(result_dir: Path, sort_by: str, limit: int | None) -> None:
@@ -420,6 +421,7 @@ def compare(run_a: Path, run_b: Path) -> None:
     "fmt",
     type=click.Choice(["markdown", "text"]),
     default="markdown",
+    help="Output format.",
 )
 @click.option(
     "--output",
@@ -460,6 +462,7 @@ def report(result_dir: Path, fmt: str, output: Path | None) -> None:
     "fmt",
     type=click.Choice(["csv", "json"]),
     default="csv",
+    help="Export format.",
 )
 @click.option(
     "--output",


### PR DESCRIPTION
## Summary
- Add descriptive `help=` text to 21 Click options that were missing it
- Affected: `cli.py` (11), `analyze_cli.py` (6), `ft_cli.py` (3), `compat_cli.py` (2), `bench_cli.py` (2)
- Improves `--help` output for all affected commands

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes (50 source files)
- [x] All 2160 tests pass

Closes #240

Generated with [Claude Code](https://claude.com/claude-code)