### PR TITLE
refactor: type extension_compat as ExtensionCompat and add _PackageSetup dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Log warning for corrupted `run_meta.json` in `analyze.py` instead of silently returning empty metadata.
 - Add `ignore_errors=True` to `shutil.rmtree` in `bench/runner.py` venv refresh to prevent crashes on permission errors.
 - Standardize exception chaining from `from None` to `from exc` in 3 `bench_cli.py` `load_series` handlers.
+- Type `FTPackageResult.extension_compat` as `ExtensionCompat | None` instead of `dict[str, Any] | None`, eliminating untyped dict access across ft subsystem.
+- Replace `_setup_package` return type `dict[str, Any]` with typed `_PackageSetup` dataclass in `bench/runner.py`.
 - Log `ValueError`/`OSError` in `ft/runner.py` stderr and stdout reader threads instead of silently ignoring.
 - Remove thin `extract_minor_version` wrapper from `analyze.py`; callers now use `io_utils.extract_minor_version` directly.
 - Replace `ProgressCallback = Any` with `Callable[[BenchProgress], None] | None` in `bench/runner.py`.

--- a/src/labeille/bench/runner.py
+++ b/src/labeille/bench/runner.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
@@ -76,6 +76,17 @@ log = get_logger("bench.runner")
 # ---------------------------------------------------------------------------
 # Install environment
 # ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PackageSetup:
+    """Result of setting up a package for benchmarking."""
+
+    repo_dir: Path
+    venvs: dict[str, Path]
+    clone_duration: float = 0.0
+    venv_durations: dict[str, float] = field(default_factory=dict)
+    install_durations: dict[str, float] = field(default_factory=dict)
 
 
 def _build_install_env(
@@ -371,7 +382,7 @@ class BenchRunner:
         """
         # Pre-setup: clone repos and create venvs for all packages.
         log.info("Pre-setup phase: cloning repos and creating venvs...")
-        pkg_setups: list[dict[str, Any]] = []
+        pkg_setups: list[_PackageSetup | None] = []
         pkg_results: list[BenchPackageResult] = []
 
         for pkg in packages:
@@ -383,18 +394,18 @@ class BenchRunner:
                     skip_reason="setup failed",
                 )
                 pkg_results.append(pkg_result)
-                pkg_setups.append({})
+                pkg_setups.append(None)
                 continue
 
             pkg_result = BenchPackageResult(
                 package=pkg.package,
-                clone_duration_s=setup.get("clone_duration", 0.0),
+                clone_duration_s=setup.clone_duration,
             )
             for cond_name in self.config.conditions:
                 pkg_result.conditions[cond_name] = BenchConditionResult(
                     condition_name=cond_name,
-                    install_duration_s=setup.get(f"install_{cond_name}", 0.0),
-                    venv_setup_duration_s=setup.get(f"venv_{cond_name}", 0.0),
+                    install_duration_s=setup.install_durations.get(cond_name, 0.0),
+                    venv_setup_duration_s=setup.venv_durations.get(cond_name, 0.0),
                 )
             pkg_results.append(pkg_result)
             pkg_setups.append(setup)
@@ -484,14 +495,14 @@ class BenchRunner:
             pkg_result.skip_reason = "setup failed"
             return pkg_result
 
-        pkg_result.clone_duration_s = setup.get("clone_duration", 0.0)
+        pkg_result.clone_duration_s = setup.clone_duration
 
         # Initialize condition results.
         for cond_name in self.config.conditions:
             pkg_result.conditions[cond_name] = BenchConditionResult(
                 condition_name=cond_name,
-                install_duration_s=setup.get(f"install_{cond_name}", 0.0),
-                venv_setup_duration_s=setup.get(f"venv_{cond_name}", 0.0),
+                install_duration_s=setup.install_durations.get(cond_name, 0.0),
+                venv_setup_duration_s=setup.venv_durations.get(cond_name, 0.0),
             )
 
         # Run iterations.
@@ -596,11 +607,10 @@ class BenchRunner:
 
         return pkg_result
 
-    def _setup_package(self, pkg: PackageEntry) -> dict[str, Any] | None:
+    def _setup_package(self, pkg: PackageEntry) -> _PackageSetup | None:
         """Clone repo and create venvs for all conditions.
 
-        Returns a setup dict with repo_dir, venvs, and durations.
-        Returns None if setup fails.
+        Returns a :class:`_PackageSetup` on success, or ``None`` on failure.
         """
         from labeille.runner import (
             clone_repo,
@@ -609,8 +619,6 @@ class BenchRunner:
             install_with_fallback,
             resolve_installer,
         )
-
-        setup: dict[str, Any] = {}
 
         # Clone the repo.
         if not pkg.repo:
@@ -634,14 +642,15 @@ class BenchRunner:
         except (OSError, subprocess.SubprocessError) as exc:
             log.error("Failed to clone %s: %s", pkg.package, exc, exc_info=True)
             return None
-        setup["clone_duration"] = time.monotonic() - clone_start
-        setup["repo_dir"] = repo_dir
+        clone_duration = time.monotonic() - clone_start
 
         # Resolve installer backend.
         installer = resolve_installer(self.config.installer)
 
         # Create a venv per condition.
         venvs: dict[str, Path] = {}
+        venv_durations: dict[str, float] = {}
+        install_durations: dict[str, float] = {}
         venvs_base = self.config.venvs_dir or (self.config.output_dir / "venvs")
         venvs_base.mkdir(parents=True, exist_ok=True)
 
@@ -666,7 +675,7 @@ class BenchRunner:
                     exc_info=True,
                 )
                 return None
-            setup[f"venv_{cond_name}"] = time.monotonic() - venv_start
+            venv_durations[cond_name] = time.monotonic() - venv_start
 
             # Install the package.
             venv_python = venv_dir / "bin" / "python"
@@ -701,8 +710,7 @@ class BenchRunner:
                     "Install failed for %s/%s: %s", pkg.package, cond_name, exc, exc_info=True
                 )
                 return None
-            setup[f"install_{cond_name}"] = time.monotonic() - install_start
-
+            install_durations[cond_name] = time.monotonic() - install_start
             # Install extra deps.
             extra_deps = resolve_extra_deps(cond, self.config.default_extra_deps)
             if extra_deps:
@@ -726,22 +734,26 @@ class BenchRunner:
 
             venvs[cond_name] = venv_dir
 
-        setup["venvs"] = venvs
-        return setup
+        return _PackageSetup(
+            repo_dir=repo_dir,
+            venvs=venvs,
+            clone_duration=clone_duration,
+            venv_durations=venv_durations,
+            install_durations=install_durations,
+        )
 
     def _run_iteration(
         self,
         *,
         pkg: PackageEntry,
         cond: ConditionDef,
-        setup: dict[str, Any],
+        setup: _PackageSetup,
         iter_index: int,
         is_warmup: bool,
     ) -> BenchIteration:
         """Execute a single timed iteration."""
-        repo_dir: Path = setup["repo_dir"]
-        venvs: dict[str, Path] = setup["venvs"]
-        venv_path = venvs[cond.name]
+        repo_dir = setup.repo_dir
+        venv_path = setup.venvs[cond.name]
 
         # Resolve the test command.
         registry_cmd = pkg.test_command or None

--- a/src/labeille/ft/analysis.py
+++ b/src/labeille/ft/analysis.py
@@ -377,8 +377,8 @@ def prioritize_triage(
             score += min(r.deadlock_count * 5, 15)
             reasons.append(f"{r.deadlock_count} deadlocks")
 
-        ext = r.extension_compat or {}
-        is_pure = ext.get("is_pure_python", True)
+        ext = r.extension_compat
+        is_pure = ext.is_pure_python if ext else True
         if not is_pure and r.category in (
             FailureCategory.CRASH,
             FailureCategory.INTERMITTENT,

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -52,7 +52,7 @@ def export_csv(
     )
 
     for r in sorted(results, key=lambda r: r.package):
-        ext = r.extension_compat or {}
+        ext = r.extension_compat
         writer.writerow(
             [
                 r.package,
@@ -66,8 +66,8 @@ def export_csv(
                 r.timeout_count,
                 r.tsan_warning_iterations,
                 round(r.mean_duration_s, 2),
-                ext.get("is_pure_python", True),
-                ext.get("gil_fallback_active", False),
+                ext.is_pure_python if ext else True,
+                ext.gil_fallback_active if ext else False,
                 r.install_ok,
                 r.import_ok,
                 len(r.flaky_tests),
@@ -327,7 +327,7 @@ def _report_extensions_md(results: list[FTPackageResult]) -> list[str]:
     ext_pkgs = [
         r
         for r in results
-        if r.extension_compat and not r.extension_compat.get("is_pure_python", True)
+        if r.extension_compat and not r.extension_compat.is_pure_python
     ]
     if not ext_pkgs:
         return []
@@ -340,11 +340,11 @@ def _report_extensions_md(results: list[FTPackageResult]) -> list[str]:
     ]
 
     for r in sorted(ext_pkgs, key=lambda r: r.package):
-        ext = r.extension_compat or {}
-        fallback = "Yes" if ext.get("gil_fallback_active") else "No"
-        scan = ext.get("source_scan", {})
-        if scan and scan.get("declarations"):
-            all_not_used = all(d.get("is_not_used", False) for d in scan["declarations"])
+        ext = r.extension_compat
+        fallback = "Yes" if ext and ext.gil_fallback_active else "No"
+        scan = ext.source_scan if ext else None
+        if scan and scan.declarations:
+            all_not_used = all(d.is_not_used for d in scan.declarations)
             source = "Declared (NOT_USED)" if all_not_used else "Declared (USED)"
         else:
             source = "Not declared"

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -17,7 +17,10 @@ import enum
 import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from labeille.ft.compat import ExtensionCompat
 
 from labeille.io_utils import (
     append_jsonl,
@@ -176,7 +179,7 @@ class FTPackageResult:
     pass_rate: float = 0.0
     mean_duration_s: float = 0.0
 
-    extension_compat: dict[str, Any] | None = None
+    extension_compat: ExtensionCompat | None = None
 
     failure_signatures: list[str] = field(default_factory=list)
     tsan_warning_types: list[str] = field(default_factory=list)
@@ -292,12 +295,20 @@ class FTPackageResult:
             "iterations": [i.to_dict() for i in self.iterations],
         }
         if self.extension_compat is not None:
-            d["extension_compat"] = self.extension_compat
+            d["extension_compat"] = self.extension_compat.to_dict()
         if self.gil_enabled_pass_rate is not None:
             d["gil_enabled_pass_rate"] = round(self.gil_enabled_pass_rate, 4)
         if self.gil_enabled_iterations is not None:
             d["gil_enabled_iterations"] = [i.to_dict() for i in self.gil_enabled_iterations]
         return d
+
+    @staticmethod
+    def _parse_extension_compat(raw: dict[str, Any] | None) -> ExtensionCompat | None:
+        if raw is None:
+            return None
+        from labeille.ft.compat import ExtensionCompat
+
+        return ExtensionCompat.from_dict(raw)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTPackageResult:
@@ -319,7 +330,7 @@ class FTPackageResult:
             tsan_warning_iterations=data.get("tsan_warning_iterations", 0),
             pass_rate=data.get("pass_rate", 0.0),
             mean_duration_s=data.get("mean_duration_s", 0.0),
-            extension_compat=data.get("extension_compat"),
+            extension_compat=cls._parse_extension_compat(data.get("extension_compat")),
             failure_signatures=data.get("failure_signatures", []),
             tsan_warning_types=data.get("tsan_warning_types", []),
             flaky_tests=data.get("flaky_tests", {}),
@@ -377,7 +388,7 @@ def categorize_package(result: FTPackageResult) -> FailureCategory:
             return FailureCategory.TSAN_WARNINGS
 
         ext = result.extension_compat
-        if ext and ext.get("gil_fallback_active", False):
+        if ext and ext.gil_fallback_active:
             return FailureCategory.COMPATIBLE_GIL_FALLBACK
 
         return FailureCategory.COMPATIBLE
@@ -458,7 +469,7 @@ class FTRunSummary:
         extensions: list[FTPackageResult] = []
         for r in results:
             ext = r.extension_compat
-            if ext and not ext.get("is_pure_python", True):
+            if ext and not ext.is_pure_python:
                 extensions.append(r)
             else:
                 pure_python.append(r)

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -890,7 +890,7 @@ def run_package_ft(
                     import_name=pkg.import_name,
                     env=env,
                 )
-                result.extension_compat = compat.to_dict()
+                result.extension_compat = compat
                 result.import_ok = compat.import_ok
                 result.import_error = compat.import_error
             except (OSError, subprocess.SubprocessError, ValueError) as exc:

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -353,7 +353,7 @@ def compat(result_dir: Path, extensions_only: bool) -> None:
     Reports which packages have C extensions, whether they declare
     Py_mod_gil, and whether GIL fallback was triggered at runtime.
     """
-    from labeille.ft.compat import ExtensionCompat, format_extension_compat
+    from labeille.ft.compat import format_extension_compat
     from labeille.ft.results import load_ft_run
 
     _, results = load_ft_run(result_dir)
@@ -362,7 +362,7 @@ def compat(result_dir: Path, extensions_only: bool) -> None:
         if r.extension_compat is None:
             continue
 
-        ext = ExtensionCompat.from_dict(r.extension_compat)
+        ext = r.extension_compat
 
         if extensions_only and ext.is_pure_python:
             continue

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -17,7 +17,7 @@ from labeille.bench.results import (
     BenchMeta,
     ConditionDef,
 )
-from labeille.bench.runner import BenchProgress, BenchRunner, quick_config
+from labeille.bench.runner import BenchProgress, BenchRunner, _PackageSetup, quick_config
 from labeille.bench.system import PythonProfile, StabilityCheck, SystemProfile, SystemSnapshot
 from labeille.bench.timing import TimedResult
 from labeille.registry import Index, IndexEntry
@@ -222,10 +222,9 @@ class TestSetupPackage(unittest.TestCase):
                 result = runner._setup_package(pkg)
 
             self.assertIsNotNone(result)
-            self.assertIn("repo_dir", result)
-            self.assertIn("venvs", result)
-            self.assertIn("clone_duration", result)
-            self.assertIn("baseline", result["venvs"])
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result.repo_dir, Path)
+            self.assertIn("baseline", result.venvs)
             mock_clone.assert_called_once()
             mock_create.assert_called_once()
             mock_install.assert_called_once()
@@ -356,8 +355,8 @@ class TestSetupPackage(unittest.TestCase):
             self.assertIsNotNone(result)
             self.assertEqual(mock_create.call_count, 2)
             self.assertEqual(mock_install.call_count, 2)
-            self.assertIn("baseline", result["venvs"])
-            self.assertIn("coverage", result["venvs"])
+            self.assertIn("baseline", result.venvs)
+            self.assertIn("coverage", result.venvs)
 
     @patch(
         "labeille.bench.runner.time.monotonic",
@@ -431,7 +430,7 @@ class TestSetupPackage(unittest.TestCase):
 
             # Setup still succeeds despite extra deps failure.
             self.assertIsNotNone(result)
-            self.assertIn("venvs", result)
+            self.assertIsNotNone(result)
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +445,7 @@ class TestRunIteration(unittest.TestCase):
         self,
         cond_name: str = "baseline",
         **config_kwargs: object,
-    ) -> tuple[BenchRunner, dict[str, object], ConditionDef]:
+    ) -> tuple[BenchRunner, _PackageSetup, ConditionDef]:
         """Create runner with a basic setup dict."""
         cond = _make_condition(cond_name)
         config = _make_config(
@@ -454,10 +453,10 @@ class TestRunIteration(unittest.TestCase):
             **config_kwargs,
         )
         runner = BenchRunner(config)
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {cond_name: Path("/tmp/fake/venv")},
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={cond_name: Path("/tmp/fake/venv")},
+        )
         return runner, setup, cond
 
     @patch("labeille.bench.runner.SystemSnapshot.capture")
@@ -589,10 +588,10 @@ class TestRunIteration(unittest.TestCase):
         cond = _make_condition(test_command_suffix="--tb=short")
         config = _make_config(conditions={"baseline": cond})
         runner = BenchRunner(config)
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"baseline": Path("/tmp/fake/venv")},
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"baseline": Path("/tmp/fake/venv")},
+        )
 
         runner._run_iteration(
             pkg=FakePackage(package="mypkg", test_command="python -m pytest"),
@@ -625,10 +624,10 @@ class TestRunIteration(unittest.TestCase):
             default_env={"PYTHONFAULTHANDLER": "1"},
         )
         runner = BenchRunner(config)
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"cov": Path("/tmp/fake/venv")},
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"cov": Path("/tmp/fake/venv")},
+        )
 
         runner._run_iteration(
             pkg=FakePackage(package="mypkg"),
@@ -710,13 +709,13 @@ class TestExecutionStrategies(unittest.TestCase):
 
     def _fake_setup(
         self, pkg: FakePackage, conditions: dict[str, ConditionDef]
-    ) -> dict[str, object]:
-        """Create a fake setup dict for a package."""
-        return {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {name: Path(f"/tmp/fake/venv_{name}") for name in conditions},
-            "clone_duration": 0.5,
-        }
+    ) -> _PackageSetup:
+        """Create a fake setup for a package."""
+        return _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={name: Path(f"/tmp/fake/venv_{name}") for name in conditions},
+            clone_duration=0.5,
+        )
 
     def test_block_order(self) -> None:
         """Block mode: all iterations of condition A, then all of B."""
@@ -819,11 +818,11 @@ class TestExecutionStrategies(unittest.TestCase):
         progress_log: list[BenchProgress] = []
         runner = BenchRunner(config, progress_callback=progress_log.append)
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/fake/venv_A")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/fake/venv_A")},
+            clone_duration=0.5,
+        )
 
         with (
             patch.object(runner, "_setup_package", return_value=setup),
@@ -864,12 +863,12 @@ class TestResultWriting(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             results_path = Path(tmpdir) / "results.jsonl"
 
-            def fake_setup(pkg: object) -> dict[str, object]:
-                return {
-                    "repo_dir": Path("/tmp/fake/repo"),
-                    "venvs": {"A": Path("/tmp/fake/venv_A")},
-                    "clone_duration": 0.5,
-                }
+            def fake_setup(pkg: object) -> _PackageSetup:
+                return _PackageSetup(
+                    repo_dir=Path("/tmp/fake/repo"),
+                    venvs={"A": Path("/tmp/fake/venv_A")},
+                    clone_duration=0.5,
+                )
 
             with (
                 patch.object(runner, "_setup_package", side_effect=fake_setup),
@@ -1140,11 +1139,11 @@ class TestAdaptiveConvergence(unittest.TestCase):
             adaptive_min_iterations=3,
         )
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/fake/venv_A")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/fake/venv_A")},
+            clone_duration=0.5,
+        )
         with patch.object(runner, "_setup_package", return_value=setup):
             result = runner._benchmark_package(pkg, 0, 1)
 
@@ -1169,11 +1168,11 @@ class TestAdaptiveConvergence(unittest.TestCase):
             adaptive_min_iterations=3,
         )
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/A"), "B": Path("/tmp/B")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/A"), "B": Path("/tmp/B")},
+            clone_duration=0.5,
+        )
         with patch.object(runner, "_setup_package", return_value=setup):
             result = runner._benchmark_package(pkg, 0, 1)
 
@@ -1196,11 +1195,11 @@ class TestAdaptiveConvergence(unittest.TestCase):
             adaptive_threshold=0.001,
         )
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/fake/venv_A")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/fake/venv_A")},
+            clone_duration=0.5,
+        )
         with patch.object(runner, "_setup_package", return_value=setup):
             result = runner._benchmark_package(pkg, 0, 1)
 
@@ -1221,11 +1220,11 @@ class TestAdaptiveConvergence(unittest.TestCase):
             adaptive=False,
         )
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/fake/venv_A")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/fake/venv_A")},
+            clone_duration=0.5,
+        )
         with patch.object(runner, "_setup_package", return_value=setup):
             result = runner._benchmark_package(pkg, 0, 1)
 
@@ -1246,11 +1245,11 @@ class TestAdaptiveConvergence(unittest.TestCase):
             adaptive_min_iterations=3,
         )
         pkg = FakePackage(package="mypkg")
-        setup: dict[str, object] = {
-            "repo_dir": Path("/tmp/fake/repo"),
-            "venvs": {"A": Path("/tmp/fake/venv_A")},
-            "clone_duration": 0.5,
-        }
+        setup = _PackageSetup(
+            repo_dir=Path("/tmp/fake/repo"),
+            venvs={"A": Path("/tmp/fake/venv_A")},
+            clone_duration=0.5,
+        )
         with patch.object(runner, "_setup_package", return_value=setup):
             result = runner._benchmark_package(pkg, 0, 1)
 
@@ -1339,13 +1338,13 @@ class TestFullIntegration(unittest.TestCase):
                 patch.object(
                     runner,
                     "_setup_package",
-                    return_value={
-                        "repo_dir": Path("/tmp/fake/repo"),
-                        "venvs": {"baseline": Path("/tmp/fake/venv")},
-                        "clone_duration": 0.5,
-                        "install_baseline": 1.0,
-                        "venv_baseline": 0.5,
-                    },
+                    return_value=_PackageSetup(
+                        repo_dir=Path("/tmp/fake/repo"),
+                        venvs={"baseline": Path("/tmp/fake/venv")},
+                        clone_duration=0.5,
+                        install_durations={"baseline": 1.0},
+                        venv_durations={"baseline": 0.5},
+                    ),
                 ),
                 # Timing.
                 patch(

--- a/tests/test_ft_analysis.py
+++ b/tests/test_ft_analysis.py
@@ -13,6 +13,7 @@ from labeille.ft.analysis import (
     detect_duration_anomalies,
     prioritize_triage,
 )
+from labeille.ft.compat import ExtensionCompat
 from labeille.ft.results import (
     FTPackageResult,
 )
@@ -304,7 +305,7 @@ class TestPrioritizeTriage(unittest.TestCase):
             make_package_result(
                 "ext_crash",
                 ["pass", "crash"],
-                extension_compat={"is_pure_python": False},
+                extension_compat=ExtensionCompat(package="ext_crash", is_pure_python=False),
             ),
             make_package_result("py_crash", ["pass", "crash"]),
         ]

--- a/tests/test_ft_export.py
+++ b/tests/test_ft_export.py
@@ -8,6 +8,7 @@ import json
 import unittest
 from typing import Any
 
+from labeille.ft.compat import ExtensionCompat
 from labeille.ft.export import export_csv, export_json, generate_report
 from labeille.ft.results import (
     FailureCategory,
@@ -263,11 +264,11 @@ class TestGenerateReport(unittest.TestCase):
                 0.7,
                 crash_count=3,
                 failure_signatures=["SIGSEGV"],
-                extension_compat={
-                    "package": "numpy",
-                    "is_pure_python": False,
-                    "gil_fallback_active": True,
-                },
+                extension_compat=ExtensionCompat(
+                    package="numpy",
+                    is_pure_python=False,
+                    gil_fallback_active=True,
+                ),
             )
         ]
         output = generate_report(meta, results, format="markdown")

--- a/tests/test_ft_results.py
+++ b/tests/test_ft_results.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ft_test_helpers import make_iteration, make_package_result
 
+from labeille.ft.compat import ExtensionCompat
 from labeille.ft.results import (
     FailureCategory,
     FTPackageResult,
@@ -279,7 +280,7 @@ class TestFTPackageResult(unittest.TestCase):
                 make_iteration(0, "pass", duration_s=10.0),
                 make_iteration(1, "crash", exit_code=-11, crash_signal="SIGSEGV"),
             ],
-            extension_compat={"is_pure_python": False, "gil_fallback_active": True},
+            extension_compat=ExtensionCompat(package="mypkg", is_pure_python=False, gil_fallback_active=True),
             install_duration_s=5.5,
             commit="abc123",
             gil_enabled_iterations=[make_iteration(0, "pass")],
@@ -386,7 +387,7 @@ class TestCategorizePackage(unittest.TestCase):
         r = FTPackageResult(
             package="pkg",
             iterations=[make_iteration(i, "pass") for i in range(5)],
-            extension_compat={"gil_fallback_active": True},
+            extension_compat=ExtensionCompat(package="pkg", gil_fallback_active=True),
         )
         r.compute_aggregates()
         cat = r.categorize()
@@ -405,7 +406,7 @@ class TestCategorizePackage(unittest.TestCase):
         r = FTPackageResult(
             package="pkg",
             iterations=[make_iteration(i, "pass", tsan_warnings=["data race"]) for i in range(5)],
-            extension_compat={"gil_fallback_active": True},
+            extension_compat=ExtensionCompat(package="pkg", gil_fallback_active=True),
         )
         r.compute_aggregates()
         cat = r.categorize()
@@ -477,12 +478,12 @@ class TestFTRunSummary(unittest.TestCase):
             make_package_result(
                 "ext1",
                 ["pass"] * 5,
-                extension_compat={"is_pure_python": False},
+                extension_compat=ExtensionCompat(package="ext1", is_pure_python=False),
             ),
             make_package_result(
                 "ext2",
                 ["fail"] * 5,
-                extension_compat={"is_pure_python": False},
+                extension_compat=ExtensionCompat(package="ext2", is_pure_python=False),
             ),
         ]
         summary = FTRunSummary.compute(results)
@@ -510,12 +511,12 @@ class TestFTRunSummary(unittest.TestCase):
         wheel_result = FTPackageResult(
             package="numpy",
             category=FailureCategory.COMPATIBLE_BY_WHEEL,
-            extension_compat={"is_pure_python": False},
+            extension_compat=ExtensionCompat(package="numpy", is_pure_python=False),
         )
         fail_result = make_package_result(
             "badext",
             ["fail"] * 5,
-            extension_compat={"is_pure_python": False},
+            extension_compat=ExtensionCompat(package="badext", is_pure_python=False),
         )
         results = [wheel_result, fail_result]
         summary = FTRunSummary.compute(results)


### PR DESCRIPTION
## Summary
- Type `FTPackageResult.extension_compat` as `ExtensionCompat | None` instead of `dict[str, Any] | None` — eliminates untyped `.get()` access across ft subsystem (ft/results.py, ft/analysis.py, ft/export.py, ft_cli.py)
- Replace `bench/runner.py` `_setup_package` return type from `dict[str, Any]` to typed `_PackageSetup` dataclass — eliminates string-keyed dict access for repo_dir, venvs, and timing data

## Test plan
- [x] ruff check passes
- [x] mypy strict passes (50 files)
- [x] All 2160 tests pass

Closes #252

Generated with [Claude Code](https://claude.com/claude-code)