### PR TITLE
refactor: reduce complexity of run_cmd and export_registry_report_md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Enhanced
+- Extract `_build_run_config` from `run_cmd` in `cli.py` to separate config validation/construction from CLI execution.
+- Extract `_md_table` helper from `export_registry_report_md` in `analyze_cli.py` to deduplicate 8 markdown table constructions.
 - Extract `_make_anomaly` helper in `bench/anomaly.py` to deduplicate 9 identical `PackageAnomaly` constructions in `detect_condition_anomalies`.
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import`.

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -486,143 +486,126 @@ def format_registry_verbose(report: RegistryReport) -> str:
     return "\n".join(lines)
 
 
+def _md_table(heading: str, headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Build a Markdown table section with heading, header row, and data rows."""
+    if not rows:
+        return []
+    lines = [f"## {heading}", ""]
+    sep = [":--" if i == 0 else "--:" for i in range(len(headers))]
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("|" + "|".join(sep) + "|")
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+    return lines
+
+
 def export_registry_report_md(report: RegistryReport) -> str:
     """Export the registry report as a Markdown document."""
-    lines: list[str] = []
-    lines.append("# Registry Report")
-    lines.append("")
-    lines.append(f"Generated: {report.generated_at}")
+    lines: list[str] = ["# Registry Report", "", f"Generated: {report.generated_at}"]
     if report.filter_description:
         lines.append(f"Filter: {report.filter_description}")
     lines.append("")
 
-    # Overview table.
-    lines.append("## Overview")
-    lines.append("")
-    lines.append("| Metric | Count | Percentage |")
-    lines.append("|--------|------:|------------|")
-    lines.append(f"| Total packages | {report.total:,} | \u2014 |")
-    lines.append(f"| Active | {report.active:,} | {_pct(report.active, report.total).strip()} |")
-    lines.append(
-        f"| Skipped | {report.skipped:,} | {_pct(report.skipped, report.total).strip()} |"
-    )
     enr = report.enrichment
-    lines.append(f"| Enriched | {enr.enriched:,} | {_pct(enr.enriched, enr.total).strip()} |")
-    lines.append("")
+    lines += _md_table(
+        "Overview",
+        ["Metric", "Count", "Percentage"],
+        [
+            ["Total packages", f"{report.total:,}", "\u2014"],
+            ["Active", f"{report.active:,}", _pct(report.active, report.total).strip()],
+            ["Skipped", f"{report.skipped:,}", _pct(report.skipped, report.total).strip()],
+            ["Enriched", f"{enr.enriched:,}", _pct(enr.enriched, enr.total).strip()],
+        ],
+    )
 
-    # Package types.
     if report.by_extension_type:
-        lines.append("## Package Types")
-        lines.append("")
-        lines.append("| Type | Total | Active | Skipped | % of Total |")
-        lines.append("|------|------:|-------:|--------:|-----------:|")
+        rows = []
         for ext_type in sorted(report.by_extension_type.keys()):
             active, skipped = report.by_extension_type[ext_type]
             total = active + skipped
-            lines.append(
-                f"| {ext_type} | {total:,} | {active:,} | {skipped:,} | "
-                f"{_pct(total, report.total).strip()} |"
+            rows.append(
+                [
+                    ext_type,
+                    f"{total:,}",
+                    f"{active:,}",
+                    f"{skipped:,}",
+                    _pct(total, report.total).strip(),
+                ]
             )
-        lines.append("")
+        lines += _md_table(
+            "Package Types",
+            ["Type", "Total", "Active", "Skipped", "% of Total"],
+            rows,
+        )
 
-    # Version readiness.
     if report.per_version:
-        lines.append("## Version Readiness")
-        lines.append("")
-        lines.append("| Python Version | Active | Version-Skipped | Active % |")
-        lines.append("|---------------|-------:|----------------:|---------:|")
+        rows = []
         for va in report.per_version:
-            ver_skipped = va.skipped - report.skipped
-            if ver_skipped < 0:
-                ver_skipped = 0
+            ver_skipped = max(va.skipped - report.skipped, 0)
             active_pct = _pct(va.total_active, va.total_active + va.skipped).strip()
-            lines.append(
-                f"| {va.version} | {va.total_active:,} | {ver_skipped:,} | {active_pct} |"
-            )
-        lines.append("")
+            rows.append([va.version, f"{va.total_active:,}", f"{ver_skipped:,}", active_pct])
+        lines += _md_table(
+            "Version Readiness",
+            ["Python Version", "Active", "Version-Skipped", "Active %"],
+            rows,
+        )
 
-    # Skip reasons.
     if report.by_skip_category:
-        lines.append("## Skip Reasons")
-        lines.append("")
-        lines.append("| Reason | Count | % of Skipped |")
-        lines.append("|--------|------:|-------------:|")
-        for cat, count in sorted(report.by_skip_category.items(), key=lambda x: -x[1]):
-            lines.append(f"| {cat} | {count:,} | {_pct(count, report.skipped).strip()} |")
-        lines.append("")
+        rows = [
+            [cat, f"{count:,}", _pct(count, report.skipped).strip()]
+            for cat, count in sorted(report.by_skip_category.items(), key=lambda x: -x[1])
+        ]
+        lines += _md_table("Skip Reasons", ["Reason", "Count", "% of Skipped"], rows)
 
-    # Compatibility blockers.
-    blocker_items_md: list[tuple[str, int]] = []
-    for field_name, label in _BLOCKER_LABELS.items():
-        count = report.compat_blockers.get(field_name, 0)
-        if count > 0:
-            blocker_items_md.append((label, count))
-    if blocker_items_md:
-        lines.append("## Compatibility Blockers")
-        lines.append("")
-        lines.append("| Technology | Packages |")
-        lines.append("|-----------|--------:|")
-        for label, count in sorted(blocker_items_md, key=lambda x: -x[1]):
-            lines.append(f"| {label} | {count:,} |")
-        lines.append("")
+    blocker_rows = [
+        [label, f"{count:,}"]
+        for field_name, label in _BLOCKER_LABELS.items()
+        if (count := report.compat_blockers.get(field_name, 0)) > 0
+    ]
+    if blocker_rows:
+        blocker_rows.sort(key=lambda r: -int(r[1].replace(",", "")))
+        lines += _md_table("Compatibility Blockers", ["Technology", "Packages"], blocker_rows)
 
-    # Download coverage.
     tiers = report.download_tiers
     if tiers.all_packages != (0, 0):
-        lines.append("## Download Coverage")
-        lines.append("")
-        lines.append("| Tier | Active | Total | Coverage |")
-        lines.append("|------|-------:|------:|---------:|")
-        for label, (active, total) in [
-            ("Top 100", tiers.top_100),
-            ("Top 500", tiers.top_500),
-            ("Top 1000", tiers.top_1000),
-            ("Top 2000", tiers.top_2000),
-        ]:
-            if total > 0:
-                lines.append(
-                    f"| {label} | {active:,} | {total:,} | {_pct(active, total).strip()} |"
-                )
-        lines.append("")
-
-    # Repository hosting.
-    host_items_md: list[tuple[str, int]] = [
-        (label, report.repo_hosts.get(key, 0)) for key, label in _HOST_LABELS
-    ]
-    host_items_md = [(lb, ct) for lb, ct in host_items_md if ct > 0]
-    if host_items_md:
-        lines.append("## Repository Hosting")
-        lines.append("")
-        lines.append("| Host | Count | Percentage |")
-        lines.append("|------|------:|-----------:|")
-        for label, count in host_items_md:
-            lines.append(f"| {label} | {count:,} | {_pct(count, report.total).strip()} |")
-        lines.append("")
-
-    # Install complexity.
-    if report.active > 0:
-        install_items_md: list[tuple[str, int]] = [
-            (label, report.install_complexity.get(key, 0)) for key, label in _INSTALL_LABELS
+        rows = [
+            [label, f"{active:,}", f"{total:,}", _pct(active, total).strip()]
+            for label, (active, total) in [
+                ("Top 100", tiers.top_100),
+                ("Top 500", tiers.top_500),
+                ("Top 1000", tiers.top_1000),
+                ("Top 2000", tiers.top_2000),
+            ]
+            if total > 0
         ]
-        install_items_md = [(lb, ct) for lb, ct in install_items_md if ct > 0]
-        if install_items_md:
-            lines.append("## Install Complexity")
-            lines.append("")
-            lines.append("| Type | Count | % of Active |")
-            lines.append("|------|------:|------------:|")
-            for label, count in install_items_md:
-                lines.append(f"| {label} | {count:,} | {_pct(count, report.active).strip()} |")
-            lines.append("")
+        lines += _md_table("Download Coverage", ["Tier", "Active", "Total", "Coverage"], rows)
 
-    # Test framework.
+    host_rows = [
+        [label, f"{ct:,}", _pct(ct, report.total).strip()]
+        for key, label in _HOST_LABELS
+        if (ct := report.repo_hosts.get(key, 0)) > 0
+    ]
+    if host_rows:
+        lines += _md_table("Repository Hosting", ["Host", "Count", "Percentage"], host_rows)
+
+    if report.active > 0:
+        install_rows = [
+            [label, f"{ct:,}", _pct(ct, report.active).strip()]
+            for key, label in _INSTALL_LABELS
+            if (ct := report.install_complexity.get(key, 0)) > 0
+        ]
+        if install_rows:
+            lines += _md_table(
+                "Install Complexity", ["Type", "Count", "% of Active"], install_rows
+            )
+
     if report.by_test_framework:
-        lines.append("## Test Framework")
-        lines.append("")
-        lines.append("| Framework | Count | % of Active |")
-        lines.append("|-----------|------:|------------:|")
-        for fw, count in sorted(report.by_test_framework.items(), key=lambda x: -x[1]):
-            lines.append(f"| {fw} | {count:,} | {_pct(count, report.active).strip()} |")
-        lines.append("")
+        rows = [
+            [fw, f"{count:,}", _pct(count, report.active).strip()]
+            for fw, count in sorted(report.by_test_framework.items(), key=lambda x: -x[1])
+        ]
+        lines += _md_table("Test Framework", ["Framework", "Count", "% of Active"], rows)
 
     return "\n".join(lines)
 

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import click
 
 if TYPE_CHECKING:
+    from labeille.runner import RunnerConfig
     from labeille.scan_deps import ScanResult
 
 from labeille import __version__
@@ -159,6 +160,127 @@ def resolve(
     click.echo(f"Failed:            {summary.failed}")
     if dry_run:
         click.echo(f"Skipped (dry-run): {summary.skipped}")
+
+
+def _build_run_config(  # noqa: PLR0913
+    *,
+    target_python: Path,
+    python_version: str,
+    registry_dir: Path,
+    results_dir: Path,
+    top_n: int | None,
+    packages_csv: str | None,
+    skip_extensions: bool,
+    skip_completed: bool,
+    force_run: bool,
+    stop_after_crash: int | None,
+    timeout: int,
+    env_pairs: tuple[str, ...],
+    run_id: str | None,
+    dry_run: bool,
+    verbose: bool,
+    quiet: bool,
+    keep_work_dirs: bool,
+    refresh_venvs: bool,
+    repos_dir: Path | None,
+    venvs_dir: Path | None,
+    extra_deps: str | None,
+    test_command_override: str | None,
+    test_command_suffix: str | None,
+    repo_overrides_raw: tuple[str, ...],
+    clone_depth: int | None,
+    no_shallow: bool,
+    work_dir: Path | None,
+    workers: int,
+    installer: str,
+    install_from: str,
+) -> RunnerConfig:
+    """Validate CLI inputs and build a RunnerConfig."""
+    from labeille.io_utils import extract_minor_version, generate_run_id
+    from labeille.runner import RunnerConfig, parse_package_specs, parse_repo_overrides
+
+    env_overrides = parse_env_pairs(env_pairs)
+
+    # Parse packages filter (supports name@revision syntax).
+    packages_filter: list[str] | None = None
+    revision_overrides: dict[str, str] = {}
+    if packages_csv:
+        packages_filter, revision_overrides = parse_package_specs(packages_csv)
+        if not packages_filter:
+            packages_filter = None
+
+    # Resolve clone depth: --no-shallow wins, then --clone-depth.
+    effective_clone_depth: int | None = None
+    if no_shallow:
+        effective_clone_depth = 0
+    elif clone_depth is not None:
+        effective_clone_depth = clone_depth
+
+    # Warn if both test command override and suffix are set.
+    if test_command_override and test_command_suffix:
+        click.echo(
+            "Warning: --test-command-override is set, --test-command-suffix will be ignored.",
+            err=True,
+        )
+
+    # Parse repo overrides.
+    try:
+        repo_overrides = parse_repo_overrides(repo_overrides_raw)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    # Generate run ID.
+    if run_id is None:
+        run_id = generate_run_id("run")
+
+    # --work-dir sets both --repos-dir and --venvs-dir as defaults.
+    if work_dir is not None:
+        if repos_dir is None:
+            repos_dir = work_dir / "repos"
+        if venvs_dir is None:
+            venvs_dir = work_dir / "venvs"
+
+    # Warn when only one of --repos-dir / --venvs-dir is set: the other
+    # directory will use a temporary path and be cleaned up after the run.
+    if (repos_dir is None) != (venvs_dir is None):
+        missing = "--venvs-dir" if venvs_dir is None else "--repos-dir"
+        click.echo(
+            f"Warning: {missing} is not set; those directories will be temporary.",
+            err=True,
+        )
+
+    return RunnerConfig(
+        target_python=target_python,
+        registry_dir=registry_dir,
+        results_dir=results_dir,
+        run_id=run_id,
+        timeout=timeout,
+        top_n=top_n,
+        packages_filter=packages_filter,
+        skip_extensions=skip_extensions,
+        skip_completed=skip_completed,
+        force_run=force_run,
+        target_python_version=extract_minor_version(python_version),
+        stop_after_crash=stop_after_crash,
+        env_overrides=env_overrides,
+        dry_run=dry_run,
+        verbose=verbose,
+        quiet=quiet,
+        keep_work_dirs=keep_work_dirs,
+        refresh_venvs=refresh_venvs,
+        workers=workers,
+        repos_dir=repos_dir,
+        venvs_dir=venvs_dir,
+        cli_args=sys.argv[1:],
+        clone_depth_override=effective_clone_depth,
+        revision_overrides=revision_overrides,
+        extra_deps=parse_csv_list(extra_deps),
+        test_command_override=test_command_override,
+        test_command_suffix=test_command_suffix,
+        repo_overrides=repo_overrides,
+        installer=installer,  # type: ignore[arg-type]  # Click Choice returns str
+        install_from=install_from,  # type: ignore[arg-type]  # Click Choice returns str
+    )
 
 
 @main.command("run")
@@ -360,23 +482,17 @@ def run_cmd(
     install_from: str,
 ) -> None:
     """Run test suites against a JIT-enabled Python build and detect crashes."""
-    from labeille.io_utils import extract_minor_version, generate_run_id
     from labeille.registry import default_registry_dir
-
-    if registry_dir is None:
-        registry_dir = default_registry_dir()
-
-    from labeille.runner import (
-        RunnerConfig,
-        run_all,
-        validate_target_python,
-    )
+    from labeille.runner import run_all, validate_target_python
     from labeille.summary import format_summary
 
     setup_logging(verbose=verbose, quiet=quiet, log_file=log_file)
 
     if workers < 1:
         raise click.UsageError("--workers must be at least 1")
+
+    if registry_dir is None:
+        registry_dir = default_registry_dir()
 
     # Validate target python up front.
     try:
@@ -385,94 +501,40 @@ def run_cmd(
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Target Python: {python_version}")
 
-    env_overrides = parse_env_pairs(env_pairs)
-
-    # Parse packages filter (supports name@revision syntax).
-    packages_filter: list[str] | None = None
-    revision_overrides: dict[str, str] = {}
-    if packages_csv:
-        from labeille.runner import parse_package_specs
-
-        packages_filter, revision_overrides = parse_package_specs(packages_csv)
-        if not packages_filter:
-            packages_filter = None
-
-    # Resolve clone depth: --no-shallow wins, then --clone-depth.
-    effective_clone_depth: int | None = None
-    if no_shallow:
-        effective_clone_depth = 0
-    elif clone_depth is not None:
-        effective_clone_depth = clone_depth
-
-    # Warn if both test command override and suffix are set.
-    if test_command_override and test_command_suffix:
-        click.echo(
-            "Warning: --test-command-override is set, --test-command-suffix will be ignored.",
-            err=True,
-        )
-
-    # Parse repo overrides.
-    from labeille.runner import parse_repo_overrides
-
-    try:
-        repo_overrides = parse_repo_overrides(repo_overrides_raw)
-    except ValueError as exc:
-        raise click.UsageError(str(exc)) from exc
-
-    # Generate run ID.
-    if run_id is None:
-        run_id = generate_run_id("run")
-
-    # --work-dir sets both --repos-dir and --venvs-dir as defaults.
-    if work_dir is not None:
-        if repos_dir is None:
-            repos_dir = work_dir / "repos"
-        if venvs_dir is None:
-            venvs_dir = work_dir / "venvs"
-
-    # Warn when only one of --repos-dir / --venvs-dir is set: the other
-    # directory will use a temporary path and be cleaned up after the run.
-    if (repos_dir is None) != (venvs_dir is None):
-        missing = "--venvs-dir" if venvs_dir is None else "--repos-dir"
-        click.echo(
-            f"Warning: {missing} is not set; those directories will be temporary.",
-            err=True,
-        )
-
-    config = RunnerConfig(
+    config = _build_run_config(
         target_python=target_python,
+        python_version=python_version,
         registry_dir=registry_dir,
         results_dir=results_dir,
-        run_id=run_id,
-        timeout=timeout,
         top_n=top_n,
-        packages_filter=packages_filter,
+        packages_csv=packages_csv,
         skip_extensions=skip_extensions,
         skip_completed=skip_completed,
         force_run=force_run,
-        target_python_version=extract_minor_version(python_version),
         stop_after_crash=stop_after_crash,
-        env_overrides=env_overrides,
+        timeout=timeout,
+        env_pairs=env_pairs,
+        run_id=run_id,
         dry_run=dry_run,
         verbose=verbose,
         quiet=quiet,
         keep_work_dirs=keep_work_dirs,
         refresh_venvs=refresh_venvs,
-        workers=workers,
         repos_dir=repos_dir,
         venvs_dir=venvs_dir,
-        cli_args=sys.argv[1:],
-        clone_depth_override=effective_clone_depth,
-        revision_overrides=revision_overrides,
-        extra_deps=parse_csv_list(extra_deps),
+        extra_deps=extra_deps,
         test_command_override=test_command_override,
         test_command_suffix=test_command_suffix,
-        repo_overrides=repo_overrides,
-        installer=installer,  # type: ignore[arg-type]  # Click Choice returns str
-        install_from=install_from,  # type: ignore[arg-type]  # Click Choice returns str
+        repo_overrides_raw=repo_overrides_raw,
+        clone_depth=clone_depth,
+        no_shallow=no_shallow,
+        work_dir=work_dir,
+        workers=workers,
+        installer=installer,
+        install_from=install_from,
     )
 
-    click.echo(f"Run ID: {run_id}")
+    click.echo(f"Run ID: {config.run_id}")
     if dry_run:
         click.echo("(dry-run mode — no tests will be executed)")
 


### PR DESCRIPTION
## Summary
- Extract `_build_run_config` helper from `run_cmd` in `cli.py` — separates config validation/construction from CLI execution (172 → 60 lines)
- Extract `_md_table` helper from `export_registry_report_md` in `analyze_cli.py` — deduplicates 8 markdown table constructions (139 → 85 lines, CC 23 → 12)

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes (50 source files)
- [x] All 2160 tests pass

Closes #242

Generated with [Claude Code](https://claude.com/claude-code)