### PR TITLE
fix: address 11 findings from deep exploration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Extract `_md_table` helper from `export_registry_report_md` in `analyze_cli.py` to deduplicate 8 markdown table constructions.
 - Extract `_prepare_source`, `_classify_install_result`, `_check_import_result` from `_survey_package` in `compat.py`, reducing complexity from 23 branches to ~8 per function.
 - Split `bench_cli.py:compare` into `_compare_intra_run`, `_compare_cross_run`, and `_report_anomalies`, eliminating CC=62.
+- Extract `_collect_package_data`, `_compute_trends`, `_classify_trends`, `_build_median_dicts` from `analyze_series_trends` in `bench/trends.py` (CC=48 → ~10 per helper).
+- Extract `_infer_field_type` from `batch_set_field` in `registry_ops.py` to deduplicate type inference.
+- Type `FTRunMeta.system_profile` and `python_profile` as `SystemProfile | dict` and `PythonProfile | dict` instead of `dict[str, Any]`.
 - Extract `_make_anomaly` helper in `bench/anomaly.py` to deduplicate 9 identical `PackageAnomaly` constructions in `detect_condition_anomalies`.
 - `bench run` and `ft run` now use shared `setup_logging()` for consistent log formatting.
 - Simplify `_run_package_inner` in `runner.py` by extracting 4 helper functions: `_align_sdist_version`, `_setup_venv`, `_install_in_venv`, `_check_import`.
@@ -29,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Use `append_jsonl()` in `migrations.py` instead of raw `open()`/`json.dumps` for pattern consistency.
 
 ### Fixed
+- Fix `bench compare` Click decorator chain pointing at wrong function after complexity split, restoring multi-directory comparison and `--metric` option.
+- Log PyPI metadata extraction failures in `ft/runner.py` instead of silently swallowing `(KeyError, TypeError)`.
+- Wrap `checkout_matching_tag` git fetch --tags in try/except to prevent unhandled `TimeoutExpired`/`OSError` crashes.
+- Make `load_ft_run` lenient for missing `ft_results.jsonl` (returns empty list like `load_bench_run`).
+- Add missing `installer_backend` field to `analyze.PackageResult` to match `runner_models.PackageResult`.
+- Narrow `IndexEntry.extension_type` from `str` to `Literal["pure", "extensions", "unknown"]`.
+- Narrow `PackageResult.install_from` and `installer_backend` from `str` to `Literal` types.
 - Fix `--no-shallow` / `--clone-depth=0` to produce actual full clones (no `--depth` flag) instead of silently defaulting to depth=1.
 - Add warning logs to 4 silent return-None paths in `repo_ops.py` (`clone_repo`, `pull_repo`, `checkout_revision`, `fetch_latest_pypi_version`).
 - Promote `pull_repo` git reset/clean failure logs from DEBUG to WARNING for visibility.
@@ -108,6 +118,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add missing `help=` text to 21 CLI options across `cli.py`, `analyze_cli.py`, `ft_cli.py`, `compat_cli.py`, and `bench_cli.py`.
 
 ### Tests
+- Add 11 tests for compat survey execution pipeline: `_prepare_source`, `_classify_install_result`, `_check_import_result`.
 - Add 26 tests for `bench track` subcommands: init, add, show, pin, unpin, list, trend, alert.
 - Add CLI tests for `registry` subcommands: rename-field, set-field (--all, --where, --packages), validate (--packages filter), migrate (list, unknown, missing name), sync (clone, pull, failure, non-git), add-index-field, remove-index-field, and group help.
 - Add `test_cli_utils.py` with 14 tests for `parse_env_pairs` and `parse_csv_list`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 ## Testing notes
 - Integration tests mock `fetch_pypi_metadata` to avoid network calls
 - Runner tests mock `subprocess.run` and `clone_repo` extensively
-- 2166 tests total across 50 test files
+- 2171 tests total across 50 test files
 
 ## Enriching packages
 

--- a/src/labeille/analyze.py
+++ b/src/labeille/analyze.py
@@ -76,9 +76,10 @@ class PackageResult:
     installed_dependencies: dict[str, str] = field(default_factory=dict)
     error_message: str | None = None
     requested_revision: str | None = None
-    install_from: str = ""
+    install_from: Literal["source", "sdist", ""] = ""
     sdist_version: str | None = None
     sdist_tag_matched: bool | None = None
+    installer_backend: Literal["pip", "uv", ""] = ""
     timestamp: str = ""
 
     @classmethod

--- a/src/labeille/bench/trends.py
+++ b/src/labeille/bench/trends.py
@@ -499,7 +499,120 @@ def _generate_alerts(
 
 
 # ---------------------------------------------------------------------------
-# Series-level analysis
+# Series-level analysis — helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_package_data(
+    run_data: list[tuple[TrackingRunEntry, BenchMeta, list[BenchPackageResult]]],
+    condition: str,
+) -> tuple[dict[str, list[tuple[float, float, str]]], set[str]]:
+    """Collect per-package median/CV/timestamp tuples from loaded runs.
+
+    Returns:
+        A tuple of (pkg_data mapping, all_packages set).
+    """
+    pkg_data: dict[str, list[tuple[float, float, str]]] = {}
+    all_packages: set[str] = set()
+
+    for entry, _meta, results in run_data:
+        for r in results:
+            if r.skipped:
+                continue
+            cond = r.conditions.get(condition)
+            if not cond or not cond.wall_time_stats:
+                continue
+            all_packages.add(r.package)
+            if r.package not in pkg_data:
+                pkg_data[r.package] = []
+            pkg_data[r.package].append(
+                (cond.wall_time_stats.median, cond.wall_time_stats.cv, entry.timestamp)
+            )
+
+    return pkg_data, all_packages
+
+
+def _compute_trends(
+    pkg_data: dict[str, list[tuple[float, float, str]]],
+    all_packages: set[str],
+    condition: str,
+    *,
+    regression_threshold: float,
+    trend_threshold: float,
+    sustained_count: int,
+) -> list[PackageTrend]:
+    """Compute :class:`PackageTrend` for every package with data points."""
+    package_trends: list[PackageTrend] = []
+    for pkg in sorted(all_packages):
+        data_points = pkg_data.get(pkg, [])
+        if not data_points:
+            continue
+        medians = [d[0] for d in data_points]
+        cvs = [d[1] for d in data_points]
+        timestamps = [d[2] for d in data_points]
+
+        pt = compute_package_trend(
+            pkg,
+            condition,
+            medians,
+            cvs,
+            timestamps,
+            regression_threshold=regression_threshold,
+            trend_threshold=trend_threshold,
+            sustained_count=sustained_count,
+        )
+        package_trends.append(pt)
+    return package_trends
+
+
+def _classify_trends(
+    package_trends: list[PackageTrend],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Classify packages into regressing, improving, volatile, and stable lists."""
+    regressing: list[str] = []
+    improving: list[str] = []
+    volatile: list[str] = []
+    stable: list[str] = []
+
+    for pt in package_trends:
+        if pt.trend_direction == "regressing":
+            regressing.append(pt.package)
+        elif pt.trend_direction == "improving":
+            improving.append(pt.package)
+        elif pt.trend_direction == "volatile":
+            volatile.append(pt.package)
+        else:
+            stable.append(pt.package)
+
+    return regressing, improving, volatile, stable
+
+
+def _build_median_dicts(
+    package_trends: list[PackageTrend],
+) -> tuple[dict[str, float], dict[str, float], dict[str, float]]:
+    """Build baseline, previous, and current median dicts from package trends.
+
+    Returns:
+        (baseline_medians, previous_medians, current_medians)
+    """
+    baseline_medians: dict[str, float] = {}
+    previous_medians: dict[str, float] = {}
+    current_medians: dict[str, float] = {}
+
+    for pt in package_trends:
+        if pt.medians:
+            baseline_medians[pt.package] = pt.medians[0]
+            current_medians[pt.package] = pt.medians[-1]
+            if len(pt.medians) >= 2:
+                previous_medians[pt.package] = pt.medians[-2]
+            else:
+                previous_medians[pt.package] = pt.medians[0]
+
+    return baseline_medians, previous_medians, current_medians
+
+
+# ---------------------------------------------------------------------------
+# Series-level analysis — orchestrator
 # ---------------------------------------------------------------------------
 
 
@@ -575,77 +688,23 @@ def analyze_series_trends(
         condition = cond_names[0] if cond_names else ""
 
     # Collect per-package medians and CVs across runs.
-    # package -> {run_index: (median, cv, timestamp)}
-    pkg_data: dict[str, list[tuple[float, float, str]]] = {}
-    all_packages: set[str] = set()
-
-    for entry, meta, results in run_data:
-        for r in results:
-            if r.skipped:
-                continue
-            cond = r.conditions.get(condition)
-            if not cond or not cond.wall_time_stats:
-                continue
-            all_packages.add(r.package)
-            if r.package not in pkg_data:
-                pkg_data[r.package] = []
-            pkg_data[r.package].append(
-                (cond.wall_time_stats.median, cond.wall_time_stats.cv, entry.timestamp)
-            )
+    pkg_data, all_packages = _collect_package_data(run_data, condition)
 
     # Compute trends.
-    package_trends: list[PackageTrend] = []
-    for pkg in sorted(all_packages):
-        data_points = pkg_data.get(pkg, [])
-        if not data_points:
-            continue
-        medians = [d[0] for d in data_points]
-        cvs = [d[1] for d in data_points]
-        timestamps = [d[2] for d in data_points]
-
-        pt = compute_package_trend(
-            pkg,
-            condition,
-            medians,
-            cvs,
-            timestamps,
-            regression_threshold=regression_threshold,
-            trend_threshold=trend_threshold,
-            sustained_count=sustained_count,
-        )
-        package_trends.append(pt)
+    package_trends = _compute_trends(
+        pkg_data,
+        all_packages,
+        condition,
+        regression_threshold=regression_threshold,
+        trend_threshold=trend_threshold,
+        sustained_count=sustained_count,
+    )
 
     # Classify packages.
-    regressing_packages: list[str] = []
-    improving_packages: list[str] = []
-    volatile_packages: list[str] = []
-    stable_packages: list[str] = []
+    regressing, improving, volatile, stable = _classify_trends(package_trends)
 
-    for pt in package_trends:
-        if pt.trend_direction == "regressing":
-            regressing_packages.append(pt.package)
-        elif pt.trend_direction == "improving":
-            improving_packages.append(pt.package)
-        elif pt.trend_direction == "volatile":
-            volatile_packages.append(pt.package)
-        else:
-            stable_packages.append(pt.package)
-
-    # Build median dicts for alert generation.
-    baseline_medians: dict[str, float] = {}
-    previous_medians: dict[str, float] = {}
-    current_medians: dict[str, float] = {}
-
-    for pt in package_trends:
-        if pt.medians:
-            baseline_medians[pt.package] = pt.medians[0]
-            current_medians[pt.package] = pt.medians[-1]
-            if len(pt.medians) >= 2:
-                previous_medians[pt.package] = pt.medians[-2]
-            else:
-                previous_medians[pt.package] = pt.medians[0]
-
-    # Generate alerts.
+    # Build median dicts and generate alerts.
+    baseline_medians, previous_medians, current_medians = _build_median_dicts(package_trends)
     alerts = _generate_alerts(
         package_trends,
         baseline_medians,
@@ -666,9 +725,9 @@ def analyze_series_trends(
         baseline_bench_id=baseline_bench_id,
         package_trends=package_trends,
         alerts=alerts,
-        regressing_packages=regressing_packages,
-        improving_packages=improving_packages,
-        volatile_packages=volatile_packages,
-        stable_packages=stable_packages,
+        regressing_packages=regressing,
+        improving_packages=improving,
+        volatile_packages=volatile,
+        stable_packages=stable,
         aggregate_median_change_pct=aggregate_change,
     )

--- a/src/labeille/bench_cli.py
+++ b/src/labeille/bench_cli.py
@@ -509,6 +509,32 @@ def show(result_dir: Path, anomalies: bool, per_test_package: str | None) -> Non
     default=None,
     help="Show per-test overhead for a specific package.",
 )
+def compare(
+    result_dirs: tuple[Path, ...],
+    baseline: str | None,
+    metric: str,
+    per_test_package: str | None,
+) -> None:
+    """Compare results from two or more benchmark runs.
+
+    Accepts either:
+    - Two result directories from different benchmark runs
+    - One result directory with multiple conditions
+
+    \b
+    Examples:
+        # Compare conditions within a single run
+        labeille bench compare results/bench_20260227_143000
+
+        # Compare two separate runs
+        labeille bench compare results/bench_baseline results/bench_jit
+    """
+    if len(result_dirs) == 1:
+        _compare_intra_run(result_dirs[0], baseline, per_test_package)
+    else:
+        _compare_cross_run(result_dirs, baseline)
+
+
 def _compare_intra_run(
     result_dir: Path,
     baseline: str | None,
@@ -625,32 +651,6 @@ def _report_anomalies(results: list[BenchPackageResult]) -> None:
             f"\n\u26a0 {n_pkgs} package(s) have measurement anomalies "
             f"(use 'bench show --anomalies' for details)."
         )
-
-
-def compare(
-    result_dirs: tuple[Path, ...],
-    baseline: str | None,
-    metric: str,
-    per_test_package: str | None,
-) -> None:
-    """Compare results from two or more benchmark runs.
-
-    Accepts either:
-    - Two result directories from different benchmark runs
-    - One result directory with multiple conditions
-
-    \b
-    Examples:
-        # Compare conditions within a single run
-        labeille bench compare results/bench_20260227_143000
-
-        # Compare two separate runs
-        labeille bench compare results/bench_baseline results/bench_jit
-    """
-    if len(result_dirs) == 1:
-        _compare_intra_run(result_dirs[0], baseline, per_test_package)
-    else:
-        _compare_cross_run(result_dirs, baseline)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labeille/ft/export.py
+++ b/src/labeille/ft/export.py
@@ -152,8 +152,10 @@ def _report_header_md(meta: FTRunMeta, summary: FTRunSummary) -> list[str]:
         "",
     ]
 
-    py = meta.python_profile or {}
-    sys_p = meta.system_profile or {}
+    py_raw = meta.python_profile
+    py = py_raw.to_dict() if hasattr(py_raw, "to_dict") else (py_raw or {})
+    sys_raw = meta.system_profile
+    sys_p = sys_raw.to_dict() if hasattr(sys_raw, "to_dict") else (sys_raw or {})
 
     lines.append(f"**Date:** {meta.timestamp}")
     lines.append(f"**Python:** {py.get('version', '?')} ({py.get('implementation', '?')})")

--- a/src/labeille/ft/results.py
+++ b/src/labeille/ft/results.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from labeille.ft.compat import ExtensionCompat
 
+from labeille.bench.system import PythonProfile, SystemProfile
 from labeille.io_utils import (
     append_jsonl,
     atomic_write_text,
@@ -410,8 +411,8 @@ class FTRunMeta:
 
     run_id: str
     timestamp: str
-    system_profile: dict[str, Any] = field(default_factory=dict)
-    python_profile: dict[str, Any] = field(default_factory=dict)
+    system_profile: SystemProfile | dict[str, Any] = field(default_factory=dict)
+    python_profile: PythonProfile | dict[str, Any] = field(default_factory=dict)
     config: dict[str, Any] = field(default_factory=dict)
     cli_args: list[str] = field(default_factory=list)
     packages_total: int = 0
@@ -420,11 +421,24 @@ class FTRunMeta:
     total_duration_s: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        d = asdict(self)
+        # Ensure typed profiles are serialized properly.
+        if isinstance(self.system_profile, SystemProfile):
+            d["system_profile"] = self.system_profile.to_dict()
+        if isinstance(self.python_profile, PythonProfile):
+            d["python_profile"] = self.python_profile.to_dict()
+        return d
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FTRunMeta:
-        return dataclass_from_dict(cls, data)
+        sys_raw = data.get("system_profile", {})
+        py_raw = data.get("python_profile", {})
+        meta = dataclass_from_dict(cls, data)
+        if isinstance(sys_raw, dict) and sys_raw:
+            meta.system_profile = SystemProfile.from_dict(sys_raw)
+        if isinstance(py_raw, dict) and py_raw:
+            meta.python_profile = PythonProfile.from_dict(py_raw)
+        return meta
 
 
 @dataclass
@@ -590,9 +604,9 @@ def load_ft_run(
 
     if not meta_path.exists():
         raise FileNotFoundError(f"No ft_meta.json in {results_dir}")
-    if not results_path.exists():
-        raise FileNotFoundError(f"No ft_results.jsonl in {results_dir}")
 
     meta = FTRunMeta.from_dict(load_json_file(meta_path))
-    results = load_jsonl(results_path, FTPackageResult.from_dict)
+    results: list[FTPackageResult] = []
+    if results_path.exists():
+        results = load_jsonl(results_path, FTPackageResult.from_dict)
     return meta, results

--- a/src/labeille/ft/runner.py
+++ b/src/labeille/ft/runner.py
@@ -492,7 +492,7 @@ def _check_ft_wheel_trust(
     try:
         pypi_version = cached_metadata["info"]["version"]
     except (KeyError, TypeError):
-        pass
+        log.warning("Could not extract version from PyPI metadata for %s", pkg.package)
 
     if has_ft_wheel(urls, target_version=ft_check_version):
         version_desc = (
@@ -566,6 +566,7 @@ def _clone_and_align_ft(
             try:
                 sdist_version: str | None = cached_metadata["info"]["version"]
             except (KeyError, TypeError):
+                log.warning("Could not extract version from PyPI metadata for %s", pkg.package)
                 sdist_version = None
         else:
             sdist_version = fetch_latest_pypi_version(pkg.package)
@@ -1005,8 +1006,8 @@ def run_ft(config: FTRunConfig) -> list[FTPackageResult]:
     meta = FTRunMeta(
         run_id=run_id,
         timestamp=utc_now_iso(),
-        system_profile=sys_profile.to_dict(),
-        python_profile=py_profile.to_dict(),
+        system_profile=sys_profile,
+        python_profile=py_profile,
         config={
             "target_python": str(config.target_python),
             "iterations": config.iterations,

--- a/src/labeille/ft_cli.py
+++ b/src/labeille/ft_cli.py
@@ -256,21 +256,23 @@ def show(result_dir: Path, sort_by: str, limit: int | None) -> None:
     py_info = ""
     if meta.python_profile:
         py = meta.python_profile
+        py_d = py.to_dict() if hasattr(py, "to_dict") else py
         flags: list[str] = []
-        if py.get("jit_enabled"):
+        if py_d.get("jit_enabled"):
             flags.append("JIT")
-        if py.get("gil_disabled"):
+        if py_d.get("gil_disabled"):
             flags.append("free-threaded")
         flag_str = f" ({', '.join(flags)})" if flags else ""
-        py_info = f"Python: {py.get('version', '?')}{flag_str}"
+        py_info = f"Python: {py_d.get('version', '?')}{flag_str}"
 
     sys_info = ""
     if meta.system_profile:
         sp = meta.system_profile
+        sp_d = sp.to_dict() if hasattr(sp, "to_dict") else sp
         sys_info = (
-            f"System: {sp.get('cpu_model', '?')}, "
-            f"{sp.get('ram_total_gb', 0):.0f}GB RAM, "
-            f"{sp.get('os_distro', '?')}"
+            f"System: {sp_d.get('cpu_model', '?')}, "
+            f"{sp_d.get('ram_total_gb', 0):.0f}GB RAM, "
+            f"{sp_d.get('os_distro', '?')}"
         )
 
     config_dict = meta.config or {}

--- a/src/labeille/registry.py
+++ b/src/labeille/registry.py
@@ -137,7 +137,7 @@ class IndexEntry:
 
     name: str
     download_count: int | None = None
-    extension_type: str = "unknown"
+    extension_type: Literal["pure", "extensions", "unknown"] = "unknown"
     enriched: bool = False
     skip: bool = False
     skip_versions_keys: list[str] = field(default_factory=list)

--- a/src/labeille/registry_ops.py
+++ b/src/labeille/registry_ops.py
@@ -449,6 +449,24 @@ def batch_rename_field(
     return OpResult(modified=modified, skipped=skipped, errors=errors, total=len(files))
 
 
+def _infer_field_type(existing_value: Any) -> str:
+    """Infer the YAML field type string from an existing parsed value.
+
+    Returns one of ``"bool"``, ``"int"``, ``"list"``, ``"dict"``, or ``"str"``.
+    The check order matters: ``bool`` must precede ``int`` because in Python
+    ``isinstance(True, int)`` is ``True``.
+    """
+    if isinstance(existing_value, bool):
+        return "bool"
+    if isinstance(existing_value, int):
+        return "int"
+    if isinstance(existing_value, list):
+        return "list"
+    if isinstance(existing_value, dict):
+        return "dict"
+    return "str"
+
+
 def batch_set_field(
     registry_dir: Path,
     field_name: str,
@@ -511,20 +529,9 @@ def batch_set_field(
             continue
 
         # Determine type from existing value or explicit --type.
-        if field_type is None:
-            existing = raw[field_name]
-            if isinstance(existing, bool):
-                field_type_resolved = "bool"
-            elif isinstance(existing, int):
-                field_type_resolved = "int"
-            elif isinstance(existing, list):
-                field_type_resolved = "list"
-            elif isinstance(existing, dict):
-                field_type_resolved = "dict"
-            else:
-                field_type_resolved = "str"
-        else:
-            field_type_resolved = field_type
+        field_type_resolved = (
+            _infer_field_type(raw[field_name]) if field_type is None else field_type
+        )
 
         parsed_value = parse_default_value(value_str, field_type_resolved)
 

--- a/src/labeille/repo_ops.py
+++ b/src/labeille/repo_ops.py
@@ -318,14 +318,17 @@ def checkout_matching_tag(
         tag found.
     """
     # Best-effort fetch of tags for shallow clones.
-    subprocess.run(
-        ["git", "fetch", "--tags", "--depth=1", "origin"],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=str(repo_dir),
-        timeout=60,
-    )
+    try:
+        subprocess.run(
+            ["git", "fetch", "--tags", "--depth=1", "origin"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(repo_dir),
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        log.debug("Tag fetch failed for %s (non-fatal): %s", repo_dir, exc)
 
     normalized = package_name.lower().replace("_", "-")
 

--- a/src/labeille/runner_models.py
+++ b/src/labeille/runner_models.py
@@ -87,10 +87,10 @@ class PackageResult:
     installed_dependencies: dict[str, str] = field(default_factory=dict)
     error_message: str | None = None
     requested_revision: str | None = None
-    install_from: str = ""  # "source" or "sdist"
+    install_from: Literal["source", "sdist", ""] = ""
     sdist_version: str | None = None
     sdist_tag_matched: bool | None = None
-    installer_backend: str = ""
+    installer_backend: Literal["pip", "uv", ""] = ""
     timestamp: str = ""
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,12 +13,16 @@ from labeille.compat import (
     CompatDiff,
     CompatDiffEntry,
     CompatMeta,
+    CompatPackageInput,
     CompatResult,
     CompatSurvey,
     ErrorMatch,
     ErrorPattern,
     _BUILTIN_PATTERNS,
     _NO_SDIST_PATTERN,
+    _check_import_result,
+    _classify_install_result,
+    _prepare_source,
     _read_packages_file,
     classify_build_output,
     diff_surveys,
@@ -1003,6 +1008,182 @@ class TestBuiltinPatterns(unittest.TestCase):
                 first_catchall_idx = i
                 break
         self.assertGreater(first_catchall_idx, last_specific_idx)
+
+
+# ---------------------------------------------------------------------------
+# _prepare_source
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareSource(unittest.TestCase):
+    """Tests for _prepare_source()."""
+
+    def _make_pkg(self, **kwargs: object) -> CompatPackageInput:
+        defaults: dict[str, object] = {"name": "mypkg"}
+        defaults.update(kwargs)
+        return CompatPackageInput(**defaults)  # type: ignore[arg-type]
+
+    def test_sdist_mode_returns_install_cmd(self) -> None:
+        """sdist mode returns pip install --no-binary <pkg> <pkg>."""
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        tmp = Path("/tmp/fake")
+        out = _prepare_source(pkg, "sdist", None, tmp, no_binary_all=False, result=result)
+        self.assertIsNotNone(out)
+        assert out is not None
+        cmd, cwd = out
+        self.assertEqual(cmd, "pip install --no-binary mypkg mypkg")
+        self.assertEqual(cwd, tmp)
+
+    def test_sdist_mode_no_binary_all(self) -> None:
+        """sdist mode with no_binary_all uses :all: flag."""
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        tmp = Path("/tmp/fake")
+        out = _prepare_source(pkg, "sdist", None, tmp, no_binary_all=True, result=result)
+        self.assertIsNotNone(out)
+        assert out is not None
+        cmd, cwd = out
+        self.assertEqual(cmd, "pip install --no-binary :all: mypkg")
+        self.assertEqual(cwd, tmp)
+
+    def test_source_mode_no_repo_url(self) -> None:
+        """source mode with no repo_url returns None and sets status='no_repo'."""
+        pkg = self._make_pkg(repo_url=None)
+        result = CompatResult(package="mypkg", status="skip")
+        tmp = Path("/tmp/fake")
+        out = _prepare_source(pkg, "source", None, tmp, no_binary_all=False, result=result)
+        self.assertIsNone(out)
+        self.assertEqual(result.status, "no_repo")
+
+    @patch("labeille.compat.clone_repo", side_effect=subprocess.CalledProcessError(1, "git"))
+    def test_source_mode_clone_fails(self, _mock_clone: MagicMock) -> None:
+        """source mode where clone raises CalledProcessError sets status='clone_error'."""
+        pkg = self._make_pkg(repo_url="https://github.com/foo/mypkg")
+        result = CompatResult(package="mypkg", status="skip")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            out = _prepare_source(
+                pkg, "source", None, tmp, no_binary_all=False, result=result
+            )
+        self.assertIsNone(out)
+        self.assertEqual(result.status, "clone_error")
+
+
+# ---------------------------------------------------------------------------
+# _classify_install_result
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyInstallResult(unittest.TestCase):
+    """Tests for _classify_install_result()."""
+
+    def test_returncode_zero_returns_false(self) -> None:
+        """Successful install (rc=0) returns False."""
+        proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        result = CompatResult(package="pkg", status="skip")
+        failed = _classify_install_result(proc, "sdist", [], result)
+        self.assertFalse(failed)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_no_sdist_pattern_sets_no_sdist(self) -> None:
+        """Non-zero rc with no-sdist pattern in sdist mode sets status='no_sdist'."""
+        proc = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="ERROR: No matching distribution found for mypkg --no-binary",
+        )
+        result = CompatResult(package="mypkg", status="skip")
+        failed = _classify_install_result(proc, "sdist", [], result)
+        self.assertTrue(failed)
+        self.assertEqual(result.status, "no_sdist")
+
+    def test_nonzero_returncode_sets_build_fail(self) -> None:
+        """Non-zero rc without no-sdist match sets status='build_fail'."""
+        proc = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="error: compilation failed\n",
+        )
+        result = CompatResult(package="pkg", status="skip")
+        failed = _classify_install_result(proc, "sdist", _BUILTIN_PATTERNS, result)
+        self.assertTrue(failed)
+        self.assertEqual(result.status, "build_fail")
+        self.assertEqual(result.exit_code, 1)
+
+
+# ---------------------------------------------------------------------------
+# _check_import_result
+# ---------------------------------------------------------------------------
+
+
+class TestCheckImportResult(unittest.TestCase):
+    """Tests for _check_import_result()."""
+
+    def _make_pkg(self, **kwargs: object) -> CompatPackageInput:
+        defaults: dict[str, object] = {"name": "mypkg"}
+        defaults.update(kwargs)
+        return CompatPackageInput(**defaults)  # type: ignore[arg-type]
+
+    @patch("labeille.compat.clean_env", return_value={})
+    @patch("labeille.compat.check_import")
+    def test_import_succeeds(self, mock_import: MagicMock, _mock_env: MagicMock) -> None:
+        """Successful import sets status='build_ok'."""
+        mock_import.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        venv_dir = Path("/tmp/fake/venv")
+        _check_import_result(pkg, venv_dir, [], result)
+        self.assertEqual(result.status, "build_ok")
+
+    @patch("labeille.compat.clean_env", return_value={})
+    @patch("labeille.compat.check_import")
+    @patch("labeille.compat.detect_crash")
+    def test_import_crash(
+        self, mock_crash: MagicMock, mock_import: MagicMock, _mock_env: MagicMock
+    ) -> None:
+        """Import that crashes sets status='import_crash'."""
+        mock_import.return_value = subprocess.CompletedProcess(
+            args=[], returncode=-11, stdout="", stderr="segfault"
+        )
+        crash_info = MagicMock()
+        crash_info.signature = "SIGSEGV"
+        mock_crash.return_value = crash_info
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        _check_import_result(pkg, Path("/tmp/fake/venv"), [], result)
+        self.assertEqual(result.status, "import_crash")
+        self.assertEqual(result.crash_signature, "SIGSEGV")
+
+    @patch("labeille.compat.clean_env", return_value={})
+    @patch("labeille.compat.check_import")
+    @patch("labeille.compat.detect_crash", return_value=None)
+    def test_import_fail(
+        self, _mock_crash: MagicMock, mock_import: MagicMock, _mock_env: MagicMock
+    ) -> None:
+        """Import failure (non-crash) sets status='import_fail'."""
+        mock_import.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="ImportError: No module named mypkg"
+        )
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        _check_import_result(pkg, Path("/tmp/fake/venv"), [], result)
+        self.assertEqual(result.status, "import_fail")
+        self.assertIn("ImportError", result.import_error)
+
+    @patch("labeille.compat.clean_env", return_value={})
+    @patch("labeille.compat.check_import", side_effect=subprocess.TimeoutExpired("cmd", 60))
+    def test_import_timeout(self, _mock_import: MagicMock, _mock_env: MagicMock) -> None:
+        """Import timeout sets status='import_fail' with timeout message."""
+        pkg = self._make_pkg()
+        result = CompatResult(package="mypkg", status="skip")
+        _check_import_result(pkg, Path("/tmp/fake/venv"), [], result)
+        self.assertEqual(result.status, "import_fail")
+        self.assertIn("timed out", result.import_error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Bug fixes:
- Fix `bench compare` Click decorator chain pointing at wrong function after complexity split (multi-dir comparison was broken)
- Log PyPI metadata extraction failures in `ft/runner.py` (2 locations)
- Wrap `checkout_matching_tag` git fetch --tags in try/except
- Make `load_ft_run` lenient for missing `ft_results.jsonl`

Type safety:
- Add missing `installer_backend` to `analyze.PackageResult`
- Narrow `IndexEntry.extension_type` to `Literal` type
- Narrow `PackageResult.install_from` and `installer_backend` to `Literal` types
- Type `FTRunMeta` profiles as `SystemProfile`/`PythonProfile` instead of `dict[str, Any]`

Complexity reduction:
- Extract 4 helpers from `analyze_series_trends` (CC=48 → ~10 each)
- Extract `_infer_field_type` from `batch_set_field`

Tests:
- Add 11 tests for compat survey execution pipeline (was 0% coverage)

## Test plan
- [x] ruff check passes
- [x] mypy strict passes (50 files)
- [x] All 2171 tests pass

Generated with [Claude Code](https://claude.com/claude-code)