### PR TITLE
fix: fix --no-shallow bug, add logging to silent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Use `append_jsonl()` in `migrations.py` instead of raw `open()`/`json.dumps` for pattern consistency.
 
 ### Fixed
+- Fix `--no-shallow` / `--clone-depth=0` to produce actual full clones (no `--depth` flag) instead of silently defaulting to depth=1.
+- Add warning logs to 4 silent return-None paths in `repo_ops.py` (`clone_repo`, `pull_repo`, `checkout_revision`, `fetch_latest_pypi_version`).
+- Promote `pull_repo` git reset/clean failure logs from DEBUG to WARNING for visibility.
+- Log warning for corrupted `run_meta.json` in `analyze.py` instead of silently returning empty metadata.
+- Add `ignore_errors=True` to `shutil.rmtree` in `bench/runner.py` venv refresh to prevent crashes on permission errors.
+- Standardize exception chaining from `from None` to `from exc` in 3 `bench_cli.py` `load_series` handlers.
 - Log `ValueError`/`OSError` in `ft/runner.py` stderr and stdout reader threads instead of silently ignoring.
 - Remove thin `extract_minor_version` wrapper from `analyze.py`; callers now use `io_utils.extract_minor_version` directly.
 - Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` in `bench/runner.py`.

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -18,7 +18,10 @@ from labeille.io_utils import (
     load_jsonl,
     utc_now_iso,
 )
+from labeille.logging import get_logger
 from labeille.registry import Index, PackageEntry
+
+log = get_logger("analyze")
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +134,7 @@ class RunData:
         try:
             data = load_json_file(meta_file)
         except ValueError:
+            log.warning("Corrupted run_meta.json in %s, using defaults", self.run_dir)
             return RunMeta(run_id=self.run_id)
         return RunMeta.from_dict(data)
 

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -655,7 +655,7 @@ class BenchRunner:
                 if venv_dir.exists():
                     import shutil
 
-                    shutil.rmtree(venv_dir)
+                    shutil.rmtree(venv_dir, ignore_errors=True)
                 create_venv(python_path, venv_dir, installer)
             except (OSError, subprocess.SubprocessError) as exc:
                 log.error(

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -862,7 +862,7 @@ def track_show(series_name: str, last_n: int | None, tracking_dir: Path) -> None
     try:
         series = load_series(series_dir)
     except (FileNotFoundError, ValueError) as exc:
-        raise click.ClickException(str(exc)) from None
+        raise click.ClickException(str(exc)) from exc
 
     click.echo(f"Series: {series.series_id}")
     if series.description:
@@ -1002,7 +1002,7 @@ def track_trend(
     try:
         series = load_series(series_dir)
     except (FileNotFoundError, ValueError) as exc:
-        raise click.ClickException(str(exc)) from None
+        raise click.ClickException(str(exc)) from exc
 
     trend = analyze_series_trends(
         series,
@@ -1053,7 +1053,7 @@ def track_alert(
     try:
         series = load_series(series_dir)
     except (FileNotFoundError, ValueError) as exc:
-        raise click.ClickException(str(exc)) from None
+        raise click.ClickException(str(exc)) from exc
 
     trend = analyze_series_trends(series, series_dir, condition=condition)
 

--- a/src/labeille/repo_ops.py
+++ b/src/labeille/repo_ops.py
@@ -29,19 +29,26 @@ def clone_repo(repo_url: str, dest: Path, clone_depth: int | None = None) -> str
     Args:
         repo_url: The URL of the git repository.
         dest: The destination directory for the clone.
-        clone_depth: Clone depth. ``None`` means shallow (depth=1).
-            A positive integer uses that depth.
+        clone_depth: Clone depth. ``None`` means full clone (no ``--depth``
+            flag). A positive integer uses that depth as ``--depth=N``.
+            The default shallow depth of 1 is applied by callers, not here.
 
     Returns:
         The HEAD commit hash, or ``None`` on failure.
 
     Raises:
         subprocess.CalledProcessError: If the clone fails.
+        subprocess.TimeoutExpired: If the clone times out.
     """
-    depth = clone_depth if clone_depth is not None else 1
-    log.debug("Running: git clone --depth=%d %s %s", depth, repo_url, dest)
+    cmd = ["git", "clone"]
+    if clone_depth is not None and clone_depth > 0:
+        cmd.append(f"--depth={clone_depth}")
+        log.debug("Running: git clone --depth=%d %s %s", clone_depth, repo_url, dest)
+    else:
+        log.debug("Running: git clone %s %s (full)", repo_url, dest)
+    cmd.extend([repo_url, str(dest)])
     clone_proc = subprocess.run(
-        ["git", "clone", f"--depth={depth}", repo_url, str(dest)],
+        cmd,
         capture_output=True,
         text=True,
         timeout=120,
@@ -74,6 +81,7 @@ def clone_repo(repo_url: str, dest: Path, clone_depth: int | None = None) -> str
     )
     if proc.returncode == 0:
         return proc.stdout.strip()
+    log.warning("git rev-parse HEAD failed in %s (exit %d)", dest, proc.returncode)
     return None
 
 
@@ -117,8 +125,9 @@ def pull_repo(dest: Path) -> str | None:
         check=False,
     )
     if reset_proc.returncode != 0:
-        log.debug(
-            "git reset --hard failed (non-fatal): %s",
+        log.warning(
+            "git reset --hard failed in %s (non-fatal): %s",
+            dest,
             reset_proc.stderr.strip(),
         )
 
@@ -132,8 +141,9 @@ def pull_repo(dest: Path) -> str | None:
         check=False,
     )
     if clean_proc.returncode != 0:
-        log.debug(
-            "git clean failed (non-fatal): %s",
+        log.warning(
+            "git clean -fdx failed in %s (non-fatal): %s",
+            dest,
             clean_proc.stderr.strip(),
         )
 
@@ -147,6 +157,7 @@ def pull_repo(dest: Path) -> str | None:
     )
     if proc.returncode == 0:
         return proc.stdout.strip()
+    log.warning("git rev-parse HEAD failed in %s (exit %d)", dest, proc.returncode)
     return None
 
 
@@ -254,6 +265,7 @@ def checkout_revision(repo_dir: Path, revision: str) -> str | None:
     )
     if rev_proc.returncode == 0:
         return rev_proc.stdout.strip()
+    log.warning("git rev-parse HEAD failed after checkout in %s", repo_dir)
     return None
 
 
@@ -278,6 +290,7 @@ def fetch_latest_pypi_version(
     try:
         return str(metadata["info"]["version"])
     except (KeyError, TypeError):
+        log.warning("Could not extract version from PyPI metadata for %s", package_name)
         return None
 
 

--- a/src/labeille/runner.py
+++ b/src/labeille/runner.py
@@ -654,8 +654,11 @@ def _ensure_repo(
         depth = config.clone_depth_override
         if depth is None:
             depth = pkg.clone_depth
+        # depth=0 means full clone (no --depth flag); None defaults to shallow.
         if depth == 0:
-            depth = None
+            depth = None  # clone_repo treats None as full clone
+        elif depth is None:
+            depth = 1  # default shallow clone for performance
         log.info("Cloning %s from %s to %s", pkg.package, repo_url, repo_dir)
         try:
             result.git_revision = clone_repo(repo_url, repo_dir, clone_depth=depth)

--- a/tests/test_repo_ops.py
+++ b/tests/test_repo_ops.py
@@ -20,8 +20,8 @@ class TestCloneRepo(unittest.TestCase):
     """Tests for clone_repo()."""
 
     @patch("labeille.repo_ops.subprocess.run")
-    def test_shallow_clone_default(self, mock_run: MagicMock) -> None:
-        """Default clone uses depth=1."""
+    def test_full_clone_default(self, mock_run: MagicMock) -> None:
+        """Default clone (clone_depth=None) produces a full clone with no --depth flag."""
         rev_proc = MagicMock(returncode=0, stdout="abc123\n", stderr="")
         clone_proc = MagicMock(returncode=0, stderr="")
         mock_run.side_effect = [clone_proc, rev_proc]
@@ -30,7 +30,10 @@ class TestCloneRepo(unittest.TestCase):
 
         self.assertEqual(result, "abc123")
         clone_call = mock_run.call_args_list[0]
-        self.assertIn("--depth=1", clone_call[0][0])
+        cmd = clone_call[0][0]
+        self.assertNotIn("--depth=1", cmd)
+        for arg in cmd:
+            self.assertFalse(arg.startswith("--depth="), f"Unexpected depth flag: {arg}")
 
     @patch("labeille.repo_ops.subprocess.run")
     def test_deep_clone_fetches_tags(self, mock_run: MagicMock) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1257,7 +1257,7 @@ class TestCloneDepth(unittest.TestCase):
         mock_get_pkgs: MagicMock,
         mock_test: MagicMock,
     ) -> None:
-        """clone_depth=None passes None to clone_repo (default depth=1)."""
+        """clone_depth=None defaults to depth=1 (shallow) for performance."""
         mock_clone.return_value = "abc1234"
         mock_install.return_value = subprocess.CompletedProcess(
             args="", returncode=0, stdout="", stderr=""
@@ -1272,7 +1272,7 @@ class TestCloneDepth(unittest.TestCase):
         pkg = _make_package(clone_depth=None)
         run_package(pkg, self.config, self.run_dir, self.env)
         _, kwargs = mock_clone.call_args
-        self.assertIsNone(kwargs.get("clone_depth"))
+        self.assertEqual(kwargs.get("clone_depth"), 1)
 
     @patch("labeille.runner.run_test_command")
     @patch("labeille.runner.get_installed_packages")


### PR DESCRIPTION
## Summary
- Fix `--no-shallow` / `--clone-depth=0` to produce actual full clones instead of silently defaulting to depth=1
- Add warning logs to 4 silent return-None paths in `repo_ops.py`
- Promote `pull_repo` git reset/clean failure logs from DEBUG to WARNING
- Log corrupted `run_meta.json` in `analyze.py`
- Add `ignore_errors=True` to `bench/runner.py` rmtree
- Standardize `from None` → `from exc` in 3 `bench_cli.py` handlers

## Test plan
- [x] ruff check passes
- [x] mypy strict passes (50 files)
- [x] All 2160 tests pass (2 tests updated for new clone_depth semantics)

Closes #248

Generated with [Claude Code](https://claude.com/claude-code)