### PR TITLE
refactor: remove thin extract_minor_version wrapper from analyze.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - Log `ValueError`/`OSError` in `ft/runner.py` stderr and stdout reader threads instead of silently ignoring.
+- Remove thin `extract_minor_version` wrapper from `analyze.py`; callers now use `io_utils.extract_minor_version` directly.
 - Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` in `bench/runner.py`.
 - Replace `list[Any]` with `list[PackageEntry]` in `bench/runner.py` `_run_sequential` and `_run_interleaved`.
 - Replace `cond: Any` with `BenchConditionResult` in `bench/compare.py` `_collect_call_durations`.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -11,7 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from labeille.io_utils import dataclass_from_dict, load_json_file, load_jsonl, utc_now_iso
+from labeille.io_utils import (
+    dataclass_from_dict,
+    extract_minor_version,
+    load_json_file,
+    load_jsonl,
+    utc_now_iso,
+)
 from labeille.registry import Index, PackageEntry
 
 
@@ -133,16 +139,6 @@ class RunData:
         if not results_file.exists():
             return []
         return load_jsonl(results_file, PackageResult.from_dict)
-
-
-def extract_minor_version(version_string: str) -> str:
-    """Extract major.minor from a full Python version string.
-
-    Delegates to :func:`labeille.io_utils.extract_minor_version`.
-    """
-    from labeille.io_utils import extract_minor_version as _extract
-
-    return _extract(version_string)
 
 
 class ResultsStore:

--- a/src/labeille/analyze_cli.py
+++ b/src/labeille/analyze_cli.py
@@ -26,10 +26,10 @@ from labeille.analyze import (
     build_reproduce_command,
     categorize_install_errors,
     compare_runs,
-    extract_minor_version,
     generate_registry_report,
     result_detail,
 )
+from labeille.io_utils import extract_minor_version
 from labeille.formatting import (
     format_duration,
     format_histogram,


### PR DESCRIPTION
## Summary
- Remove thin `extract_minor_version` wrapper from `analyze.py` that just delegated to `io_utils.extract_minor_version`
- Update `analyze_cli.py` to import directly from `io_utils`

## Test plan
- [x] ruff check passes
- [x] mypy strict passes (50 source files)
- [x] All 2160 tests pass

Closes #246

Generated with [Claude Code](https://claude.com/claude-code)