### PR TITLE
feat: add labeille cext-build for compile database generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- `labeille cext-build` command for generating `compile_commands.json` compilation databases from C extension packages. Uses [Bear](https://github.com/rizsotto/Bear) to intercept compiler invocations during the build, with automatic fallback to build-system-specific mechanisms for Meson and CMake projects.
+- `CextBuildConfig`, `CextBuildResult`, `CextBuildMeta` dataclasses in `cext_build.py`.
+- `detect_bear()` for auto-detecting bear installation and version.
+- `detect_build_system()` for identifying the build system from project files (meson, cmake, setuptools, flit, hatch, pdm).
+- `extract_build_requires()` for reading `[build-system].requires` from `pyproject.toml` to support `--no-build-isolation` builds.
+- `find_compile_db()` for searching repo and build directories for generated compilation databases.
+- `postprocess_compile_db()` for fixing source file paths in generated compilation databases.
+- Output includes per-package `compile_commands.json`, repo symlinks, build logs, and JSONL result summaries.
+- Designed for integration with [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit) Tier 2 analysis (clang-tidy).
+
 ### Enhanced
 - Extract `_build_run_config` from `run_cmd` in `cli.py` to separate config validation/construction from CLI execution.
 - Extract `_md_table` helper from `export_registry_report_md` in `analyze_cli.py` to deduplicate 8 markdown table constructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 - Click CLI framework — Click 8.3+ (no `mix_stderr` in CliRunner)
 
 ## Architecture
-- `cli.py` — Click CLI entry point with `resolve`, `run`, `scan-deps`, `bisect`, `registry`, `analyze`, `bench`, `ft`, and `compat` subcommands
+- `cli.py` — Click CLI entry point with `resolve`, `run`, `scan-deps`, `bisect`, `registry`, `analyze`, `bench`, `ft`, `compat`, and `cext-build` subcommands
 - `cli_utils.py` — Shared Click helpers (parse_csv_list, parse_env_pairs)
 - `resolve.py` — PyPI metadata fetching, repo URL extraction, registry building
 - `runner.py` — Clone repos, create venvs, run test suites, detect crashes
@@ -67,7 +67,7 @@ ASAN_OPTIONS=detect_leaks=0 PYTHON_JIT=0 .venv/bin/python -m unittest discover t
 ## Testing notes
 - Integration tests mock `fetch_pypi_metadata` to avoid network calls
 - Runner tests mock `subprocess.run` and `clone_repo` extensively
-- 2182 tests total across 50 test files
+- 2224 tests total across 52 test files
 
 ## Enriching packages
 

--- a/src/labeille/cext_build.py
+++ b/src/labeille/cext_build.py
@@ -1,0 +1,673 @@
+"""Build C extension packages and generate compile_commands.json.
+
+Wraps package builds with Bear to intercept compiler invocations and
+produce compilation databases for clang-tidy analysis. Falls back to
+build-system-specific mechanisms (Meson, CMake) when Bear is not
+available.
+
+Designed for integration with cext-review-toolkit's Tier 2 analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+import tomllib
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from labeille.io_utils import append_jsonl, write_meta_json
+from labeille.logging import get_logger
+from labeille.runner import (
+    InstallerBackend,
+    clean_env,
+    clone_repo,
+    create_venv,
+    install_package,
+    pull_repo,
+    resolve_installer,
+)
+
+log = get_logger("cext_build")
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CextBuildConfig:
+    """Configuration for a cext-build run."""
+
+    target_python: Path
+    output_dir: Path = field(default_factory=lambda: Path("cext-builds"))
+    registry_dir: Path | None = None
+    repos_dir: Path | None = None
+    venvs_dir: Path | None = None
+    packages_filter: list[str] | None = None
+    top_n: int | None = None
+    timeout: int = 600
+    installer: str = "auto"
+    no_build_isolation: bool = True
+    bear_path: str | None = None
+    skip_if_exists: bool = True
+    verbose: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Result data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CextBuildResult:
+    """Result of building a single C extension package."""
+
+    package: str = ""
+    status: str = ""  # ok, build_fail, no_compile_db, no_repo, clone_error,
+    #                    timeout, skipped, pure_python
+    compile_db_path: str | None = None
+    compile_db_entries: int = 0
+    compile_db_method: str = ""  # bear, meson, cmake, none
+    build_duration_s: float = 0.0
+    exit_code: int | None = None
+    error_summary: str = ""
+    repo_dir: str = ""
+    build_system: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSONL. Sparse output."""
+        d: dict[str, Any] = {"package": self.package, "status": self.status}
+        if self.compile_db_path:
+            d["compile_db_path"] = self.compile_db_path
+        if self.compile_db_entries:
+            d["compile_db_entries"] = self.compile_db_entries
+        if self.compile_db_method:
+            d["compile_db_method"] = self.compile_db_method
+        d["build_duration_s"] = round(self.build_duration_s, 2)
+        if self.exit_code is not None:
+            d["exit_code"] = self.exit_code
+        if self.error_summary:
+            d["error_summary"] = self.error_summary
+        if self.repo_dir:
+            d["repo_dir"] = self.repo_dir
+        if self.build_system:
+            d["build_system"] = self.build_system
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CextBuildResult:
+        """Deserialize from dict, ignoring unknown fields."""
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
+
+
+@dataclass
+class CextBuildMeta:
+    """Metadata for a cext-build run."""
+
+    build_id: str
+    target_python: str
+    python_version: str
+    started_at: str
+    finished_at: str = ""
+    total_packages: int = 0
+    built_ok: int = 0
+    compile_db_generated: int = 0
+    bear_available: bool = False
+    bear_version: str = ""
+    no_build_isolation: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict."""
+        return {k: v for k, v in asdict(self).items() if v or isinstance(v, (bool, int))}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CextBuildMeta:
+        """Deserialize from dict, ignoring unknown fields."""
+        from labeille.io_utils import dataclass_from_dict
+
+        return dataclass_from_dict(cls, data)
+
+
+# ---------------------------------------------------------------------------
+# Bear detection
+# ---------------------------------------------------------------------------
+
+
+def detect_bear() -> tuple[str | None, str]:
+    """Detect bear and return (path, version).
+
+    Returns ``(None, "")`` if bear is not installed.
+    """
+    bear_path = shutil.which("bear")
+    if bear_path is None:
+        return None, ""
+    try:
+        proc = subprocess.run(
+            [bear_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version = (proc.stdout.strip() or proc.stderr.strip()).split("\n")[0]
+        return bear_path, version
+    except Exception:  # noqa: BLE001
+        return bear_path, "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Build system detection
+# ---------------------------------------------------------------------------
+
+
+def detect_build_system(repo_dir: Path) -> str:
+    """Detect the build system from project files.
+
+    Returns one of: ``"meson"``, ``"cmake"``, ``"setuptools"``,
+    ``"flit"``, ``"hatch"``, ``"pdm"``, ``"unknown"``.
+    """
+    # Direct file checks take priority.
+    if (repo_dir / "meson.build").exists():
+        return "meson"
+    if (repo_dir / "CMakeLists.txt").exists():
+        return "cmake"
+
+    # Check pyproject.toml build-backend.
+    pyproject = repo_dir / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            backend = data.get("build-system", {}).get("build-backend", "")
+            if "mesonpy" in backend or "meson" in backend:
+                return "meson"
+            if "scikit_build" in backend or "skbuild" in backend:
+                return "cmake"
+            if "flit" in backend:
+                return "flit"
+            if "hatch" in backend:
+                return "hatch"
+            if "pdm" in backend:
+                return "pdm"
+            if "setuptools" in backend:
+                return "setuptools"
+        except (OSError, tomllib.TOMLDecodeError):
+            pass
+
+    # Fallback to setup.py/setup.cfg.
+    if (repo_dir / "setup.py").exists() or (repo_dir / "setup.cfg").exists():
+        return "setuptools"
+
+    return "unknown"
+
+
+def extract_build_requires(repo_dir: Path) -> list[str]:
+    """Extract ``[build-system].requires`` from pyproject.toml.
+
+    Returns a safe fallback if pyproject.toml is missing or unparseable.
+    """
+    pyproject = repo_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return ["setuptools", "wheel"]
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        reqs = data.get("build-system", {}).get("requires", [])
+        return reqs if reqs else ["setuptools", "wheel"]
+    except (OSError, tomllib.TOMLDecodeError):
+        return ["setuptools", "wheel"]
+
+
+# ---------------------------------------------------------------------------
+# Compile database helpers
+# ---------------------------------------------------------------------------
+
+_C_EXTENSIONS = {".c", ".cpp", ".cxx", ".cc", ".h", ".hpp"}
+
+
+def find_compile_db(repo_dir: Path) -> Path | None:
+    """Search for compile_commands.json in a repo and its build dirs.
+
+    Checks the repo root first, then common build directories
+    (``builddir/``, ``build/``, ``_skbuild/``, ``_cmake_build/``).
+    """
+    # Repo root.
+    root_db = repo_dir / "compile_commands.json"
+    if root_db.exists():
+        return root_db
+
+    # Known build directories.
+    for subdir_name in ("builddir", "build", "_skbuild", "_cmake_build"):
+        candidate = repo_dir / subdir_name / "compile_commands.json"
+        if candidate.exists():
+            return candidate
+
+    # Search all immediate child directories.
+    try:
+        for child in repo_dir.iterdir():
+            if child.is_dir():
+                candidate = child / "compile_commands.json"
+                if candidate.exists():
+                    return candidate
+    except OSError:
+        pass
+
+    return None
+
+
+def postprocess_compile_db(compile_db_path: Path, repo_dir: Path) -> int:
+    """Fix paths in compile_commands.json and count valid entries.
+
+    Rewrites file paths that reference build temp directories to
+    point to actual source files in *repo_dir* where possible.
+
+    Returns the number of entries with valid (existing) source file paths.
+    """
+    try:
+        entries = json.loads(compile_db_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0
+
+    if not isinstance(entries, list):
+        return 0
+
+    valid = 0
+    for entry in entries:
+        file_path = entry.get("file", "")
+        if not file_path:
+            continue
+
+        # Resolve relative to directory field.
+        directory = Path(entry.get("directory", str(repo_dir)))
+        resolved = Path(file_path)
+        if not resolved.is_absolute():
+            resolved = directory / resolved
+
+        if resolved.exists():
+            valid += 1
+            continue
+
+        # Try to find the file in repo_dir by basename.
+        basename = resolved.name
+        suffix = resolved.suffix
+        if suffix not in _C_EXTENSIONS:
+            continue
+
+        matches = list(repo_dir.rglob(basename))
+        if len(matches) == 1:
+            entry["file"] = str(matches[0])
+            entry["directory"] = str(matches[0].parent)
+            valid += 1
+
+    # Write back.
+    try:
+        compile_db_path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        log.warning("Could not write corrected compile_commands.json: %s", exc)
+
+    return valid
+
+
+# ---------------------------------------------------------------------------
+# Per-package build
+# ---------------------------------------------------------------------------
+
+
+def build_package_cext(
+    pkg: Any,
+    config: CextBuildConfig,
+    pkg_output_dir: Path,
+    *,
+    bear_path: str | None = None,
+    installer: InstallerBackend = InstallerBackend.PIP,
+) -> CextBuildResult:
+    """Build a single package and generate its compile database.
+
+    Steps:
+        1. Skip pure Python packages.
+        2. Clone or update the repo.
+        3. Detect the build system.
+        4. Create a venv with the target Python.
+        5. Install build dependencies (for --no-build-isolation).
+        6. Build with bear (or fallback to build-system-specific method).
+        7. Find and post-process compile_commands.json.
+        8. Save build log and symlink repo into output.
+    """
+    result = CextBuildResult(package=pkg.package)
+
+    # Step 1: Skip pure Python.
+    ext_type = getattr(pkg, "extension_type", "unknown")
+    if ext_type == "pure":
+        result.status = "pure_python"
+        return result
+
+    # Check skip_if_exists.
+    if config.skip_if_exists:
+        existing_db = pkg_output_dir / "compile_commands.json"
+        if existing_db.exists():
+            result.status = "skipped"
+            return result
+
+    # Step 2: Clone.
+    repos_base = config.repos_dir or (config.output_dir / "_repos")
+    repos_base.mkdir(parents=True, exist_ok=True)
+    repo_dir = repos_base / pkg.package
+
+    repo_url = getattr(pkg, "repo", None)
+    if not repo_url:
+        result.status = "no_repo"
+        return result
+
+    try:
+        if repo_dir.exists() and (repo_dir / ".git").is_dir():
+            pull_repo(repo_dir)
+        else:
+            clone_repo(repo_url, repo_dir)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        result.status = "clone_error"
+        result.error_summary = str(exc)[:200]
+        return result
+
+    result.repo_dir = str(repo_dir)
+
+    # Step 3: Detect build system.
+    build_sys = detect_build_system(repo_dir)
+    result.build_system = build_sys
+
+    # Step 4: Create venv.
+    venvs_base = config.venvs_dir or (config.output_dir / "_venvs")
+    venvs_base.mkdir(parents=True, exist_ok=True)
+    venv_dir = venvs_base / pkg.package
+
+    try:
+        if venv_dir.exists():
+            shutil.rmtree(venv_dir, ignore_errors=True)
+        create_venv(config.target_python, venv_dir, installer)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        result.status = "build_fail"
+        result.error_summary = f"Venv creation failed: {exc}"
+        return result
+
+    venv_python = venv_dir / "bin" / "python"
+    env = clean_env(ASAN_OPTIONS="detect_leaks=0")
+
+    # Step 5: Install build dependencies.
+    if config.no_build_isolation:
+        build_deps = extract_build_requires(repo_dir)
+        if build_deps:
+            deps_str = " ".join(f"'{d}'" for d in build_deps)
+            try:
+                install_package(
+                    venv_python,
+                    f"pip install {deps_str}",
+                    cwd=repo_dir,
+                    env=env,
+                    timeout=config.timeout,
+                    installer=installer,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+                log.warning(
+                    "Build deps install failed for %s: %s (continuing anyway)",
+                    pkg.package,
+                    exc,
+                )
+
+    # Step 6: Build.
+    install_cmd = getattr(pkg, "install_command", None) or "pip install -e ."
+
+    if config.no_build_isolation and "--no-build-isolation" not in install_cmd:
+        install_cmd = install_cmd.replace("pip install", "pip install --no-build-isolation", 1)
+
+    start = time.monotonic()
+
+    if bear_path:
+        old_db = repo_dir / "compile_commands.json"
+        if old_db.exists():
+            old_db.unlink()
+        full_cmd = f"{bear_path} -- {install_cmd}"
+        log.info("Building %s with bear: %s", pkg.package, full_cmd)
+    else:
+        full_cmd = install_cmd
+        if build_sys == "cmake":
+            env["CMAKE_ARGS"] = env.get("CMAKE_ARGS", "") + " -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+        log.info("Building %s (no bear): %s", pkg.package, full_cmd)
+
+    try:
+        proc = install_package(
+            venv_python,
+            full_cmd,
+            cwd=repo_dir,
+            env=env,
+            timeout=config.timeout,
+            installer=installer,
+        )
+        result.exit_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        result.status = "timeout"
+        result.build_duration_s = time.monotonic() - start
+        return result
+    except (subprocess.CalledProcessError, OSError) as exc:
+        result.status = "build_fail"
+        result.error_summary = str(exc)[:200]
+        result.build_duration_s = time.monotonic() - start
+        return result
+
+    result.build_duration_s = time.monotonic() - start
+
+    # Save build log.
+    log_text = ""
+    if proc.stdout:
+        log_text += proc.stdout
+    if proc.stderr:
+        log_text += "\n--- STDERR ---\n" + proc.stderr
+    if log_text:
+        try:
+            (pkg_output_dir / "build.log").write_text(log_text, encoding="utf-8")
+        except OSError as exc:
+            log.warning("Could not save build log for %s: %s", pkg.package, exc)
+
+    if proc.returncode != 0:
+        result.status = "build_fail"
+        result.error_summary = (proc.stderr or "")[-500:]
+        return result
+
+    # Step 7: Find and post-process compile database.
+    compile_db = find_compile_db(repo_dir)
+
+    if compile_db is not None:
+        result.compile_db_method = "bear" if bear_path else build_sys
+        valid_entries = postprocess_compile_db(compile_db, repo_dir)
+        result.compile_db_entries = valid_entries
+
+        output_db = pkg_output_dir / "compile_commands.json"
+        if compile_db != output_db:
+            shutil.copy2(compile_db, output_db)
+        result.compile_db_path = str(output_db)
+
+        if valid_entries == 0:
+            result.status = "no_compile_db"
+            result.compile_db_method = "none"
+        else:
+            result.status = "ok"
+    else:
+        result.status = "no_compile_db"
+        result.compile_db_method = "none"
+
+    # Step 8: Symlink repo into output directory.
+    repo_link = pkg_output_dir / "repo"
+    if not repo_link.exists():
+        try:
+            repo_link.symlink_to(repo_dir.resolve())
+        except OSError:
+            pass  # Symlinks may not work on all platforms/filesystems.
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Full run orchestration
+# ---------------------------------------------------------------------------
+
+
+def _load_packages(config: CextBuildConfig) -> list[Any]:
+    """Load and filter packages for building.
+
+    Filters to extension packages only (``extension_type != "pure"``).
+    """
+    from labeille.registry import load_index, load_package
+
+    if config.registry_dir is None and config.packages_filter is None:
+        raise ValueError("Either --registry-dir or --packages must be provided.")
+
+    packages: list[Any] = []
+
+    if config.registry_dir:
+        index = load_index(config.registry_dir)
+        names = [e.name for e in index.packages]
+
+        if config.packages_filter:
+            filter_set = set(config.packages_filter)
+            names = [n for n in names if n in filter_set]
+
+        for name in names:
+            try:
+                pkg = load_package(name, config.registry_dir)
+                packages.append(pkg)
+            except (FileNotFoundError, OSError, ValueError) as exc:
+                log.warning("Package %s not found in registry: %s", name, exc)
+
+        if config.top_n and len(packages) > config.top_n:
+            packages = packages[: config.top_n]
+    elif config.packages_filter:
+        from labeille.classifier import classify_from_urls
+        from labeille.registry import PackageEntry
+        from labeille.resolve import extract_repo_url, fetch_pypi_metadata
+
+        for name in config.packages_filter:
+            meta = fetch_pypi_metadata(name, timeout=10.0)
+            repo_url = None
+            ext_type: Literal["pure", "extensions", "unknown"] = "unknown"
+            if meta:
+                repo_url = extract_repo_url(meta)
+                ext_type = classify_from_urls(meta.get("urls", []))
+            packages.append(
+                PackageEntry(
+                    package=name,
+                    repo=repo_url,
+                    extension_type=ext_type,
+                )
+            )
+
+    # Filter to extension packages.
+    packages = [p for p in packages if getattr(p, "extension_type", "unknown") != "pure"]
+
+    if not packages:
+        log.warning("No C extension packages found after filtering.")
+
+    return packages
+
+
+def run_cext_builds(
+    config: CextBuildConfig,
+) -> tuple[CextBuildMeta, list[CextBuildResult]]:
+    """Execute a complete cext-build run.
+
+    1. Detect bear.
+    2. Profile target Python.
+    3. Load packages (from registry or inline list).
+    4. Filter to C extension packages.
+    5. Build each package and generate compile databases.
+    6. Save metadata and results.
+    """
+    from labeille.bench.system import capture_python_profile
+    from labeille.io_utils import utc_now_iso
+
+    # Detect bear.
+    bear_path_resolved, bear_version = detect_bear()
+    if config.bear_path:
+        bear_path_resolved = config.bear_path
+
+    if bear_path_resolved:
+        log.info("Bear found: %s (%s)", bear_path_resolved, bear_version)
+    else:
+        log.warning(
+            "Bear not found. Will use build-system fallbacks "
+            "(Meson/CMake only). Install bear for full coverage: "
+            "apt install bear (Ubuntu) or brew install bear (macOS)."
+        )
+
+    # Profile target Python.
+    py_profile = capture_python_profile(config.target_python)
+
+    # Build run ID and output dir.
+    build_id = f"cext_{time.strftime('%Y%m%d_%H%M%S')}"
+    output_dir = config.output_dir / build_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create metadata.
+    meta = CextBuildMeta(
+        build_id=build_id,
+        target_python=str(config.target_python),
+        python_version=py_profile.version,
+        started_at=utc_now_iso(),
+        bear_available=bear_path_resolved is not None,
+        bear_version=bear_version,
+        no_build_isolation=config.no_build_isolation,
+    )
+
+    # Load packages.
+    packages = _load_packages(config)
+    meta.total_packages = len(packages)
+
+    # Write initial metadata.
+    meta_path = output_dir / "cext_meta.json"
+    write_meta_json(meta_path, meta.to_dict())
+
+    # Resolve installer.
+    installer = resolve_installer(config.installer)
+
+    # Results file.
+    results_path = output_dir / "cext_results.jsonl"
+
+    # Build each package.
+    results: list[CextBuildResult] = []
+    for i, pkg in enumerate(packages, 1):
+        log.info("[%d/%d] Building %s...", i, len(packages), pkg.package)
+
+        pkg_output_dir = output_dir / pkg.package
+        pkg_output_dir.mkdir(parents=True, exist_ok=True)
+
+        result = build_package_cext(
+            pkg,
+            config,
+            pkg_output_dir,
+            bear_path=bear_path_resolved,
+            installer=installer,
+        )
+        results.append(result)
+
+        # Append to JSONL.
+        append_jsonl(results_path, result.to_dict())
+
+        status_icon = "✓" if result.status == "ok" else "✗" if "fail" in result.status else "—"
+        entries_str = f" ({result.compile_db_entries} TUs)" if result.compile_db_entries else ""
+        log.info(
+            "  %s %s [%s]%s (%.1fs)",
+            status_icon,
+            pkg.package,
+            result.status,
+            entries_str,
+            result.build_duration_s,
+        )
+
+    # Finalize metadata.
+    meta.finished_at = utc_now_iso()
+    meta.built_ok = sum(1 for r in results if r.status == "ok")
+    meta.compile_db_generated = sum(1 for r in results if r.compile_db_entries > 0)
+    write_meta_json(meta_path, meta.to_dict())
+
+    return meta, results

--- a/src/labeille/cext_build_cli.py
+++ b/src/labeille/cext_build_cli.py
@@ -1,0 +1,182 @@
+"""CLI for ``labeille cext-build``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from labeille.logging import setup_logging
+
+
+@click.command("cext-build")
+@click.option(
+    "--target-python",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Path to the Python interpreter to build against.",
+)
+@click.option(
+    "--registry-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Registry directory for package metadata.",
+)
+@click.option(
+    "--packages",
+    "packages_csv",
+    type=str,
+    default=None,
+    help="Comma-separated list of package names.",
+)
+@click.option(
+    "--top",
+    "top_n",
+    type=int,
+    default=None,
+    help="Top N extension packages by download count.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=Path("cext-builds"),
+    show_default=True,
+    help="Output directory for build results and compile databases.",
+)
+@click.option(
+    "--repos-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Persistent directory for repo clones.",
+)
+@click.option(
+    "--venvs-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Persistent directory for build venvs.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Build timeout in seconds per package.",
+)
+@click.option(
+    "--installer",
+    type=click.Choice(["auto", "uv", "pip"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Package installer backend.",
+)
+@click.option(
+    "--no-skip-existing",
+    is_flag=True,
+    default=False,
+    help="Rebuild packages even if compile_commands.json already exists.",
+)
+@click.option(
+    "--bear-path",
+    type=str,
+    default=None,
+    help="Path to bear binary (default: auto-detect).",
+)
+@click.option(
+    "--build-isolation/--no-build-isolation",
+    default=False,
+    help=(
+        "Use pip's build isolation (default: off). "
+        "Bear requires --no-build-isolation for reliable results."
+    ),
+)
+@click.option("-v", "--verbose", is_flag=True, help="Show detailed output.")
+def cext_build(
+    target_python: Path,
+    registry_dir: Path | None,
+    packages_csv: str | None,
+    top_n: int | None,
+    output_dir: Path,
+    repos_dir: Path | None,
+    venvs_dir: Path | None,
+    timeout: int,
+    installer: str,
+    no_skip_existing: bool,
+    bear_path: str | None,
+    build_isolation: bool,
+    verbose: bool,
+) -> None:
+    """Build C extensions and generate compile_commands.json databases.
+
+    Uses Bear to intercept compiler invocations during the build.
+    When Bear is not available, falls back to build-system-specific
+    mechanisms for Meson and CMake projects.
+
+    The output is designed for use with cext-review-toolkit's
+    clang-tidy analysis (Tier 2).
+
+    \b
+    Examples:
+        # Build from registry (extension packages only)
+        labeille cext-build --target-python ~/cpython/python \\
+            --registry-dir registry --top 20
+
+        # Build specific packages
+        labeille cext-build --target-python ~/cpython/python \\
+            --packages numpy,lxml,pyyaml
+
+        # With persistent repos and venvs
+        labeille cext-build --target-python ~/cpython/python \\
+            --registry-dir registry --top 50 \\
+            --repos-dir ~/cext-repos --venvs-dir ~/cext-venvs
+    """
+    setup_logging(verbose=verbose)
+
+    from labeille.cext_build import CextBuildConfig, run_cext_builds
+
+    packages_filter = (
+        [p.strip() for p in packages_csv.split(",") if p.strip()] if packages_csv else None
+    )
+
+    if not registry_dir and not packages_filter:
+        click.echo("Error: provide --registry-dir, --packages, or both.", err=True)
+        sys.exit(1)
+
+    config = CextBuildConfig(
+        target_python=target_python,
+        output_dir=output_dir,
+        registry_dir=registry_dir,
+        repos_dir=repos_dir,
+        venvs_dir=venvs_dir,
+        packages_filter=packages_filter,
+        top_n=top_n,
+        timeout=timeout,
+        installer=installer,
+        no_build_isolation=not build_isolation,
+        bear_path=bear_path,
+        skip_if_exists=not no_skip_existing,
+        verbose=verbose,
+    )
+
+    meta, results = run_cext_builds(config)
+
+    # Print summary.
+    click.echo("")
+    click.echo(f"Build complete: {meta.build_id}")
+    click.echo(f"  Packages:              {meta.total_packages}")
+    click.echo(f"  Built OK:              {meta.built_ok}")
+    click.echo(f"  Compile DBs generated: {meta.compile_db_generated}")
+
+    if meta.bear_available:
+        click.echo(f"  Bear:                  {meta.bear_version}")
+    else:
+        click.echo("  Bear:                  not available (used fallbacks)")
+
+    # Per-status breakdown.
+    status_counts: dict[str, int] = {}
+    for r in results:
+        status_counts[r.status] = status_counts.get(r.status, 0) + 1
+    for status, count in sorted(status_counts.items()):
+        click.echo(f"  {status}: {count}")
+
+    click.echo(f"\nOutput: {config.output_dir / meta.build_id}")

--- a/src/labeille/cli.py
+++ b/src/labeille/cli.py
@@ -39,6 +39,7 @@ def _register_subcommands() -> None:
     """Register subcommand groups on the main CLI group."""
     from labeille.analyze_cli import analyze as analyze_group
     from labeille.bench_cli import bench as bench_group
+    from labeille.cext_build_cli import cext_build as cext_build_cmd
     from labeille.compat_cli import compat as compat_group
     from labeille.ft_cli import ft as ft_group
     from labeille.registry_cli import registry as registry_group
@@ -48,6 +49,7 @@ def _register_subcommands() -> None:
     main.add_command(bench_group)
     main.add_command(ft_group)
     main.add_command(compat_group)
+    main.add_command(cext_build_cmd)
 
 
 _register_subcommands()

--- a/tests/test_cext_build.py
+++ b/tests/test_cext_build.py
@@ -1,0 +1,441 @@
+"""Tests for labeille.cext_build — compile database generation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from labeille.cext_build import (
+    CextBuildConfig,
+    CextBuildMeta,
+    CextBuildResult,
+    build_package_cext,
+    detect_bear,
+    detect_build_system,
+    extract_build_requires,
+    find_compile_db,
+    postprocess_compile_db,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_bear
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBear(unittest.TestCase):
+    @patch("labeille.cext_build.subprocess.run")
+    @patch("labeille.cext_build.shutil.which", return_value="/usr/bin/bear")
+    def test_bear_found(self, _mock_which: MagicMock, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(stdout="bear 3.1.0\n", stderr="")
+        path, version = detect_bear()
+        self.assertEqual(path, "/usr/bin/bear")
+        self.assertEqual(version, "bear 3.1.0")
+
+    @patch("labeille.cext_build.shutil.which", return_value=None)
+    def test_bear_not_found(self, _mock_which: MagicMock) -> None:
+        path, version = detect_bear()
+        self.assertIsNone(path)
+        self.assertEqual(version, "")
+
+    @patch("labeille.cext_build.subprocess.run", side_effect=OSError("fail"))
+    @patch("labeille.cext_build.shutil.which", return_value="/usr/bin/bear")
+    def test_bear_version_fails(self, _w: MagicMock, _r: MagicMock) -> None:
+        path, version = detect_bear()
+        self.assertEqual(path, "/usr/bin/bear")
+        self.assertEqual(version, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# detect_build_system
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBuildSystem(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_meson_build_file(self) -> None:
+        (self.repo / "meson.build").write_text("project('x')\n")
+        self.assertEqual(detect_build_system(self.repo), "meson")
+
+    def test_cmakelists(self) -> None:
+        (self.repo / "CMakeLists.txt").write_text("cmake_minimum_required()\n")
+        self.assertEqual(detect_build_system(self.repo), "cmake")
+
+    def test_pyproject_mesonpy(self) -> None:
+        (self.repo / "pyproject.toml").write_text('[build-system]\nbuild-backend = "mesonpy"\n')
+        self.assertEqual(detect_build_system(self.repo), "meson")
+
+    def test_pyproject_skbuild(self) -> None:
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "scikit_build_core.build"\n'
+        )
+        self.assertEqual(detect_build_system(self.repo), "cmake")
+
+    def test_pyproject_setuptools(self) -> None:
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "setuptools.build_meta"\n'
+        )
+        self.assertEqual(detect_build_system(self.repo), "setuptools")
+
+    def test_pyproject_flit(self) -> None:
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "flit_core.buildapi"\n'
+        )
+        self.assertEqual(detect_build_system(self.repo), "flit")
+
+    def test_pyproject_hatch(self) -> None:
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "hatchling.build"\n'
+        )
+        self.assertEqual(detect_build_system(self.repo), "hatch")
+
+    def test_setup_py_only(self) -> None:
+        (self.repo / "setup.py").write_text("from setuptools import setup\n")
+        self.assertEqual(detect_build_system(self.repo), "setuptools")
+
+    def test_empty_dir(self) -> None:
+        self.assertEqual(detect_build_system(self.repo), "unknown")
+
+    def test_meson_build_overrides_pyproject(self) -> None:
+        (self.repo / "meson.build").write_text("project('x')\n")
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "setuptools.build_meta"\n'
+        )
+        self.assertEqual(detect_build_system(self.repo), "meson")
+
+
+# ---------------------------------------------------------------------------
+# extract_build_requires
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBuildRequires(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_standard_pyproject(self) -> None:
+        (self.repo / "pyproject.toml").write_text(
+            '[build-system]\nrequires = ["setuptools>=68", "cython"]\n'
+        )
+        self.assertEqual(extract_build_requires(self.repo), ["setuptools>=68", "cython"])
+
+    def test_no_pyproject(self) -> None:
+        self.assertEqual(extract_build_requires(self.repo), ["setuptools", "wheel"])
+
+    def test_no_build_system_key(self) -> None:
+        (self.repo / "pyproject.toml").write_text("[project]\nname = 'foo'\n")
+        self.assertEqual(extract_build_requires(self.repo), ["setuptools", "wheel"])
+
+    def test_empty_requires(self) -> None:
+        (self.repo / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+        self.assertEqual(extract_build_requires(self.repo), ["setuptools", "wheel"])
+
+
+# ---------------------------------------------------------------------------
+# find_compile_db
+# ---------------------------------------------------------------------------
+
+
+class TestFindCompileDb(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_in_repo_root(self) -> None:
+        db = self.repo / "compile_commands.json"
+        db.write_text("[]")
+        self.assertEqual(find_compile_db(self.repo), db)
+
+    def test_in_builddir(self) -> None:
+        (self.repo / "builddir").mkdir()
+        db = self.repo / "builddir" / "compile_commands.json"
+        db.write_text("[]")
+        self.assertEqual(find_compile_db(self.repo), db)
+
+    def test_in_build(self) -> None:
+        (self.repo / "build").mkdir()
+        db = self.repo / "build" / "compile_commands.json"
+        db.write_text("[]")
+        self.assertEqual(find_compile_db(self.repo), db)
+
+    def test_in_random_subdir(self) -> None:
+        (self.repo / "my_build").mkdir()
+        db = self.repo / "my_build" / "compile_commands.json"
+        db.write_text("[]")
+        result = find_compile_db(self.repo)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, db)
+
+    def test_not_found(self) -> None:
+        self.assertIsNone(find_compile_db(self.repo))
+
+
+# ---------------------------------------------------------------------------
+# postprocess_compile_db
+# ---------------------------------------------------------------------------
+
+
+class TestPostprocessCompileDb(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_valid_paths_unchanged(self) -> None:
+        src = self.repo / "src" / "foo.c"
+        src.parent.mkdir(parents=True)
+        src.write_text("int main() {}")
+        db_path = self.repo / "compile_commands.json"
+        entries = [{"directory": str(self.repo), "file": str(src), "command": "cc foo.c"}]
+        db_path.write_text(json.dumps(entries))
+        count = postprocess_compile_db(db_path, self.repo)
+        self.assertEqual(count, 1)
+
+    def test_rewrites_broken_paths(self) -> None:
+        src = self.repo / "src" / "foo.c"
+        src.parent.mkdir(parents=True)
+        src.write_text("int main() {}")
+        db_path = self.repo / "compile_commands.json"
+        entries = [
+            {"directory": "/tmp/nonexistent", "file": "/tmp/nonexistent/foo.c", "command": "cc"}
+        ]
+        db_path.write_text(json.dumps(entries))
+        count = postprocess_compile_db(db_path, self.repo)
+        self.assertEqual(count, 1)
+        updated = json.loads(db_path.read_text())
+        self.assertEqual(updated[0]["file"], str(src))
+
+    def test_ambiguous_filename_not_rewritten(self) -> None:
+        for d in ("src", "lib"):
+            p = self.repo / d / "bar.c"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("int x;")
+        db_path = self.repo / "compile_commands.json"
+        entries = [{"directory": "/tmp/x", "file": "/tmp/x/bar.c", "command": "cc"}]
+        db_path.write_text(json.dumps(entries))
+        count = postprocess_compile_db(db_path, self.repo)
+        self.assertEqual(count, 0)
+
+    def test_empty_compile_db(self) -> None:
+        db_path = self.repo / "compile_commands.json"
+        db_path.write_text("[]")
+        self.assertEqual(postprocess_compile_db(db_path, self.repo), 0)
+
+
+# ---------------------------------------------------------------------------
+# CextBuildResult serialization
+# ---------------------------------------------------------------------------
+
+
+class TestCextBuildResult(unittest.TestCase):
+    def test_to_dict_sparse(self) -> None:
+        r = CextBuildResult(package="numpy", status="ok", compile_db_entries=14)
+        d = r.to_dict()
+        self.assertEqual(d["package"], "numpy")
+        self.assertEqual(d["status"], "ok")
+        self.assertEqual(d["compile_db_entries"], 14)
+        self.assertNotIn("error_summary", d)
+
+    def test_to_dict_roundtrip(self) -> None:
+        r = CextBuildResult(package="lxml", status="build_fail", exit_code=1, error_summary="err")
+        d = r.to_dict()
+        r2 = CextBuildResult.from_dict(d)
+        self.assertEqual(r2.package, "lxml")
+        self.assertEqual(r2.status, "build_fail")
+        self.assertEqual(r2.exit_code, 1)
+
+    def test_from_dict_unknown_fields(self) -> None:
+        d: dict[str, Any] = {"package": "foo", "status": "ok", "unknown_field": 42}
+        r = CextBuildResult.from_dict(d)
+        self.assertEqual(r.package, "foo")
+
+
+# ---------------------------------------------------------------------------
+# CextBuildMeta serialization
+# ---------------------------------------------------------------------------
+
+
+class TestCextBuildMeta(unittest.TestCase):
+    def test_to_dict_roundtrip(self) -> None:
+        m = CextBuildMeta(
+            build_id="cext_test",
+            target_python="/usr/bin/python3",
+            python_version="3.15.0",
+            started_at="2026-01-01T00:00:00",
+            bear_available=True,
+            bear_version="3.1.0",
+        )
+        d = m.to_dict()
+        m2 = CextBuildMeta.from_dict(d)
+        self.assertEqual(m2.build_id, "cext_test")
+        self.assertTrue(m2.bear_available)
+
+
+# ---------------------------------------------------------------------------
+# build_package_cext
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPackageCext(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+        self.output_dir = self.tmpdir / "output"
+        self.output_dir.mkdir()
+        self.config = CextBuildConfig(
+            target_python=Path("/usr/bin/python3"),
+            output_dir=self.tmpdir / "builds",
+            repos_dir=self.tmpdir / "repos",
+            venvs_dir=self.tmpdir / "venvs",
+            skip_if_exists=False,
+        )
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_pkg(self, **kwargs: Any) -> MagicMock:
+        pkg = MagicMock()
+        pkg.package = kwargs.get("package", "mypkg")
+        pkg.repo = kwargs.get("repo", "https://github.com/user/mypkg")
+        pkg.extension_type = kwargs.get("extension_type", "extensions")
+        pkg.install_command = kwargs.get("install_command", "pip install -e .")
+        return pkg
+
+    def test_pure_python_skipped(self) -> None:
+        pkg = self._make_pkg(extension_type="pure")
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "pure_python")
+
+    def test_no_repo_skipped(self) -> None:
+        pkg = self._make_pkg(repo=None)
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "no_repo")
+
+    @patch("labeille.cext_build.install_package")
+    @patch("labeille.cext_build.create_venv")
+    @patch("labeille.cext_build.clone_repo")
+    def test_build_success_with_bear(
+        self,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+    ) -> None:
+        mock_clone.return_value = "abc123"
+
+        # Set up repo dir and source file.
+        repo_dir = self.config.repos_dir / "mypkg"  # type: ignore[operator]
+        repo_dir.mkdir(parents=True)
+        src_file = repo_dir / "src" / "mod.c"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("int x;")
+
+        # install_package side_effect: simulate bear creating compile_commands.json.
+        def _create_db(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            db = repo_dir / "compile_commands.json"
+            db.write_text(
+                json.dumps(
+                    [{"directory": str(repo_dir), "file": str(src_file), "command": "cc"}] * 5
+                )
+            )
+            return subprocess.CompletedProcess(args="", returncode=0, stdout="", stderr="")
+
+        mock_install.side_effect = _create_db
+
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir, bear_path="/usr/bin/bear")
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.compile_db_method, "bear")
+        self.assertEqual(result.compile_db_entries, 5)
+
+    @patch("labeille.cext_build.install_package")
+    @patch("labeille.cext_build.create_venv")
+    @patch("labeille.cext_build.clone_repo")
+    def test_build_fail(
+        self,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+    ) -> None:
+        mock_clone.return_value = "abc123"
+        mock_install.return_value = subprocess.CompletedProcess(
+            args="", returncode=1, stdout="", stderr="error: compile failed"
+        )
+        repo_dir = self.config.repos_dir / "mypkg"  # type: ignore[operator]
+        repo_dir.mkdir(parents=True)
+
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "build_fail")
+        self.assertEqual(result.exit_code, 1)
+
+    @patch("labeille.cext_build.install_package")
+    @patch("labeille.cext_build.create_venv")
+    @patch("labeille.cext_build.clone_repo")
+    def test_build_timeout(
+        self,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+    ) -> None:
+        mock_clone.return_value = "abc123"
+        mock_install.side_effect = subprocess.TimeoutExpired(cmd="pip", timeout=600)
+        repo_dir = self.config.repos_dir / "mypkg"  # type: ignore[operator]
+        repo_dir.mkdir(parents=True)
+
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "timeout")
+
+    @patch("labeille.cext_build.install_package")
+    @patch("labeille.cext_build.create_venv")
+    @patch("labeille.cext_build.clone_repo")
+    def test_no_compile_db_generated(
+        self,
+        mock_clone: MagicMock,
+        mock_venv: MagicMock,
+        mock_install: MagicMock,
+    ) -> None:
+        mock_clone.return_value = "abc123"
+        mock_install.return_value = subprocess.CompletedProcess(
+            args="", returncode=0, stdout="", stderr=""
+        )
+        repo_dir = self.config.repos_dir / "mypkg"  # type: ignore[operator]
+        repo_dir.mkdir(parents=True)
+
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "no_compile_db")
+
+    def test_skip_if_exists(self) -> None:
+        self.config.skip_if_exists = True
+        (self.output_dir / "compile_commands.json").write_text("[]")
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "skipped")
+
+    @patch("labeille.cext_build.clone_repo", side_effect=OSError("network error"))
+    def test_clone_error(self, _mock: MagicMock) -> None:
+        pkg = self._make_pkg()
+        result = build_package_cext(pkg, self.config, self.output_dir)
+        self.assertEqual(result.status, "clone_error")
+        self.assertIn("network error", result.error_summary)

--- a/tests/test_cext_build_cli.py
+++ b/tests/test_cext_build_cli.py
@@ -1,0 +1,38 @@
+"""Tests for labeille.cext_build_cli — CLI for cext-build command."""
+
+from __future__ import annotations
+
+import unittest
+
+from click.testing import CliRunner
+
+from labeille.cli import main
+
+
+class TestCextBuildCLI(unittest.TestCase):
+    def test_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["cext-build", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--target-python", result.output)
+        self.assertIn("--packages", result.output)
+        self.assertIn("--registry-dir", result.output)
+        self.assertIn("--bear-path", result.output)
+        self.assertIn("compile_commands.json", result.output)
+
+    def test_command_registered(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        self.assertIn("cext-build", result.output)
+
+    def test_requires_target_python(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["cext-build", "--packages", "numpy"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_requires_packages_or_registry(self) -> None:
+        runner = CliRunner()
+        # Use a fake python path that exists.
+        result = runner.invoke(main, ["cext-build", "--target-python", "/bin/sh"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("provide", result.output.lower() + (result.output if result.output else ""))


### PR DESCRIPTION
## Summary
- Add `labeille cext-build` command that builds C extension packages and produces `compile_commands.json` compilation databases
- Uses Bear to intercept compiler invocations, with fallback to Meson/CMake native compile database generation
- Includes build system detection, pyproject.toml parsing, compile database post-processing, and per-package output
- Designed for integration with cext-review-toolkit Tier 2 analysis (clang-tidy)
- New files: `cext_build.py` (core, 580 LOC), `cext_build_cli.py` (CLI, 170 LOC)

## Test plan
- [x] ruff format/check passes
- [x] mypy strict passes (52 source files)
- [x] All 2224 tests pass (42 new: 38 in test_cext_build.py + 4 in test_cext_build_cli.py)

Closes #256

Generated with [Claude Code](https://claude.com/claude-code)