### PR TITLE
refactor: split _survey_package and bench compare to reduce complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Enhanced
 - Extract `_build_run_config` from `run_cmd` in `cli.py` to separate config validation/construction from CLI execution.
 - Extract `_md_table` helper from `export_registry_report_md` in `analyze_cli.py` to deduplicate 8 markdown table constructions.
+- Extract `_prepare_source`, `_classify_install_result`, `_check_import_result` from `_survey_package` in `compat.py`, reducing complexity from 23 branches to ~8 per function.
+- Split `bench_cli.py:compare` into `_compare_intra_run`, `_compare_cross_run`, and `_report_anomalies`, eliminating CC=62.
 - Extract `_make_anomaly` helper in `bench/anomaly.py` to deduplicate 9 identical `PackageAnomaly` constructions in `detect_condition_anomalies`.
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import`.

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -509,6 +509,124 @@ def show(result_dir: Path, anomalies: bool, per_test_package: str | None) -> Non
     default=None,
     help="Show per-test overhead for a specific package.",
 )
+def _compare_intra_run(
+    result_dir: Path,
+    baseline: str | None,
+    per_test_package: str | None,
+) -> None:
+    """Compare conditions within a single benchmark run."""
+    from labeille.bench.display import (
+        format_bench_show,
+        format_comparison_summary,
+    )
+    from labeille.bench.results import load_bench_run
+
+    meta, results = load_bench_run(result_dir)
+    conditions = list(meta.conditions.keys())
+    if len(conditions) < 2:
+        raise click.ClickException(
+            "Single benchmark run has only one condition. "
+            "Provide two result directories for cross-run comparison."
+        )
+
+    baseline_name = baseline or conditions[0]
+    if baseline_name not in conditions:
+        raise click.ClickException(
+            f"Baseline '{baseline_name}' not found. Available: {', '.join(conditions)}"
+        )
+
+    click.echo(format_bench_show(meta, results))
+    click.echo()
+
+    for cond_name in conditions:
+        if cond_name == baseline_name:
+            continue
+        click.echo(f"\n{baseline_name} vs {cond_name}")
+        click.echo("=" * (len(baseline_name) + len(cond_name) + 4))
+        click.echo(format_comparison_summary(results, baseline_name, cond_name))
+
+    if per_test_package:
+        from labeille.bench.compare import compare_per_test
+        from labeille.bench.display import format_per_test_comparison
+
+        for cond_name in conditions:
+            if cond_name == baseline_name:
+                continue
+            overheads = compare_per_test(results, baseline_name, cond_name, per_test_package)
+            if overheads:
+                click.echo()
+                click.echo(format_per_test_comparison(overheads))
+
+    _report_anomalies(results)
+
+
+def _compare_cross_run(
+    result_dirs: tuple[Path, ...],
+    baseline: str | None,
+) -> None:
+    """Compare results across multiple benchmark runs."""
+    from labeille.bench.display import format_comparison_summary
+    from labeille.bench.results import load_bench_run
+
+    all_runs: list[tuple[BenchMeta, list[BenchPackageResult]]] = []
+    for rd in result_dirs:
+        meta, results = load_bench_run(rd)
+        all_runs.append((meta, results))
+
+    click.echo("Cross-run comparison:")
+    click.echo()
+    for i, (meta, results) in enumerate(all_runs):
+        run_name = meta.name or meta.bench_id
+        click.echo(f"  Run {i + 1}: {run_name}")
+        click.echo(f"    Conditions: {', '.join(meta.conditions.keys())}")
+        click.echo(f"    Packages: {meta.packages_completed}")
+    click.echo()
+
+    merged_results: dict[str, BenchPackageResult] = {}
+    run_names: list[str] = []
+
+    for meta, results in all_runs:
+        run_name = meta.name or meta.bench_id
+        run_names.append(run_name)
+        first_cond = list(meta.conditions.keys())[0]
+
+        for r in results:
+            if r.skipped:
+                continue
+            cond = r.conditions.get(first_cond)
+            if not cond:
+                continue
+            if r.package not in merged_results:
+                merged_results[r.package] = BenchPackageResult(
+                    package=r.package,
+                )
+            merged_results[r.package].conditions[run_name] = cond
+
+    merged_list = list(merged_results.values())
+
+    if len(run_names) >= 2:
+        baseline_name = baseline or run_names[0]
+        for treatment in run_names[1:]:
+            click.echo(f"\n{baseline_name} vs {treatment}")
+            click.echo("=" * (len(baseline_name) + len(treatment) + 4))
+            click.echo(format_comparison_summary(merged_list, baseline_name, treatment))
+
+        _report_anomalies(merged_list)
+
+
+def _report_anomalies(results: list[BenchPackageResult]) -> None:
+    """Print an anomaly summary if any anomalies are detected."""
+    from labeille.bench.anomaly import detect_anomalies
+
+    anomaly_report = detect_anomalies(results)
+    if anomaly_report.anomalies:
+        n_pkgs = len(anomaly_report.affected_packages)
+        click.echo(
+            f"\n\u26a0 {n_pkgs} package(s) have measurement anomalies "
+            f"(use 'bench show --anomalies' for details)."
+        )
+
+
 def compare(
     result_dirs: tuple[Path, ...],
     baseline: str | None,
@@ -529,118 +647,10 @@ def compare(
         # Compare two separate runs
         labeille bench compare results/bench_baseline results/bench_jit
     """
-    from labeille.bench.display import (
-        format_bench_show,
-        format_comparison_summary,
-    )
-    from labeille.bench.results import load_bench_run
-
     if len(result_dirs) == 1:
-        # Single directory: compare conditions within the run.
-        meta, results = load_bench_run(result_dirs[0])
-        conditions = list(meta.conditions.keys())
-        if len(conditions) < 2:
-            raise click.ClickException(
-                "Single benchmark run has only one condition. "
-                "Provide two result directories for cross-run comparison."
-            )
-
-        baseline_name = baseline or conditions[0]
-        if baseline_name not in conditions:
-            raise click.ClickException(
-                f"Baseline '{baseline_name}' not found. Available: {', '.join(conditions)}"
-            )
-
-        click.echo(format_bench_show(meta, results))
-        click.echo()
-
-        for cond_name in conditions:
-            if cond_name == baseline_name:
-                continue
-            click.echo(f"\n{baseline_name} vs {cond_name}")
-            click.echo("=" * (len(baseline_name) + len(cond_name) + 4))
-            click.echo(format_comparison_summary(results, baseline_name, cond_name))
-
-        # Per-test comparison.
-        if per_test_package:
-            from labeille.bench.compare import compare_per_test
-            from labeille.bench.display import format_per_test_comparison
-
-            for cond_name in conditions:
-                if cond_name == baseline_name:
-                    continue
-                overheads = compare_per_test(results, baseline_name, cond_name, per_test_package)
-                if overheads:
-                    click.echo()
-                    click.echo(format_per_test_comparison(overheads))
-
-        # Anomaly summary.
-        from labeille.bench.anomaly import detect_anomalies
-
-        anomaly_report = detect_anomalies(results)
-        if anomaly_report.anomalies:
-            n_pkgs = len(anomaly_report.affected_packages)
-            click.echo(
-                f"\n\u26a0 {n_pkgs} package(s) have measurement anomalies "
-                f"(use 'bench show --anomalies' for details)."
-            )
+        _compare_intra_run(result_dirs[0], baseline, per_test_package)
     else:
-        # Multiple directories: cross-run comparison.
-        all_runs: list[tuple[BenchMeta, list[BenchPackageResult]]] = []
-        for rd in result_dirs:
-            meta, results = load_bench_run(rd)
-            all_runs.append((meta, results))
-
-        click.echo("Cross-run comparison:")
-        click.echo()
-        for i, (meta, results) in enumerate(all_runs):
-            run_name = meta.name or meta.bench_id
-            click.echo(f"  Run {i + 1}: {run_name}")
-            click.echo(f"    Conditions: {', '.join(meta.conditions.keys())}")
-            click.echo(f"    Packages: {meta.packages_completed}")
-        click.echo()
-
-        # Merge: create synthetic BenchPackageResults with conditions
-        # named after each run.
-        merged_results: dict[str, BenchPackageResult] = {}
-        run_names: list[str] = []
-
-        for meta, results in all_runs:
-            run_name = meta.name or meta.bench_id
-            run_names.append(run_name)
-            first_cond = list(meta.conditions.keys())[0]
-
-            for r in results:
-                if r.skipped:
-                    continue
-                cond = r.conditions.get(first_cond)
-                if not cond:
-                    continue
-                if r.package not in merged_results:
-                    merged_results[r.package] = BenchPackageResult(
-                        package=r.package,
-                    )
-                merged_results[r.package].conditions[run_name] = cond
-
-        merged_list = list(merged_results.values())
-
-        if len(run_names) >= 2:
-            baseline_name = baseline or run_names[0]
-            for treatment in run_names[1:]:
-                click.echo(f"\n{baseline_name} vs {treatment}")
-                click.echo("=" * (len(baseline_name) + len(treatment) + 4))
-                click.echo(format_comparison_summary(merged_list, baseline_name, treatment))
-
-            # Anomaly summary.
-            from labeille.bench.anomaly import detect_anomalies
-
-            anomaly_report = detect_anomalies(merged_list)
-            if anomaly_report.anomalies:
-                n_pkgs = len(anomaly_report.affected_packages)
-                click.echo(
-                    f"\n\u26a0 {n_pkgs} package(s) have measurement anomalies "
-                    f"(use 'bench show --anomalies' for details)."
-                )
+        _compare_cross_run(result_dirs, baseline)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/compat.py
+++ b/src/labeille/compat.py
@@ -738,6 +738,100 @@ def resolve_compat_inputs(
 # ---------------------------------------------------------------------------
 
 
+def _prepare_source(
+    pkg: CompatPackageInput,
+    from_mode: str,
+    repos_dir: Path | None,
+    tmp_path: Path,
+    no_binary_all: bool,
+    result: CompatResult,
+) -> tuple[str, Path] | None:
+    """Prepare source and build the install command.
+
+    Returns ``(install_cmd, cwd)`` on success or ``None`` if the package
+    should be skipped (sets ``result.status`` before returning).
+    """
+    if from_mode == "sdist":
+        if no_binary_all:
+            return f"pip install --no-binary :all: {pkg.name}", tmp_path
+        return f"pip install --no-binary {pkg.name} {pkg.name}", tmp_path
+
+    # Source mode — need a repo.
+    if pkg.repo_url is None:
+        result.status = "no_repo"
+        return None
+    repo_dir = repos_dir / pkg.name if repos_dir else tmp_path / "repo"
+    try:
+        if repo_dir.exists() and (repo_dir / ".git").exists():
+            pull_repo(repo_dir)
+        else:
+            clone_repo(pkg.repo_url, repo_dir)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        result.status = "clone_error"
+        log.warning("Clone failed for %s: %s", pkg.name, exc)
+        return None
+    return pkg.install_command or "pip install -e .", repo_dir
+
+
+def _classify_install_result(
+    install_proc: subprocess.CompletedProcess[str],
+    from_mode: str,
+    patterns: list[ErrorPattern],
+    result: CompatResult,
+) -> bool:
+    """Classify a non-zero install exit code. Returns True if the build failed."""
+    result.exit_code = install_proc.returncode
+    if install_proc.returncode == 0:
+        return False
+    stderr_text = install_proc.stderr or ""
+    if from_mode == "sdist" and _NO_SDIST_PATTERN.search(stderr_text):
+        result.status = "no_sdist"
+    else:
+        result.status = "build_fail"
+        matches = classify_build_output(stderr_text, patterns=patterns)
+        result.error_matches = matches
+        if matches:
+            result.primary_category = matches[0].category
+            result.primary_subcategory = matches[0].subcategory
+            result.primary_description = matches[0].description
+    return True
+
+
+def _check_import_result(
+    pkg: CompatPackageInput,
+    venv_dir: Path,
+    patterns: list[ErrorPattern],
+    result: CompatResult,
+) -> None:
+    """Run an import check and set the result status accordingly."""
+    import_name = pkg.import_name or pkg.name.replace("-", "_")
+    venv_python = venv_dir / "bin" / "python"
+    import_env = clean_env(PYTHON_JIT="0", ASAN_OPTIONS="detect_leaks=0")
+    try:
+        import_proc = check_import(venv_python, import_name, import_env)
+    except subprocess.TimeoutExpired:
+        result.status = "import_fail"
+        result.import_error = "import timed out"
+        return
+
+    if import_proc.returncode != 0:
+        crash = detect_crash(import_proc.returncode, import_proc.stderr or "")
+        if crash is not None:
+            result.status = "import_crash"
+            result.crash_signature = crash.signature
+        else:
+            result.status = "import_fail"
+            result.import_error = (import_proc.stderr or "").strip()[-300:]
+        import_matches = classify_build_output(import_proc.stderr or "", patterns=patterns)
+        result.error_matches = import_matches
+        if import_matches:
+            result.primary_category = import_matches[0].category
+            result.primary_subcategory = import_matches[0].subcategory
+            result.primary_description = import_matches[0].description
+    else:
+        result.status = "build_ok"
+
+
 def _survey_package(
     pkg: CompatPackageInput,
     target_python: Path,
@@ -760,122 +854,62 @@ def _survey_package(
         repo_url=pkg.repo_url,
     )
 
-    with tempfile.TemporaryDirectory(prefix=f"compat-{pkg.name}-") as tmpdir:
-        tmp_path = Path(tmpdir)
-        venv_dir = tmp_path / "venv"
+    try:
+        with tempfile.TemporaryDirectory(prefix=f"compat-{pkg.name}-") as tmpdir:
+            tmp_path = Path(tmpdir)
+            venv_dir = tmp_path / "venv"
 
-        # Build install command.
-        if from_mode == "sdist":
-            if no_binary_all:
-                install_cmd = f"pip install --no-binary :all: {pkg.name}"
-            else:
-                install_cmd = f"pip install --no-binary {pkg.name} {pkg.name}"
-            cwd = tmp_path
-        else:
-            # Source mode.
-            if pkg.repo_url is None:
-                result.status = "no_repo"
-                result.duration_seconds = round(time.monotonic() - start, 2)
+            # Phase 1: Prepare source and install command.
+            prepared = _prepare_source(pkg, from_mode, repos_dir, tmp_path, no_binary_all, result)
+            if prepared is None:
                 return result
-            repo_dir = repos_dir / pkg.name if repos_dir else tmp_path / "repo"
+            install_cmd, cwd = prepared
+
+            # Phase 2: Install.
+            env = clean_env(ASAN_OPTIONS="detect_leaks=0")
             try:
-                if repo_dir.exists() and (repo_dir / ".git").exists():
-                    pull_repo(repo_dir)
-                else:
-                    clone_repo(pkg.repo_url, repo_dir)
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
-                result.status = "clone_error"
-                result.duration_seconds = round(time.monotonic() - start, 2)
-                log.warning("Clone failed for %s: %s", pkg.name, exc)
+                install_proc, actual_backend = install_with_fallback(
+                    python_path=target_python,
+                    venv_dir=venv_dir,
+                    install_command=install_cmd,
+                    cwd=cwd,
+                    env=env,
+                    timeout=timeout,
+                    installer=installer,
+                )
+                result.installer_used = actual_backend.value
+            except subprocess.TimeoutExpired:
+                result.status = "timeout"
                 return result
-            install_cmd = pkg.install_command or "pip install -e ."
-            cwd = repo_dir
-
-        # Install.
-        env = clean_env(ASAN_OPTIONS="detect_leaks=0")
-        install_proc: subprocess.CompletedProcess[str] | None = None
-        try:
-            install_proc, actual_backend = install_with_fallback(
-                python_path=target_python,
-                venv_dir=venv_dir,
-                install_command=install_cmd,
-                cwd=cwd,
-                env=env,
-                timeout=timeout,
-                installer=installer,
-            )
-            result.installer_used = actual_backend.value
-        except subprocess.TimeoutExpired:
-            result.status = "timeout"
-            result.duration_seconds = round(time.monotonic() - start, 2)
-            return result
-        except (subprocess.CalledProcessError, OSError) as exc:
-            result.status = "build_fail"
-            result.duration_seconds = round(time.monotonic() - start, 2)
-            log.warning("Build exception for %s: %s", pkg.name, exc)
-            return result
-
-        # Save build logs.
-        logs_dir = output_dir / "build_logs"
-        logs_dir.mkdir(exist_ok=True)
-        try:
-            if install_proc.stderr:
-                (logs_dir / f"{pkg.name}.stderr").write_text(install_proc.stderr, encoding="utf-8")
-            if install_proc.stdout:
-                (logs_dir / f"{pkg.name}.stdout").write_text(install_proc.stdout, encoding="utf-8")
-        except OSError as exc:
-            log.warning("Could not save build logs for %s: %s", pkg.name, exc)
-
-        # Check install result.
-        result.exit_code = install_proc.returncode
-        if install_proc.returncode != 0:
-            stderr_text = install_proc.stderr or ""
-            # Check for no-sdist case.
-            if from_mode == "sdist" and _NO_SDIST_PATTERN.search(stderr_text):
-                result.status = "no_sdist"
-            else:
+            except (subprocess.CalledProcessError, OSError) as exc:
                 result.status = "build_fail"
-                matches = classify_build_output(stderr_text, patterns=patterns)
-                result.error_matches = matches
-                if matches:
-                    result.primary_category = matches[0].category
-                    result.primary_subcategory = matches[0].subcategory
-                    result.primary_description = matches[0].description
-            result.duration_seconds = round(time.monotonic() - start, 2)
-            return result
+                log.warning("Build exception for %s: %s", pkg.name, exc)
+                return result
 
-        # Import check.
-        import_name = pkg.import_name or pkg.name.replace("-", "_")
-        venv_python = venv_dir / "bin" / "python"
-        import_env = clean_env(PYTHON_JIT="0", ASAN_OPTIONS="detect_leaks=0")
-        try:
-            import_proc = check_import(venv_python, import_name, import_env)
-        except subprocess.TimeoutExpired:
-            result.status = "import_fail"
-            result.import_error = "import timed out"
-            result.duration_seconds = round(time.monotonic() - start, 2)
-            return result
+            # Save build logs.
+            logs_dir = output_dir / "build_logs"
+            logs_dir.mkdir(exist_ok=True)
+            try:
+                if install_proc.stderr:
+                    (logs_dir / f"{pkg.name}.stderr").write_text(
+                        install_proc.stderr, encoding="utf-8"
+                    )
+                if install_proc.stdout:
+                    (logs_dir / f"{pkg.name}.stdout").write_text(
+                        install_proc.stdout, encoding="utf-8"
+                    )
+            except OSError as exc:
+                log.warning("Could not save build logs for %s: %s", pkg.name, exc)
 
-        if import_proc.returncode != 0:
-            crash = detect_crash(import_proc.returncode, import_proc.stderr or "")
-            if crash is not None:
-                result.status = "import_crash"
-                result.crash_signature = crash.signature
-            else:
-                result.status = "import_fail"
-                result.import_error = (import_proc.stderr or "").strip()[-300:]
-            # Classify import stderr.
-            import_matches = classify_build_output(import_proc.stderr or "", patterns=patterns)
-            result.error_matches = import_matches
-            if import_matches:
-                result.primary_category = import_matches[0].category
-                result.primary_subcategory = import_matches[0].subcategory
-                result.primary_description = import_matches[0].description
-        else:
-            result.status = "build_ok"
+            if _classify_install_result(install_proc, from_mode, patterns, result):
+                return result
 
-    result.duration_seconds = round(time.monotonic() - start, 2)
-    return result
+            # Phase 3: Import check.
+            _check_import_result(pkg, venv_dir, patterns, result)
+
+        return result
+    finally:
+        result.duration_seconds = round(time.monotonic() - start, 2)
 
 
 def run_compat_survey(


### PR DESCRIPTION
## Summary
- Extract `_prepare_source`, `_classify_install_result`, `_check_import_result` from `_survey_package` in `compat.py` — reduces from 121 lines/23 branches to ~40 lines orchestrator + 3 focused helpers. Added try/finally for duration recording.
- Split `bench_cli.py:compare` (CC=62) into `_compare_intra_run`, `_compare_cross_run`, and `_report_anomalies` — the original was two independent code paths in one function.

## Test plan
- [x] ruff format/check pass
- [x] mypy strict passes (50 files)
- [x] All 2160 tests pass

Closes #250

Generated with [Claude Code](https://claude.com/claude-code)