### PR TITLE
fix: log errors in ft/runner.py reader threads instead of silently ignoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Use `append_jsonl()` in `migrations.py` instead of raw `open()`/`json.dumps` for pattern consistency.
 
 ### Fixed
+- Log `ValueError`/`OSError` in `ft/runner.py` stderr and stdout reader threads instead of silently ignoring.
 - Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` in `bench/runner.py`.
 - Replace `list[Any]` with `list[PackageEntry]` in `bench/runner.py` `_run_sequential` and `_run_interleaved`.
 - Replace `cond: Any` with `BenchConditionResult` in `bench/compare.py` `_collect_call_durations`.

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -287,8 +287,8 @@ def _start_output_monitor(
                 if isinstance(line, bytes):
                     line = line.decode("utf-8", errors="replace")
                 monitor.feed(line)
-        except (ValueError, OSError):
-            pass
+        except (ValueError, OSError) as exc:
+            log.debug("Stderr reader stopped: %s", exc)
         finally:
             monitor.mark_finished()
 
@@ -378,8 +378,8 @@ def run_single_iteration(
                     stdout_chunks.append(raw_line.decode("utf-8", errors="replace"))
                 else:
                     stdout_chunks.append(raw_line)
-        except (ValueError, OSError):
-            pass
+        except (ValueError, OSError) as exc:
+            log.debug("Stdout reader stopped: %s", exc)
 
     stdout_thread = threading.Thread(target=_stdout_reader, daemon=True)
     stdout_thread.start()


### PR DESCRIPTION
## Summary
- Log `ValueError`/`OSError` at debug level in stderr and stdout reader threads instead of silently passing
- Preserves visibility into monitor thread failures without disrupting normal operation

## Test plan
- [x] ruff check passes
- [x] mypy strict passes
- [x] All 2160 tests pass

Closes #244

Generated with [Claude Code](https://claude.com/claude-code)